### PR TITLE
Restore website logo and favicon

### DIFF
--- a/website/docs/getting-started.html
+++ b/website/docs/getting-started.html
@@ -5,12 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Getting started — IronKernel</title>
     <meta name="description" content="Install IronKernel, run your first program, and create an IKC package." />
+    <link rel="icon" href="../assets/ironkernel-mark.png" type="image/png" />
     <link rel="stylesheet" href="../assets/site.css" />
   </head>
   <body>
     <header class="nav">
       <div class="wrap nav-inner">
-        <a class="brand" href="../index.html">IronKernel</a>
+        <a class="brand" href="../index.html">
+          <img src="../assets/ironkernel-mark.png" alt="" width="32" height="32" />
+          IronKernel
+        </a>
         <ul class="nav-links">
           <li><a href="getting-started.html" aria-current="page">Start</a></li>
           <li><a href="intro.html">Intro</a></li>

--- a/website/docs/guide.html
+++ b/website/docs/guide.html
@@ -5,12 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Language guide — IronKernel</title>
     <meta name="description" content="A progressive tour of IronKernel with examples at every step." />
+    <link rel="icon" href="../assets/ironkernel-mark.png" type="image/png" />
     <link rel="stylesheet" href="../assets/site.css" />
   </head>
   <body>
     <header class="nav">
       <div class="wrap nav-inner">
         <a class="brand" href="../index.html">
+          <img src="../assets/ironkernel-mark.png" alt="" width="32" height="32" />
           IronKernel
         </a>
         <ul class="nav-links">

--- a/website/docs/intro.html
+++ b/website/docs/intro.html
@@ -5,12 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Introduction — IronKernel</title>
     <meta name="description" content="What is Kernel, and how IronKernel brings it to the .NET CLR." />
+    <link rel="icon" href="../assets/ironkernel-mark.png" type="image/png" />
     <link rel="stylesheet" href="../assets/site.css" />
   </head>
   <body>
     <header class="nav">
       <div class="wrap nav-inner">
         <a class="brand" href="../index.html">
+          <img src="../assets/ironkernel-mark.png" alt="" width="32" height="32" />
           IronKernel
         </a>
         <ul class="nav-links">

--- a/website/docs/operators.html
+++ b/website/docs/operators.html
@@ -5,12 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Operators — IronKernel</title>
     <meta name="description" content="Reference for IronKernel primitive and standard-library operators." />
+    <link rel="icon" href="../assets/ironkernel-mark.png" type="image/png" />
     <link rel="stylesheet" href="../assets/site.css" />
   </head>
   <body>
     <header class="nav">
       <div class="wrap nav-inner">
         <a class="brand" href="../index.html">
+          <img src="../assets/ironkernel-mark.png" alt="" width="32" height="32" />
           IronKernel
         </a>
         <ul class="nav-links">

--- a/website/index.html
+++ b/website/index.html
@@ -8,12 +8,14 @@
       name="description"
       content="IronKernel is a Kernel dialect for .NET: first-class operatives, environments, and continuations — I run on .NET."
     />
+    <link rel="icon" href="assets/ironkernel-mark.png" type="image/png" />
     <link rel="stylesheet" href="assets/site.css" />
   </head>
   <body>
     <header class="nav">
       <div class="wrap nav-inner">
         <a class="brand" href="index.html" aria-label="IronKernel home">
+          <img src="assets/ironkernel-mark.png" alt="" width="32" height="32" />
           IronKernel
         </a>
         <ul class="nav-links">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restore the tracked IronKernel mark in homepage and documentation navigation
- restore favicon references on every website page

## Context
The asset was present in Git history; an incomplete workspace file listing led to its references being removed incorrectly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8498e3c-8e84-496a-bc69-85678d76f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8498e3c-8e84-496a-bc69-85678d76f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786907961&installation_id=147070874&pr_number=7&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F7&signature=81897fca547cb929929c57c479cc736ed183516a08e4cfa606ac3b791a87b073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->