### PR TITLE
Cursor/vscode playground f515

### DIFF
--- a/editors/vscode/src/cli.ts
+++ b/editors/vscode/src/cli.ts
@@ -113,7 +113,15 @@ export function runProcess(
         return;
       }
       if (error.name === "AbortError") {
-        cancelled = true;
+        settled = true;
+        clearTimeout(timeout);
+        resolve({
+          exitCode: null,
+          stdout: Buffer.concat(stdout).toString("utf8"),
+          stderr: Buffer.concat(stderr).toString("utf8"),
+          timedOut,
+          cancelled: true
+        });
         return;
       }
       settled = true;

--- a/editors/vscode/src/playgroundPanel.ts
+++ b/editors/vscode/src/playgroundPanel.ts
@@ -115,12 +115,18 @@ export class PlaygroundPanel implements vscode.Disposable {
         [],
         { timeoutMs, maxOutputBytes, signal: controller.signal }
       );
+      if (this.activeRun !== controller) {
+        return;
+      }
       await this.panel.webview.postMessage({
         type: "completed",
         ...result,
         diagnostics: parseDiagnostics(result.stderr)
       });
     } catch (error) {
+      if (this.activeRun !== controller) {
+        return;
+      }
       const message = error instanceof Error ? error.message : String(error);
       this.output.appendLine(`[playground] ${message}`);
       await this.panel.webview.postMessage({ type: "failed", message });

--- a/editors/vscode/test/cli.abort.test.ts
+++ b/editors/vscode/test/cli.abort.test.ts
@@ -1,0 +1,46 @@
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args)
+}));
+
+import { runProcess } from "../src/cli.js";
+
+describe("runProcess AbortError settlement", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it("settles on AbortError without waiting for close or the full timeout", async () => {
+    const fakeChild = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: () => boolean;
+    };
+    fakeChild.stdout = new EventEmitter();
+    fakeChild.stderr = new EventEmitter();
+    fakeChild.kill = () => true;
+    spawnMock.mockReturnValue(fakeChild);
+
+    const timeoutMs = 5000;
+    const started = Date.now();
+    const resultPromise = runProcess(
+      { command: "unused", prefixArgs: [], cwd: "/" },
+      [],
+      { timeoutMs, maxOutputBytes: 4096 }
+    );
+
+    const abortError = new Error("The operation was aborted");
+    abortError.name = "AbortError";
+    fakeChild.emit("error", abortError);
+
+    const result = await resultPromise;
+    expect(result.cancelled).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBeNull();
+    expect(Date.now() - started).toBeLessThan(timeoutMs / 2);
+  });
+});

--- a/editors/vscode/test/cli.test.ts
+++ b/editors/vscode/test/cli.test.ts
@@ -59,6 +59,26 @@ describe("CLI process boundary", () => {
     expect(result.exitCode).not.toBe(0);
   });
 
+  it("settles immediately when the abort signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const timeoutMs = 5000;
+    const started = Date.now();
+    const result = await runProcess(
+      {
+        command: process.execPath,
+        prefixArgs: ["-e", "setInterval(() => {}, 1000)"],
+        cwd: repositoryRoot
+      },
+      [],
+      { timeoutMs, maxOutputBytes: 4096, signal: controller.signal }
+    );
+
+    expect(result.cancelled).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(Date.now() - started).toBeLessThan(timeoutMs / 2);
+  });
+
   it(
     "runs playground source through the real IronKernel CLI",
     async () => {


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786918210&installation_id=147070874&pr_number=11&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F11&signature=87b758929d5c873238c3de2b05efd7b33d924048a178d697eaca68ee9b98a0f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to VS Code extension process spawning and playground UI race handling; no auth or core runtime changes.
> 
> **Overview**
> Fixes **cancel/abort** handling for the VS Code playground’s IronKernel CLI wrapper and stops superseded runs from updating the webview.
> 
> **`runProcess`** now **resolves immediately** when spawn emits **`AbortError`** (clears the timeout, returns `cancelled: true` and buffered output) instead of leaving the promise pending until **`close`** or the full timeout.
> 
> **`PlaygroundPanel`** skips posting **`completed`** / **`failed`** if **`activeRun`** no longer matches the run that finished, so a newer run or cancel does not get overwritten by a late result.
> 
> Adds Vitest coverage for **`AbortError`** settlement (mocked child) and for an **already-aborted** `AbortSignal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b79021de1370b9bed585014d3a5abf34090f79e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->