### PR TITLE
Fix binding guards matching Applicative-wrapped primitives

### DIFF
--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -61,6 +61,25 @@ let ``compiled guard deoptimizes after primitive rebinding`` () =
     | result -> failwithf "guard did not fall back after rebind: %A" result
 
 [<Fact>]
+let ``wrapped if is not analyzed as a guarded intrinsic`` () =
+    let env = freshEnv ()
+    ignore (evalIn env "(define if (wrap if))")
+
+    match analyzeGuarded env (parseOk "(if #t 1 2)") with
+    | COperate (CVar "if", [Bool true; Obj _; Obj _]) -> ()
+    | CGuarded _ as other ->
+        failwithf "wrapped if must not use guarded fast path: %s" (showCore other)
+    | other -> failwith (showCore other)
+
+[<Fact>]
+let ``compiled wrapped if evaluates unused branch like the interpreter`` () =
+    // Operative if skips the unused branch; applicative (wrap if) evaluates both.
+    // A buggy guard fast path would return 1 while the interpreter errors.
+    assertParitySession
+        [ "(define if (wrap if))"
+          "(if #t 1 missing-binding)" ]
+
+[<Fact>]
 let ``compiled guard detects a new shadowing binding`` () =
     let parent = freshEnv ()
     let child = newEnv [parent]

--- a/IronKernel.Tests/EnvironmentTests.fs
+++ b/IronKernel.Tests/EnvironmentTests.fs
@@ -62,6 +62,29 @@ let ``binding guards track identity and version`` () =
     Assert.False(bindingGuardMatches env guard)
 
 [<Fact>]
+let ``binding guards reject applicative-wrapped primitives`` () =
+    let env = freshEnv ()
+    ignore (evalIn env "(define if (wrap if))")
+
+    Assert.True(tryCreateBindingGuard env "if" PrimitiveIf |> Option.isNone)
+
+    // Rebuild a guard against a fresh env, then wrap in place without relying on
+    // version alone: identity check must fail for Applicative-wrapped if.
+    let env2 = freshEnv ()
+    let guard =
+        tryCreateBindingGuard env2 "if" PrimitiveIf
+        |> Option.defaultWith (fun () -> failwith "missing primitive if guard")
+    match getVar' env2 "if" with
+    | Some bare ->
+        // Mutate the cell value while preserving id/version so only identity is tested.
+        match resolveBindingCell env2 "if" with
+        | Some cell ->
+            cell.state <- { cell.state with value = Applicative bare }
+            Assert.False(bindingGuardMatches env2 guard)
+        | None -> failwith "missing if binding"
+    | None -> failwith "missing if binding"
+
+[<Fact>]
 let ``set updates only the first binding in depth-first order`` () =
     let first = newEnv []
     let second = newEnv []

--- a/IronKernel/SymbolTable.fs
+++ b/IronKernel/SymbolTable.fs
@@ -49,9 +49,12 @@ module SymbolTable =
             Some value
         | None -> None
 
-    let rec private primitiveIdentity = function
+    /// Only bare primitive operatives carry a guarded identity. An Applicative
+    /// wrapping a primitive (e.g. after `(define if (wrap if))`) must not match,
+    /// because the compiler fast path invokes operative semantics while the
+    /// binding evaluates all operands first.
+    let private primitiveIdentity = function
         | PrimitiveOperative primitive -> primitive.identity
-        | Applicative combiner -> primitiveIdentity combiner
         | _ -> None
 
     let tryCreateBindingGuard env name expectedIdentity =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`primitiveIdentity` previously walked through `Applicative` wrappers, so after `(define if (wrap if))` (or the same for `define`) a binding guard could still report `PrimitiveIf` / `PrimitiveDefine`.

That let the guarded compiler fast path call `Runtime.if_then_else` / `define` with operative semantics (lazy operands) while the live binding was an applicative that evaluates every operand first—changing side effects, errors, and continuation behavior versus the interpreter.

## Fix

Only bare `PrimitiveOperative` values contribute a guard identity. Wrapped combiners fall back to the generic `COperate` path.

## Tests

- Binding guards reject applicative-wrapped primitives (including same cell/version with swapped value)
- Environment-aware analysis does not emit `CGuarded` for wrapped `if`
- Interpreter/compiler parity: wrapped `if` evaluates the unused branch (unbound-var error) in both engines

All 75 tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a28803af-3f08-4207-ba19-568cb9f9167c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a28803af-3f08-4207-ba19-568cb9f9167c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786916952&installation_id=147070874&pr_number=10&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F10&signature=ff92f11ca42aea50dcafb6b2d0ca8d862dd110a52e7fdb67eb85e4bc6e42eec1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->