### PR TITLE
Set up Cursor Cloud dev environment (.NET 10) and document gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+IronKernel is a single product: an F#/.NET 10 hybrid CLR compiler + REPL for the
+Kernel language (`IronKernel.sln`, projects `IronKernel`, `IronKernel.Tests`,
+`Mono.Terminal`). The `website/` directory is only a static promo site
+(`python3 -m http.server -d website 8080`) and is not part of the app.
+
+### Environment
+- The .NET 10 SDK lives at `~/.dotnet` and is added to `PATH`/`DOTNET_ROOT` via
+  `~/.bashrc`. New login shells already have `dotnet` available. Non-login shells
+  may need the full path `~/.dotnet/dotnet`.
+
+### Build / test / lint / run
+- Standard commands are in `README.md`. Debug (dev) is the default for
+  `dotnet build`/`dotnet test`; CI (`.github/workflows/ci.yml`) uses `-c Release`.
+- There is no separate linter; the F# compiler warnings emitted during
+  `dotnet build` are the lint signal (the build currently has warnings, 0 errors).
+
+### REPL gotchas (non-obvious)
+- `dotnet run --project IronKernel` loads `kernel.scm` and `promises.scm` using
+  paths **relative to the current working directory**. Run it from the
+  `IronKernel/` directory (where those files live) or from a build output dir
+  that contains them. Running from the repo root fails with
+  `File not found: 'kernel.scm'`.
+- The REPL uses the `Mono.Terminal` line editor, which needs a **real TTY**.
+  Piping stdin (`printf ... | dotnet run`) crashes with a `System.Console`
+  `SetCursorPosition` exception. For scripted/interactive REPL testing, drive it
+  through a pty (e.g. a `tmux` session with `send-keys`).
+- IronKernel is **Kernel, not Scheme**. Use `define`/`defn`, `lambda`, `if`,
+  `letrec`. `+` and `*` are **binary** (exactly 2 args). `display`, `=?`, and
+  `$let` are not bound; print via .NET interop, e.g.
+  `(define write (lambda (x) (. System.Console WriteLine x)))`.
+
+### Running scripts / compiling
+- Run a script file: `dotnet run --project IronKernel -- path/to/file.scm`
+  (this `load`s the file but does **not** auto-load the stdlib).
+- Compile to an IKC package:
+  `dotnet run --project IronKernel -- compile file.scm -o out.dll`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the development environment for IronKernel (F#/.NET 10 hybrid CLR compiler + REPL) and documents non-obvious startup/run caveats for future Cloud agents.

- Installed the .NET 10 SDK (`10.0.302`) at `~/.dotnet` (on `PATH`/`DOTNET_ROOT` via `~/.bashrc`).
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering build/test/lint/run and REPL gotchas.
- Update script (run on VM startup) refreshes NuGet deps: `$HOME/.dotnet/dotnet restore IronKernel.sln`.

## Verification
- `dotnet build IronKernel.sln --no-restore` → 0 errors (warnings only).
- `dotnet test IronKernel.sln --no-build` → 52 passed, 0 failed.
- REPL hello-world (`.NET interop`, recursion, arithmetic) works end to end.
- `dotnet run --project IronKernel -- compile Examples/hello.scm -o /tmp/hello.dll` → wrote IKC package.

### Key gotchas documented
- REPL loads `kernel.scm`/`promises.scm` relative to CWD → run from `IronKernel/`.
- REPL line editor needs a real TTY (piping stdin crashes) → drive via a pty/tmux.
- IronKernel is Kernel, not Scheme (`+`/`*` are binary; use `.NET` interop to print).

## Walkthrough
[ironkernel_repl_demo.mp4](https://cursor.com/agents/bc-d841e667-8087-4feb-9dd0-6ea68a07938b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fironkernel_repl_demo.mp4)

[IronKernel REPL outputs](https://cursor.com/agents/bc-d841e667-8087-4feb-9dd0-6ea68a07938b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fironkernel_repl_outputs.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d841e667-8087-4feb-9dd0-6ea68a07938b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d841e667-8087-4feb-9dd0-6ea68a07938b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786893141&installation_id=147070874&pr_number=3&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F3&signature=873ead3891a4cfcd10fbc0cfd3029733caa7ff77ecb240ab73887f982ba42dbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->