### PR TITLE
Add binding-aware guarded compiler fast paths

### DIFF
--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -8,6 +8,7 @@ open IronKernel.Emit
 open IronKernel.Eval
 open IronKernel.Ir
 open IronKernel.Errors
+open IronKernel.SymbolTable
 open IronKernel.Tests.TestHelpers
 
 [<Fact>]
@@ -27,6 +28,51 @@ let ``analyze combinations without privileging operator names`` () =
     match analyze (parseOk "(+ 1 2)") with
     | COperate (CVar "+", [Obj _; Obj _]) -> ()
     | other -> failwith (showCore other)
+
+[<Fact>]
+let ``environment-aware analysis guards primitive forms`` () =
+    let env = freshEnv ()
+
+    match analyzeGuarded env (parseOk "(if #t 1 2)") with
+    | CGuarded (guard, CIf _, COperate (CVar "if", _)) ->
+        Assert.True(bindingGuardMatches env guard)
+    | other -> failwith (showCore other)
+
+    match analyzeGuarded env (parseOk "(define answer 42)") with
+    | CGuarded (guard, CDefine (CVar "answer", _), COperate (CVar "define", _)) ->
+        Assert.True(bindingGuardMatches env guard)
+    | other -> failwith (showCore other)
+
+[<Fact>]
+let ``compiled guard deoptimizes after primitive rebinding`` () =
+    let env = freshEnv ()
+    let compiled = compileLispValGuarded env (parseOk "(if #t 1 2)")
+
+    match compiled.Invoke(env, newContinuation env) with
+    | Choice2Of2 (Obj (:? int as value)) -> Assert.Equal(1, value)
+    | result -> failwithf "unexpected guarded result: %A" result
+
+    ignore (evalIn env "(define if (vau operands caller operands))")
+
+    match compiled.Invoke(env, newContinuation env) with
+    | Choice2Of2 (List [Bool true; Obj (:? int as one); Obj (:? int as two)]) ->
+        Assert.Equal(1, one)
+        Assert.Equal(2, two)
+    | result -> failwithf "guard did not fall back after rebind: %A" result
+
+[<Fact>]
+let ``compiled guard detects a new shadowing binding`` () =
+    let parent = freshEnv ()
+    let child = newEnv [parent]
+    let compiled = compileLispValGuarded child (parseOk "(if #t 1 2)")
+
+    ignore (evalIn child "(define if (vau operands caller operands))")
+
+    match compiled.Invoke(child, newContinuation child) with
+    | Choice2Of2 (List [Bool true; Obj (:? int as one); Obj (:? int as two)]) ->
+        Assert.Equal(1, one)
+        Assert.Equal(2, two)
+    | result -> failwithf "guard did not detect shadowing: %A" result
 
 [<Fact>]
 let ``toLispVal roundtrips analyzed if`` () =

--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -34,12 +34,12 @@ let ``environment-aware analysis guards primitive forms`` () =
     let env = freshEnv ()
 
     match analyzeGuarded env (parseOk "(if #t 1 2)") with
-    | CGuarded (guard, CIf _, COperate (CVar "if", _)) ->
+    | CGuarded (guard, CIntrinsicOperate (PrimitiveIf, _), COperate (CVar "if", _)) ->
         Assert.True(bindingGuardMatches env guard)
     | other -> failwith (showCore other)
 
     match analyzeGuarded env (parseOk "(define answer 42)") with
-    | CGuarded (guard, CDefine (CVar "answer", _), COperate (CVar "define", _)) ->
+    | CGuarded (guard, CIntrinsicOperate (PrimitiveDefine, _), COperate (CVar "define", _)) ->
         Assert.True(bindingGuardMatches env guard)
     | other -> failwith (showCore other)
 

--- a/IronKernel.Tests/ConformanceTests.fs
+++ b/IronKernel.Tests/ConformanceTests.fs
@@ -63,3 +63,11 @@ let ``rebinding core names preserves combination semantics`` () =
       [ "(define begin (vau xs e xs))"; "(begin missing)" ]
       [ "(define reset (vau xs e xs))"; "(reset missing)" ] ]
     |> List.iter assertParitySession
+
+[<Fact>]
+let ``guarded if preserves continuation context`` () =
+    assertParitySession
+        [ "(load \"kernel.scm\")"
+          "(define saved #f)"
+          "(+ 10 (if (call/cc (lambda (k) (begin (define saved k) #t))) 1 2))"
+          "(saved #f)" ]

--- a/IronKernel.Tests/EnvironmentTests.fs
+++ b/IronKernel.Tests/EnvironmentTests.fs
@@ -60,3 +60,19 @@ let ``binding guards track identity and version`` () =
 
     ignore (evalIn env "(define if (vau operands caller operands))")
     Assert.False(bindingGuardMatches env guard)
+
+[<Fact>]
+let ``set updates only the first binding in depth-first order`` () =
+    let first = newEnv []
+    let second = newEnv []
+    ignore (defineVar first "x" (Obj (1 :> obj)))
+    ignore (defineVar second "x" (Obj (2 :> obj)))
+    let child = newEnv [first; second]
+
+    ignore (setVar child "x" (Obj (9 :> obj)))
+
+    match getVar first "x", getVar second "x" with
+    | Choice2Of2 (Obj (:? int as firstValue)), Choice2Of2 (Obj (:? int as secondValue)) ->
+        Assert.Equal(9, firstValue)
+        Assert.Equal(2, secondValue)
+    | values -> failwithf "unexpected parent values: %A" values

--- a/IronKernel.Tests/EnvironmentTests.fs
+++ b/IronKernel.Tests/EnvironmentTests.fs
@@ -2,6 +2,7 @@ module IronKernel.Tests.EnvironmentTests
 
 open Xunit
 open IronKernel.Ast
+open IronKernel.SymbolTable
 open IronKernel.Tests.TestHelpers
 
 [<Fact>]
@@ -45,3 +46,17 @@ let ``eval with explicit environment`` () =
         "(eval e '(define x 99))", Inert
         "(eval e 'x)", Obj 99
     ]
+
+[<Fact>]
+let ``binding guards track identity and version`` () =
+    let env = freshEnv ()
+    let guard =
+        tryCreateBindingGuard env "if" PrimitiveIf
+        |> Option.defaultWith (fun () -> failwith "missing primitive if guard")
+
+    Assert.True(bindingGuardMatches env guard)
+    ignore (defineVar env "unrelated" (Obj (1 :> obj)))
+    Assert.True(bindingGuardMatches env guard)
+
+    ignore (evalIn env "(define if (vau operands caller operands))")
+    Assert.False(bindingGuardMatches env guard)

--- a/IronKernel/Analyze.fs
+++ b/IronKernel/Analyze.fs
@@ -5,6 +5,7 @@ module Analyze =
 
     open Ast
     open Ir
+    open SymbolTable
 
     let rec analyze (value: LispVal) : CoreExpr =
         match value with
@@ -37,6 +38,36 @@ module Analyze =
     let analyzeForms (forms: LispVal list) : CoreExpr list =
         List.map analyze forms
 
+    let rec analyzeGuarded env (value: LispVal) : CoreExpr =
+        match value with
+        | List (Atom "if" :: [condition; consequent; alternative] as form) ->
+            let fallback = COperate(CVar "if", List.tail form)
+            match tryCreateBindingGuard env "if" PrimitiveIf with
+            | Some guard ->
+                CGuarded(
+                    guard,
+                    CIf(
+                        analyzeGuarded env condition,
+                        analyzeGuarded env consequent,
+                        analyzeGuarded env alternative),
+                    fallback)
+            | None -> fallback
+        | List (Atom "define" :: [Atom name; rhs] as form) ->
+            let fallback = COperate(CVar "define", List.tail form)
+            match tryCreateBindingGuard env "define" PrimitiveDefine with
+            | Some guard ->
+                CGuarded(
+                    guard,
+                    CDefine(CVar name, analyzeGuarded env rhs),
+                    fallback)
+            | None -> fallback
+        | List (op :: operands) ->
+            COperate(analyzeGuarded env op, operands)
+        | other -> analyze other
+
+    let analyzeFormsGuarded env forms =
+        List.map (analyzeGuarded env) forms
+
     /// Reify CoreExpr back to a LispVal tree for residual evaluation.
     let rec toLispVal = function
         | CLit v -> v
@@ -48,6 +79,7 @@ module Analyze =
         | CVau (f, e, body) -> List (Atom "vau" :: f :: Atom e :: List.map toLispVal body)
         | CApp (op, args) -> List (toLispVal op :: List.map toLispVal args)
         | COperate (op, operands) -> List (toLispVal op :: operands)
+        | CGuarded (_, _, fallback) -> toLispVal fallback
         | CEval (e, x) -> List [Atom "eval"; toLispVal e; toLispVal x]
         | CReset x -> List [Atom "reset"; toLispVal x]
         | CResidual v -> v

--- a/IronKernel/Analyze.fs
+++ b/IronKernel/Analyze.fs
@@ -46,10 +46,7 @@ module Analyze =
             | Some guard ->
                 CGuarded(
                     guard,
-                    CIf(
-                        analyzeGuarded env condition,
-                        analyzeGuarded env consequent,
-                        analyzeGuarded env alternative),
+                    CIntrinsicOperate(PrimitiveIf, [condition; consequent; alternative]),
                     fallback)
             | None -> fallback
         | List (Atom "define" :: [Atom name; rhs] as form) ->
@@ -58,7 +55,7 @@ module Analyze =
             | Some guard ->
                 CGuarded(
                     guard,
-                    CDefine(CVar name, analyzeGuarded env rhs),
+                    CIntrinsicOperate(PrimitiveDefine, [Atom name; rhs]),
                     fallback)
             | None -> fallback
         | List (op :: operands) ->
@@ -79,6 +76,8 @@ module Analyze =
         | CVau (f, e, body) -> List (Atom "vau" :: f :: Atom e :: List.map toLispVal body)
         | CApp (op, args) -> List (toLispVal op :: List.map toLispVal args)
         | COperate (op, operands) -> List (toLispVal op :: operands)
+        | CIntrinsicOperate (PrimitiveIf, operands) -> List (Atom "if" :: operands)
+        | CIntrinsicOperate (PrimitiveDefine, operands) -> List (Atom "define" :: operands)
         | CGuarded (_, _, fallback) -> toLispVal fallback
         | CEval (e, x) -> List [Atom "eval"; toLispVal e; toLispVal x]
         | CReset x -> List [Atom "reset"; toLispVal x]

--- a/IronKernel/Ast.fs
+++ b/IronKernel/Ast.fs
@@ -44,14 +44,29 @@ module Ast =
         tag     : System.Guid
         value   : LispVal
     }
-    and Env = (string * LispVal ref) list ref
+    and PrimitiveIdentity =
+        | PrimitiveIf
+        | PrimitiveDefine
+    and PrimitiveOperativeRecord = {
+        identity : PrimitiveIdentity option
+        invoke : LispVal -> LispVal -> LispVal list -> Step
+    }
+    and BindingState = {
+        value : LispVal
+        version : int64
+    }
+    and BindingCell = {
+        id : int64
+        mutable state : BindingState
+    }
+    and Env = (string * BindingCell) list ref
     and LispVal = 
         | Atom of string 
         | List of LispVal list
         | DottedList of (LispVal list * LispVal)
         | Bool of bool
         | Environment of Env * (LispVal list)
-        | PrimitiveOperative of (LispVal -> LispVal -> LispVal list -> Step)
+        | PrimitiveOperative of PrimitiveOperativeRecord
         | Operative of OperativeRecord
         | Applicative of LispVal
         | IOFunc of (LispVal list -> ThrowsError<LispVal>)
@@ -98,7 +113,12 @@ module Ast =
 
     let rec unwordsList = (List.map showVal) >> unwords
     and unwordsArray = (Array.map showVal) >> unwordsa
-    and printBindings bnds = List.fold (fun (acc:string) (a,b) -> acc + "(" + a + ": " + showVal (!b) + " )\n" ) "" bnds
+    and printBindings bnds =
+        List.fold
+            (fun (acc:string) (name, cell) ->
+                acc + "(" + name + ": " + showVal cell.state.value + " )\n")
+            ""
+            bnds
     and printEnvironment (Environment(env,st)) = "(" + (printBindings !env) + " (" + unwordsList st  + "))"
     and showVal = function
         

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -130,6 +130,11 @@ module Compiler =
             let fop = compileToFunc op
             let ops = List.toArray operands
             KernelFunc(fun env cont -> Helpers.App(env, cont, fop, ops))
+        | CIntrinsicOperate (identity, operands) ->
+            KernelFunc(fun env cont ->
+                match identity with
+                | PrimitiveIf -> run (Runtime.if_then_else env cont operands)
+                | PrimitiveDefine -> run (Runtime.define env cont operands))
         | CGuarded (guard, specialized, fallback) ->
             let fast = compileToFunc specialized
             let generic = compileToFunc fallback

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -12,6 +12,7 @@ module Compiler =
     open Ir
     open Analyze
     open Eval
+    open SymbolTable
     open Choice
 
     type KernelFunc = Func<LispVal, LispVal, ThrowsError<LispVal>>
@@ -129,6 +130,12 @@ module Compiler =
             let fop = compileToFunc op
             let ops = List.toArray operands
             KernelFunc(fun env cont -> Helpers.App(env, cont, fop, ops))
+        | CGuarded (guard, specialized, fallback) ->
+            let fast = compileToFunc specialized
+            let generic = compileToFunc fallback
+            KernelFunc(fun env cont ->
+                if bindingGuardMatches env guard then fast.Invoke(env, cont)
+                else generic.Invoke(env, cont))
         | CResidual v ->
             KernelFunc(fun env cont -> eval env cont v)
         | other ->
@@ -136,10 +143,12 @@ module Compiler =
             KernelFunc(fun env cont -> eval env cont v)
 
     let compileLispVal (v: LispVal) = compileToFunc (analyze v)
+    let compileLispValGuarded env (v: LispVal) = compileToFunc (analyzeGuarded env v)
 
     let compileForms (forms: LispVal list) = List.map compileLispVal forms
+    let compileFormsGuarded env forms = List.map (compileLispValGuarded env) forms
 
-    let evalCompiled env cont (v: LispVal) = compileLispVal(v).Invoke(env, cont)
+    let evalCompiled env cont (v: LispVal) = compileLispValGuarded env v |> fun f -> f.Invoke(env, cont)
 
     let analyzeAndCompile (source: string) : ThrowsError<KernelFunc list> =
         match Parser.readExprList source with
@@ -152,13 +161,13 @@ module Compiler =
         sourceLine : string option
     }
 
-    let analyzeAndCompileLocated sourceName (source: string) : ThrowsError<LocatedKernelFunc list> =
+    let analyzeAndCompileLocated env sourceName (source: string) : ThrowsError<LocatedKernelFunc list> =
         match Parser.readLocatedExprList sourceName source with
         | Choice1Of2 e -> throwError e
         | Choice2Of2 forms ->
             forms
             |> List.map (fun form ->
-                { func = compileLispVal (Source.toLispVal form)
+                { func = compileLispValGuarded env (Source.toLispVal form)
                   span = Source.spanOf form
                   sourceLine = Source.sourceLineAt source form.span.startPosition.line })
             |> returnM

--- a/IronKernel/Emit.fs
+++ b/IronKernel/Emit.fs
@@ -40,8 +40,8 @@ module Emit =
     let compileSource (source: string) : ThrowsError<KernelFunc list> =
         analyzeAndCompile source
 
-    let compileSourceLocated sourceName source =
-        analyzeAndCompileLocated sourceName source
+    let compileSourceLocated env sourceName source =
+        analyzeAndCompileLocated env sourceName source
 
     let private readSource (path: string) : ThrowsError<string> =
         try
@@ -52,12 +52,13 @@ module Emit =
         match readSource path with
         | Choice1Of2 e -> throwError e
         | Choice2Of2 source ->
-            match compileSourceLocated path source with
+            let env = makePrimitiveBindings ()
+            match compileSourceLocated env path source with
             | Choice1Of2 e -> throwError e
             | Choice2Of2 forms -> forms |> List.map (fun form -> form.func) |> returnM
 
     let runSource (env: LispVal) sourceName source =
-        match compileSourceLocated sourceName source with
+        match compileSourceLocated env sourceName source with
         | Choice1Of2 e -> throwError e
         | Choice2Of2 forms -> runLocatedForms env forms
 
@@ -103,7 +104,8 @@ module Emit =
             match readSource inputPath with
             | Choice1Of2 e -> throwError e
             | Choice2Of2 source ->
-                match compileSourceLocated inputPath source with
+                let env = makePrimitiveBindings ()
+                match compileSourceLocated env inputPath source with
                 | Choice1Of2 e -> throwError e
                 | Choice2Of2 _ -> writeIkcPackage outputPath source
 

--- a/IronKernel/Eval.fs
+++ b/IronKernel/Eval.fs
@@ -93,7 +93,7 @@ module Eval =
 
     and operateStep (Environment _ as _env) (Continuation (cpr, metaCont, ct) as cont) (func: LispVal) (args: LispVal list) : Step =
         match func with
-        | PrimitiveOperative f -> f _env cont args
+        | PrimitiveOperative primitive -> primitive.invoke _env cont args
         | CompiledCombiner f -> f _env cont args
         | IOFunc f ->
             match evalArgs _env (newContinuation _env) args with

--- a/IronKernel/Ir.fs
+++ b/IronKernel/Ir.fs
@@ -5,6 +5,7 @@ namespace IronKernel
 module Ir =
 
     open Ast
+    open SymbolTable
 
     /// Explicit core forms after analysis. Residual wraps trees that stay interpreted.
     type CoreExpr =
@@ -17,6 +18,7 @@ module Ir =
         | CVau of formals: LispVal * envarg: string * body: CoreExpr list
         | CApp of op: CoreExpr * args: CoreExpr list
         | COperate of op: CoreExpr * operands: LispVal list
+        | CGuarded of guard: BindingGuard * specialized: CoreExpr * fallback: CoreExpr
         | CEval of envExpr: CoreExpr * expr: CoreExpr
         | CReset of CoreExpr
         | CResidual of LispVal
@@ -50,6 +52,8 @@ module Ir =
         | CVau (f, e, body) -> sprintf "(vau %s %s ...)" (showVal f) e
         | CApp (op, args) -> sprintf "(%s %s)" (showCore op) (String.concat " " (List.map showCore args))
         | COperate (op, _) -> sprintf "(operate %s ...)" (showCore op)
+        | CGuarded (guard, specialized, _) ->
+            sprintf "(guard %s@%d %s)" guard.name guard.version (showCore specialized)
         | CEval (e, x) -> sprintf "(eval %s %s)" (showCore e) (showCore x)
         | CReset x -> sprintf "(reset %s)" (showCore x)
         | CResidual v -> "residual:" + showVal v

--- a/IronKernel/Ir.fs
+++ b/IronKernel/Ir.fs
@@ -18,6 +18,7 @@ module Ir =
         | CVau of formals: LispVal * envarg: string * body: CoreExpr list
         | CApp of op: CoreExpr * args: CoreExpr list
         | COperate of op: CoreExpr * operands: LispVal list
+        | CIntrinsicOperate of identity: PrimitiveIdentity * operands: LispVal list
         | CGuarded of guard: BindingGuard * specialized: CoreExpr * fallback: CoreExpr
         | CEval of envExpr: CoreExpr * expr: CoreExpr
         | CReset of CoreExpr
@@ -52,6 +53,7 @@ module Ir =
         | CVau (f, e, body) -> sprintf "(vau %s %s ...)" (showVal f) e
         | CApp (op, args) -> sprintf "(%s %s)" (showCore op) (String.concat " " (List.map showCore args))
         | COperate (op, _) -> sprintf "(operate %s ...)" (showCore op)
+        | CIntrinsicOperate (identity, _) -> sprintf "(intrinsic %A ...)" identity
         | CGuarded (guard, specialized, _) ->
             sprintf "(guard %s@%d %s)" guard.name guard.version (showCore specialized)
         | CEval (e, x) -> sprintf "(eval %s %s)" (showCore e) (showCore x)

--- a/IronKernel/Runtime.fs
+++ b/IronKernel/Runtime.fs
@@ -303,12 +303,14 @@
 
         let make_encapsulation_type env cont _ =
             let counter =  Guid.NewGuid()
+            let primitive f =
+                PrimitiveOperative { identity = None; invoke = f }
             let encapsulator =
-                Applicative (PrimitiveOperative ( fun e c (arg::_) -> Encapsulation { tag = counter; value = arg } |> bounceContinue e c ))
+                Applicative (primitive (fun e c (arg::_) -> Encapsulation { tag = counter; value = arg } |> bounceContinue e c))
             let predicate =
-                Applicative (PrimitiveOperative ( fun e c (arg::_) -> match arg with Encapsulation { tag = tag ; value = _ } -> Bool (counter.Equals(tag))  |> bounceContinue e c | _ -> Bool(false)  |> bounceContinue e c))
+                Applicative (primitive (fun e c (arg::_) -> match arg with Encapsulation { tag = tag ; value = _ } -> Bool (counter.Equals(tag))  |> bounceContinue e c | _ -> Bool(false)  |> bounceContinue e c))
             let decapsulator = 
-                Applicative (PrimitiveOperative ( fun e c (arg::_) -> match arg with Encapsulation { tag = tag ; value = value} when counter.Equals(tag) -> bounceContinue e c value | _ -> fail (Default "encapsulation type mismatch") ))
+                Applicative (primitive (fun e c (arg::_) -> match arg with Encapsulation { tag = tag ; value = value} when counter.Equals(tag) -> bounceContinue e c value | _ -> fail (Default "encapsulation type mismatch")))
                 
             List [encapsulator; predicate; decapsulator] |> bounceContinue env cont
 
@@ -350,10 +352,24 @@
 
         /// Fresh environment containing only primitive operators (safe for isolated tests).
         let makePrimitiveBindings () = 
-            let makeFunc t (var,func) = (var, t func)
-            let primi = (Map.toList ioPrimitives |> List.map (makeFunc IOFunc)) 
-                      @ (Map.toList primitiveOperatives     |> List.map (makeFunc PrimitiveOperative))
-                      @ (Map.toList primitiveApplicatives   |> List.map (makeFunc (Applicative << PrimitiveOperative)))
+            let operativeIdentity = function
+                | "if" -> Some PrimitiveIf
+                | "define" -> Some PrimitiveDefine
+                | _ -> None
+            let makeOperative (name, func) =
+                name,
+                PrimitiveOperative
+                    { identity = operativeIdentity name
+                      invoke = func }
+            let makeApplicative (name, func) =
+                name,
+                Applicative
+                    (PrimitiveOperative
+                        { identity = None
+                          invoke = func })
+            let primi = (Map.toList ioPrimitives |> List.map (fun (name, func) -> name, IOFunc func))
+                      @ (Map.toList primitiveOperatives |> List.map makeOperative)
+                      @ (Map.toList primitiveApplicatives |> List.map makeApplicative)
             bindVars (newEnv []) primi
 
         /// Shared bootstrap environment (REPL / CLI). Prefer `makePrimitiveBindings` in tests.

--- a/IronKernel/SymbolTable.fs
+++ b/IronKernel/SymbolTable.fs
@@ -2,28 +2,75 @@
 
 module SymbolTable =
 
+    open System
+    open System.Threading
     open Ast
     open Errors
-    
+
+    type BindingGuard = {
+        name : string
+        cellId : int64
+        version : int64
+        expectedIdentity : PrimitiveIdentity
+    }
+
+    let mutable private nextBindingId = 0L
+
+    let private newBindingCell value =
+        { id = Interlocked.Increment(&nextBindingId)
+          state = { value = value; version = 0L } }
+
+    let private updateBindingCell cell value =
+        let state = cell.state
+        cell.state <- { value = value; version = state.version + 1L }
+
     let keyEq name (k,_) = k = name
 
-    let rec getVar' (Environment(env,st)) var = 
-        let result = !env |> List.tryFind (keyEq var)
-        match result with
-        |Some(_,x) -> Some !x
-        |None      -> let r = List.choose (fun x -> getVar' x var) st 
-                      match r with
-                      |s::_ -> Some s
-                      |[] -> None
+    let rec resolveBindingCell (Environment(env, parents)) var =
+        match !env |> List.tryFind (keyEq var) with
+        | Some (_, cell) -> Some cell
+        | None ->
+            let rec search = function
+                | [] -> None
+                | (Environment _ as parent) :: rest ->
+                    match resolveBindingCell parent var with
+                    | Some cell -> Some cell
+                    | None -> search rest
+                | _ :: rest -> search rest
+            search parents
 
-    let rec setVar' (Environment(env,st)) var value = 
-        let result = !env |> List.tryFind (keyEq var)
-        match result with
-        |Some(_,x) -> x := value; Some value
-        |None      -> let r = List.choose (fun x -> setVar' x var value) st 
-                      match r with
-                      |s::_ -> Some s
-                      |[] -> None
+    let getVar' env var =
+        resolveBindingCell env var |> Option.map (fun cell -> cell.state.value)
+
+    let setVar' env var value =
+        match resolveBindingCell env var with
+        | Some cell ->
+            updateBindingCell cell value
+            Some value
+        | None -> None
+
+    let rec private primitiveIdentity = function
+        | PrimitiveOperative primitive -> primitive.identity
+        | Applicative combiner -> primitiveIdentity combiner
+        | _ -> None
+
+    let tryCreateBindingGuard env name expectedIdentity =
+        match resolveBindingCell env name with
+        | Some cell when primitiveIdentity cell.state.value = Some expectedIdentity ->
+            Some
+                { name = name
+                  cellId = cell.id
+                  version = cell.state.version
+                  expectedIdentity = expectedIdentity }
+        | _ -> None
+
+    let bindingGuardMatches env guard =
+        match resolveBindingCell env guard.name with
+        | Some cell ->
+            cell.id = guard.cellId
+            && cell.state.version = guard.version
+            && primitiveIdentity cell.state.value = Some guard.expectedIdentity
+        | None -> false
 
     let getVar env var = 
         match getVar' env var with
@@ -35,12 +82,16 @@ module SymbolTable =
         |Some(x) -> succeed x
         |None      -> throwError (UnboundVar("Getting an unbound variable",var))
 
-    let defineVar (Environment(env,_)) var value = 
+    let defineVar (Environment(env,_)) var value =
         let result = !env |> List.tryFind (keyEq var)
         match result with
-        |Some(_,x) -> x := value ; succeed value
-        |None      -> env := (var,ref value) :: !env; succeed value
+        | Some (_, cell) ->
+            updateBindingCell cell value
+            succeed value
+        | None ->
+            env := (var, newBindingCell value) :: !env
+            succeed value
 
     /// Import bindings into the environment
-    let bindVars (Environment(env,fr)) bindings = 
-        Environment(ref ((bindings |> List.map ( fun (x,y) -> x, ref y)) @ !env),fr)
+    let bindVars (Environment(env,fr)) bindings =
+        Environment(ref ((bindings |> List.map (fun (name, value) -> name, newBindingCell value)) @ !env),fr)

--- a/IronKernel/SymbolTable.fs
+++ b/IronKernel/SymbolTable.fs
@@ -56,20 +56,24 @@ module SymbolTable =
 
     let tryCreateBindingGuard env name expectedIdentity =
         match resolveBindingCell env name with
-        | Some cell when primitiveIdentity cell.state.value = Some expectedIdentity ->
-            Some
-                { name = name
-                  cellId = cell.id
-                  version = cell.state.version
-                  expectedIdentity = expectedIdentity }
+        | Some cell ->
+            let state = cell.state
+            if primitiveIdentity state.value = Some expectedIdentity then
+                Some
+                    { name = name
+                      cellId = cell.id
+                      version = state.version
+                      expectedIdentity = expectedIdentity }
+            else None
         | _ -> None
 
     let bindingGuardMatches env guard =
         match resolveBindingCell env guard.name with
         | Some cell ->
+            let state = cell.state
             cell.id = guard.cellId
-            && cell.state.version = guard.version
-            && primitiveIdentity cell.state.value = Some guard.expectedIdentity
+            && state.version = guard.version
+            && primitiveIdentity state.value = Some guard.expectedIdentity
         | None -> false
 
     let getVar env var = 

--- a/README.md
+++ b/README.md
@@ -112,12 +112,16 @@ IronKernel keeps a **LISP / Kernel S-expression surface** (parentheses are inten
 | Module | Role |
 |--------|------|
 | `Parser.fs` | FParsec → homoiconic `LispVal` |
-| `Ir.fs` / `Analyze.fs` | Core IR + analysis |
+| `Ir.fs` / `Analyze.fs` | Core IR + binding-aware guarded analysis |
 | `Eval.fs` | Trampolined CPS interpreter (TCO-capable) |
-| `Compiler.fs` | Expression-tree hybrid compiler |
+| `Compiler.fs` | Guarded Expression-tree compiler with generic fallback |
 | `Emit.fs` | IKC package emit / load |
 | `Runtime.fs` | Primitive operatives & applicatives |
 | `kernel.scm` | Stdlib (`lambda`, `let`, modules, …) |
+
+Compiler fast paths are guarded by stable binding-cell identity and version.
+Rebinding or shadowing a primitive invalidates its guard before any specialized
+work begins, so execution falls back to ordinary Kernel combiner dispatch.
 
 ## License
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace raw binding refs with stable versioned binding cells
- tag primitive `if` and `define` combiners with semantic identities
- add guarded Core IR that specializes only when resolved binding identity/version matches
- invoke existing CPS-correct primitives directly on guard hits, skipping lookup and generic combiner dispatch
- fall back before specialized work after rebinding or shadowing
- make ordered assignment update only the first depth-first binding

## Validation
- focused guard, environment, continuation, and parity suite passes (22 tests)
- full Debug and Release suites pass (72 tests each)
- CI passes

## Design
Guards resolve through the dynamic environment and compare binding-cell identity, version, and primitive semantic identity. Guard failure selects the existing generic path; no unsupported CLR machine-code deoptimization or stack reconstruction is required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8498e3c-8e84-496a-bc69-85678d76f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8498e3c-8e84-496a-bc69-85678d76f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786909074&installation_id=147070874&pr_number=8&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F8&signature=409572d658abc6bc3b5aa9653ab946c1142fd0bfbeea202d78960c3db463e350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->