### PR TITLE
Add tagged effect handlers and CLR Task suspension

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -21,6 +21,7 @@ dotnet run --project IronKernel -- run hello.ikc
 | `vau-dotnet.scm` | User-defined control forms and .NET interop | Guided feature tour |
 | `samples.scm` | Recursion and the `let` family | Prints intermediate values |
 | `continuations.scm` | Full continuations | Defines local output helpers |
+| `effects-async.scm` | Tagged deep handlers and CLR Task suspension | Requires `unrestricted` profile |
 | `coroutines.scm` | Cooperative scheduling experiment | Historical example; not yet covered by the compatibility suite |
 | `zipper.scm` | Delimited continuations | Functional zipper traversal |
 | `sqrt.scm` | Operative-based numeric procedure | Defines `sqrt`; intentionally produces no output |

--- a/Examples/effects-async.scm
+++ b/Examples/effects-async.scm
@@ -1,0 +1,16 @@
+; Tagged deep handlers and CLR Task suspension.
+
+(define request (make-prompt-tag))
+
+(define handled
+  (prompt request
+    (lambda (value resume-request)
+      (resume resume-request (+ value 1)))
+    (+ 1 (perform request 40))))
+
+(printf "handled={0}\n" handled)
+
+(define delayed
+  (await-task (task-delay 25 "async complete")))
+
+(Console.write-line delayed)

--- a/Examples/effects-async.scm
+++ b/Examples/effects-async.scm
@@ -8,7 +8,8 @@
       (resume resume-request (+ value 1)))
     (+ 1 (perform request 40))))
 
-(printf "handled={0}\n" handled)
+(Console.write-line
+  (if (eqv? handled 42) "handled=42" "unexpected handler result"))
 
 (define delayed
   (await-task (task-delay 25 "async complete")))

--- a/IronKernel.Tests/CapabilityTests.fs
+++ b/IronKernel.Tests/CapabilityTests.fs
@@ -22,10 +22,10 @@ let ``profiles expose only their declared host authority`` () =
     let safe = makePrimitiveBindingsForProfile Safe
     let unrestricted = makePrimitiveBindingsForProfile Unrestricted
 
-    for name in [ "."; "new"; ".get"; ".set"; "load"; "read-contents"; "Console.write-line" ] do
+    for name in [ "."; "new"; ".get"; ".set"; "load"; "read-contents"; "Console.write-line"; "await-task"; "task-delay" ] do
         expectUnbound minimal name
 
-    for name in [ "."; "new"; ".get"; ".set"; "load"; "read-contents"; "print" ] do
+    for name in [ "."; "new"; ".get"; ".set"; "load"; "read-contents"; "print"; "await-task"; "task-delay" ] do
         expectUnbound safe name
 
     match getVar safe "Console.write-line", getVar unrestricted "." with
@@ -81,3 +81,18 @@ let ``safe bootstrap loads stdlib without granting source loading`` () =
         expectUnbound env "load"
         assertEval env "((lambda (x) x) 42)" (Obj (42 :> obj))
         assertEval env "(String.concat \"safe\" \"-mode\")" (Obj ("safe-mode" :> obj))
+
+[<Fact>]
+let ``stolen async primitive checks the invoking environment`` () =
+    let unrestricted = makePrimitiveBindingsForProfile Unrestricted
+    let safe = makePrimitiveBindingsForProfile Safe
+    let awaitPrimitive =
+        getVar unrestricted "await-task"
+        |> function
+            | Choice2Of2 value -> value
+            | Choice1Of2 error -> failwith (showError error)
+    ignore (defineVar safe "await-task" awaitPrimitive)
+
+    match evalRaw Interpreted safe "(await-task #inert)" with
+    | Choice1Of2 (CapabilityDenied _) -> ()
+    | result -> failwithf "stolen async primitive escaped its capability: %A" result

--- a/IronKernel.Tests/EffectTests.fs
+++ b/IronKernel.Tests/EffectTests.fs
@@ -67,6 +67,21 @@ let ``await task suspends and resumes the trampoline`` () =
     | result -> failwithf "unexpected async result: %A" result
 
 [<Fact>]
+let ``await task maps faults to language errors`` () =
+    let env = makePrimitiveBindings ()
+    let completion =
+        TaskCompletionSource<LispVal>(TaskCreationOptions.RunContinuationsAsynchronously)
+    ignore (defineVar env "pending" (Obj(completion.Task :> obj)))
+
+    let resultTask =
+        evalAsync env (newContinuation env) (parseOk "(await-task pending)")
+    completion.SetException(System.InvalidOperationException("async boom"))
+
+    match resultTask.GetAwaiter().GetResult() with
+    | Choice1Of2 (ClrException error) -> Assert.Contains("async boom", error.Message)
+    | result -> failwithf "unexpected faulted-task result: %A" result
+
+[<Fact>]
 let ``effects and async preserve interpreter compiler parity`` () =
     assertParitySession
         [ "(load \"kernel.scm\")"

--- a/IronKernel.Tests/EffectTests.fs
+++ b/IronKernel.Tests/EffectTests.fs
@@ -50,6 +50,21 @@ let ``effect resumptions are one shot`` () =
         | result -> failwithf "unexpected repeated-resume result: %A" result)
 
 [<Fact>]
+let ``aborting handler invalidates the resumption`` () =
+    withKernel (fun env ->
+        ignore (evalIn env "(define effect (make-prompt-tag))")
+        ignore (evalIn env "(define saved (vector #inert))")
+        assertEval env
+            """(prompt effect
+                 (lambda (value k)
+                   (begin (vector-set! saved 0 k) (+ value 1)))
+                 (+ 100 (perform effect 41)))"""
+            (Obj 42)
+        match evalRaw Interpreted env "(resume (vector-ref saved 0) 0)" with
+        | Choice1Of2 (Default message) -> Assert.Contains("already been consumed", message)
+        | result -> failwithf "unexpected aborted-resumption result: %A" result)
+
+[<Fact>]
 let ``await task suspends and resumes the trampoline`` () =
     let env = makePrimitiveBindings ()
     let completion =
@@ -80,6 +95,21 @@ let ``await task maps faults to language errors`` () =
     match resultTask.GetAwaiter().GetResult() with
     | Choice1Of2 (ClrException error) -> Assert.Contains("async boom", error.Message)
     | result -> failwithf "unexpected faulted-task result: %A" result
+
+[<Fact>]
+let ``await task unwraps generic task results`` () =
+    let env = makePrimitiveBindings ()
+    let completion =
+        TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously)
+    ignore (defineVar env "pending" (Obj(completion.Task :> obj)))
+
+    let resultTask =
+        evalAsync env (newContinuation env) (parseOk "(await-task pending)")
+    completion.SetResult("hello")
+
+    match resultTask.GetAwaiter().GetResult() with
+    | Choice2Of2 (Obj (:? string as value)) -> Assert.Equal("hello", value)
+    | result -> failwithf "unexpected generic-task result: %A" result
 
 [<Fact>]
 let ``effects and async preserve interpreter compiler parity`` () =

--- a/IronKernel.Tests/EffectTests.fs
+++ b/IronKernel.Tests/EffectTests.fs
@@ -40,12 +40,14 @@ let ``deep effect handler can abort or resume`` () =
 let ``effect resumptions are one shot`` () =
     withKernel (fun env ->
         ignore (evalIn env "(define effect (make-prompt-tag))")
-        let expression =
+        ignore (evalIn env "(define saved (vector #inert))")
+        assertEval env
             """(prompt effect
                  (lambda (value k)
-                   (begin (resume k value) (resume k value)))
+                   (begin (vector-set! saved 0 k) (resume k value)))
                  (perform effect 1))"""
-        match evalRaw Interpreted env expression with
+            (Obj 1)
+        match evalRaw Interpreted env "(resume (vector-ref saved 0) 0)" with
         | Choice1Of2 (Default message) -> Assert.Contains("already been consumed", message)
         | result -> failwithf "unexpected repeated-resume result: %A" result)
 
@@ -63,6 +65,15 @@ let ``aborting handler invalidates the resumption`` () =
         match evalRaw Interpreted env "(resume (vector-ref saved 0) 0)" with
         | Choice1Of2 (Default message) -> Assert.Contains("already been consumed", message)
         | result -> failwithf "unexpected aborted-resumption result: %A" result)
+
+[<Fact>]
+let ``resume result is not replaced by trailing handler forms`` () =
+    evalSessionKernel
+        [ "(define effect (make-prompt-tag))", Inert
+          """(prompt effect
+               (lambda (value k)
+                 (begin (resume k (+ value 1)) 999))
+               (+ 100 (perform effect 41)))""", Obj 142 ]
 
 [<Fact>]
 let ``await task suspends and resumes the trampoline`` () =

--- a/IronKernel.Tests/EffectTests.fs
+++ b/IronKernel.Tests/EffectTests.fs
@@ -1,0 +1,75 @@
+module IronKernel.Tests.EffectTests
+
+open System.Threading.Tasks
+open Xunit
+
+open IronKernel.Ast
+open IronKernel.Eval
+open IronKernel.Runtime
+open IronKernel.SymbolTable
+open IronKernel.Tests.TestHelpers
+
+[<Fact>]
+let ``tagged shift selects the nearest matching prompt`` () =
+    evalSessionKernel
+        [ "(define outer (make-prompt-tag))", Inert
+          "(define inner (make-prompt-tag))", Inert
+          "(reset outer (+ 100 (reset inner (+ 10 (shift outer (lambda (k) 1))))))", Obj 1
+          "(reset outer (+ 100 (reset inner (+ 10 (shift inner (lambda (k) 1))))))", Obj 101
+          "(reset outer (+ 100 (reset inner (+ 10 (shift outer (lambda (k) (k 1)))))))", Obj 111 ]
+
+[<Fact>]
+let ``tagged shift reports a missing prompt`` () =
+    withKernel (fun env ->
+        ignore (evalIn env "(define tag (make-prompt-tag))")
+        match evalRaw Interpreted env "(shift tag (lambda (k) 1))" with
+        | Choice1Of2 (Default message) -> Assert.Contains("matching tagged prompt", message)
+        | result -> failwithf "unexpected missing-prompt result: %A" result)
+
+[<Fact>]
+let ``deep effect handler can abort or resume`` () =
+    evalSessionKernel
+        [ "(define effect (make-prompt-tag))", Inert
+          "(prompt effect (lambda (value k) (+ value 1)) (+ 100 (perform effect 41)))", Obj 42
+          "(prompt effect (lambda (value k) (resume k (+ value 1))) (+ 1 (perform effect 40)))", Obj 42
+          """(prompt effect
+               (lambda (value k) (resume k (+ value 1)))
+               (+ (perform effect 1) (perform effect 2)))""", Obj 5 ]
+
+[<Fact>]
+let ``effect resumptions are one shot`` () =
+    withKernel (fun env ->
+        ignore (evalIn env "(define effect (make-prompt-tag))")
+        let expression =
+            """(prompt effect
+                 (lambda (value k)
+                   (begin (resume k value) (resume k value)))
+                 (perform effect 1))"""
+        match evalRaw Interpreted env expression with
+        | Choice1Of2 (Default message) -> Assert.Contains("already been consumed", message)
+        | result -> failwithf "unexpected repeated-resume result: %A" result)
+
+[<Fact>]
+let ``await task suspends and resumes the trampoline`` () =
+    let env = makePrimitiveBindings ()
+    let completion =
+        TaskCompletionSource<LispVal>(TaskCreationOptions.RunContinuationsAsynchronously)
+    ignore (defineVar env "pending" (Obj(completion.Task :> obj)))
+
+    let resultTask =
+        evalAsync env (newContinuation env) (parseOk "(+ 1 (await-task pending))")
+
+    Assert.False(resultTask.IsCompleted)
+    completion.SetResult(Obj (41 :> obj))
+
+    match resultTask.GetAwaiter().GetResult() with
+    | Choice2Of2 (Obj (:? int as value)) -> Assert.Equal(42, value)
+    | result -> failwithf "unexpected async result: %A" result
+
+[<Fact>]
+let ``effects and async preserve interpreter compiler parity`` () =
+    assertParitySession
+        [ "(load \"kernel.scm\")"
+          "(define effect (make-prompt-tag))"
+          "(prompt effect (lambda (value k) (resume k value)) (+ 1 (perform effect 41)))"
+          "(+ 1 (await-task (task-delay 5 41)))" ]

--- a/IronKernel.Tests/IronKernel.Tests.fsproj
+++ b/IronKernel.Tests/IronKernel.Tests.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="ConformanceTests.fs" />
     <Compile Include="CliTests.fs" />
     <Compile Include="ContinuationTests.fs" />
+    <Compile Include="EffectTests.fs" />
     <Compile Include="StdlibTests.fs" />
     <Compile Include="ExampleTests.fs" />
   </ItemGroup>

--- a/IronKernel/Analyze.fs
+++ b/IronKernel/Analyze.fs
@@ -22,6 +22,8 @@ module Analyze =
         | Operative _
         | Applicative _
         | Continuation _
+        | PromptTag _
+        | Resumption _
         | IOFunc _
         | Port _
         | Status _ -> CLit value

--- a/IronKernel/Ast.fs
+++ b/IronKernel/Ast.fs
@@ -18,6 +18,7 @@ module Ast =
         | RawClrInterop
         | HostIO
         | SourceLoading
+        | HostAsync
         | GeneratedClr of string
 
     type CapabilityProfile =
@@ -33,6 +34,12 @@ module Ast =
     type Step =
         | Done of ThrowsError<LispVal>
         | More of (unit -> Step)
+        | Await of AwaitRequest
+
+    and AwaitRequest = {
+        register : (ThrowsError<LispVal> -> unit) -> unit
+        resume : ThrowsError<LispVal> -> Step
+    }
 
     and OperativeRecord = { 
         prms    : LispVal ;
@@ -52,6 +59,15 @@ module Ast =
         currentCont : DeferredCode option
         nextCont    : LispVal option
         args        : (LispVal list) option
+    }
+    and PromptFrame = {
+        parentCont : LispVal
+        tag : System.Guid option
+        handler : LispVal option
+    }
+    and ResumptionRecord = {
+        continuation : LispVal
+        mutable consumed : int
     }
     and EncapsulationRecord = {
         tag     : System.Guid
@@ -92,7 +108,9 @@ module Ast =
         | Inert
         | Nil
         | Obj of obj
-        | Continuation of  ContinuationRecord * (LispVal option) * ContinuationType
+        | Continuation of ContinuationRecord * PromptFrame option * ContinuationType
+        | PromptTag of System.Guid
+        | Resumption of ResumptionRecord
         | Status of string
         | Keyword of string
         | Vector of LispVal array
@@ -122,6 +140,7 @@ module Ast =
             [ RawClrInterop
               HostIO
               SourceLoading
+              HostAsync
               GeneratedClr "safe" ]
 
     let newEnvWithCapabilities capabilities frames =
@@ -179,6 +198,8 @@ module Ast =
         | Nil -> "()"
         | Obj o -> "<obj " + (if o = null then "null" else (o.ToString() + " : " + o.GetType().Name)) + ">"
         | Continuation _ -> "<continuation>"
+        | PromptTag _ -> "<prompt-tag>"
+        | Resumption _ -> "<resumption>"
         | Status s -> "error : " + s
         | Inert -> "#inert"
         | Keyword s -> ":" + s

--- a/IronKernel/Eval.fs
+++ b/IronKernel/Eval.fs
@@ -2,6 +2,8 @@
 
 module Eval =
     
+    open System.Threading
+    open System.Threading.Tasks
     open Choice
     open Ast
     open Errors
@@ -12,25 +14,77 @@ module Eval =
     let inline fail (e: LispError) : Step = Done (throwError e)
     let inline ofResult (r: ThrowsError<LispVal>) : Step = Done r
 
-    let run (step: Step) : ThrowsError<LispVal> =
+    let rec runAsync (step: Step) : Task<ThrowsError<LispVal>> =
         let mutable current = step
-        let mutable finished = false
-        let mutable result : ThrowsError<LispVal> = returnM Inert
-        while not finished do
+        let mutable running = true
+        while running do
             match current with
-            | Done r ->
-                result <- r
-                finished <- true
-            | More f ->
-                current <- f ()
-        result
+            | More next -> current <- next ()
+            | Done _
+            | Await _ -> running <- false
+        match current with
+        | Done result -> Task.FromResult result
+        | Await request ->
+            let completion =
+                TaskCompletionSource<ThrowsError<LispVal>>(
+                    TaskCreationOptions.RunContinuationsAsynchronously)
+            try
+                request.register (fun outcome -> completion.TrySetResult(outcome) |> ignore)
+            with ex ->
+                completion.TrySetResult(throwError (ClrException ex)) |> ignore
+            task {
+                let! outcome = completion.Task.ConfigureAwait(false)
+                return! runAsync (request.resume outcome)
+            }
+        | More _ -> failwith "unreachable trampoline state"
+
+    let run (step: Step) : ThrowsError<LispVal> =
+        runAsync step |> fun pending -> pending.GetAwaiter().GetResult()
+
+    let rec private appendContinuationRecord left right =
+        match left.nextCont with
+        | None ->
+            { left with nextCont = Some (Continuation(right, None, Full)) }
+        | Some (Continuation(next, None, continuationType)) ->
+            { left with
+                nextCont =
+                    Some
+                        (Continuation(
+                            appendContinuationRecord next right,
+                            None,
+                            continuationType)) }
+        | Some _ -> left
+
+    let findPrompt tag continuation =
+        let rec search accumulated = function
+            | Continuation(current, Some frame, continuationType) ->
+                let combined =
+                    match accumulated with
+                    | None -> current
+                    | Some previous -> appendContinuationRecord previous current
+                if frame.tag = tag then Some(combined, frame)
+                else search (Some combined) frame.parentCont
+            | _ -> None
+        search None continuation
+
+    let promptContinuation env parent tag handler =
+        Continuation(
+            { closure = env
+              currentCont = None
+              nextCont = None
+              args = None },
+            Some
+                { parentCont = parent
+                  tag = tag
+                  handler = handler },
+            Full)
 
     let rec continueEvalStep (Environment _ as env) (Continuation _ as cont) value : Step =
         match cont with
         | Continuation ({ currentCont = None; nextCont = None }, None, _) ->
             ok value
-        | Continuation ({ closure = e; currentCont = None; nextCont = None }, Some pCont, _) ->
-            More (fun () -> continueEvalStep e pCont value)
+        | Continuation ({ closure = e; currentCont = None; nextCont = None }, Some frame, _) ->
+            More (fun () -> continueEvalStep e frame.parentCont value)
         | Continuation ({ closure = e; currentCont = None; nextCont = Some (Continuation (cr, None, _)) }, metaCont, ct) ->
             More (fun () -> continueEvalStep e (Continuation (cr, metaCont, ct)) value)
         | Continuation ({ closure = e; currentCont = Some (NativeCode { cont = f; args = args }); nextCont = Some (Continuation (ncr, None, _)) }, metaCont, ct) ->
@@ -43,7 +97,7 @@ module Eval =
                     More (fun () -> continueEvalStep e (Continuation (cr, metaCont, ct)) value)
                 | None ->
                     match metaCont with
-                    | Some pCont -> More (fun () -> continueEvalStep e pCont value)
+                    | Some frame -> More (fun () -> continueEvalStep e frame.parentCont value)
                     | None -> ok value
                 | Some _ ->
                     fail (Default "Internal Error: metacontinuation in wrong position")
@@ -104,14 +158,29 @@ module Eval =
                 | Choice1Of2 e -> fail e
                 | Choice2Of2 q -> ofResult (f q)
         | Applicative f -> evalArgsExStep _env cont args f
-        | Continuation (cr, _, ct') ->
+        | Continuation (cr, capturedPrompt, ct') ->
             match args with
             | [] -> fail (NumArgs (1, []))
             | [a] ->
                 match ct' with
                 | Full -> More (fun () -> evalStep _env func a)
-                | Delimited -> More (fun () -> evalStep _env (Continuation (cr, Some cont, Full)) a)
+                | Delimited ->
+                    let prompt =
+                        match capturedPrompt with
+                        | Some frame -> Some { frame with parentCont = cont }
+                        | None ->
+                            Some
+                                { parentCont = cont
+                                  tag = None
+                                  handler = None }
+                    More (fun () -> evalStep _env (Continuation (cr, prompt, Full)) a)
             | _ -> fail (NumArgs (1, args))
+        | Resumption resumption ->
+            match args with
+            | [argument] when Interlocked.Exchange(&resumption.consumed, 1) = 0 ->
+                More (fun () -> operateStep _env cont resumption.continuation [argument])
+            | [_] -> fail (Default "resumption has already been consumed")
+            | _ -> fail (NumArgs(1, args))
         | Operative { prms = prms; envarg = envarg; body = body; closure = closure } ->
             let evalBody env =
                 match cpr with
@@ -188,3 +257,5 @@ module Eval =
     let bounceEval env cont value = More (fun () -> evalStep env cont value)
     let bounceOperate env cont func args = More (fun () -> operateStep env cont func args)
     let bounceBind env cont lf rf = More (fun () -> bindStep env cont lf rf)
+
+    let evalAsync env cont value = runAsync (evalStep env cont value)

--- a/IronKernel/Eval.fs
+++ b/IronKernel/Eval.fs
@@ -178,7 +178,15 @@ module Eval =
         | Resumption resumption ->
             match args with
             | [argument] when Interlocked.Exchange(&resumption.consumed, 1) = 0 ->
-                More (fun () -> operateStep _env cont resumption.continuation [argument])
+                // Resume is a non-local exit from the handler: reinstall the
+                // delimited body under its captured prompt, then continue to
+                // that prompt's parent. Returning through the handler cont
+                // would let trailing handler forms replace the prompt result.
+                let resumeCont =
+                    match resumption.continuation with
+                    | Continuation(_, Some frame, _) -> frame.parentCont
+                    | _ -> cont
+                More (fun () -> operateStep _env resumeCont resumption.continuation [argument])
             | [_] -> fail (Default "resumption has already been consumed")
             | _ -> fail (NumArgs(1, args))
         | Operative { prms = prms; envarg = envarg; body = body; closure = closure } ->

--- a/IronKernel/Runtime.fs
+++ b/IronKernel/Runtime.fs
@@ -1,6 +1,8 @@
 ﻿namespace IronKernel
 
     open System
+    open System.Threading
+    open System.Threading.Tasks
     open Choice
     open Errors
     open Ast
@@ -82,6 +84,7 @@
             | [(Obj arg1); (Obj arg2)] -> returnM (Bool(arg1.Equals(arg2)))
             | [(Bool arg1); (Bool arg2)] -> returnM (Bool(arg1 = arg2))
             | [(Atom arg1); (Atom arg2)] -> returnM (Bool(arg1 = arg2))
+            | [(PromptTag arg1); (PromptTag arg2)] -> returnM (Bool(arg1 = arg2))
             | [(DottedList (xs,x)); (DottedList (ys,y))] -> eqv' [List (xs@[x]); List(ys@[y])]
             | [(List arg1); (List arg2)] -> 
                 let eqvPair (x1,x2) = 
@@ -247,9 +250,39 @@
                 bounceEval env (makeCPS env cont cps) r 
             | badForm -> fail (BadSpecialForm("invalid arguments",List(badForm)))
 
-        let reset env cont  = function 
-            | (exp::_) -> bounceEval env (Continuation({closure = env; currentCont = None ; nextCont = None; args = None}, Some cont, Full)) exp
+        let reset env cont = function
+            | [body] ->
+                bounceEval env (promptContinuation env cont None None) body
+            | [tagExpression; body] ->
+                let install e c tag _ =
+                    match tag with
+                    | PromptTag id ->
+                        bounceEval e (promptContinuation e c (Some id) None) body
+                    | found -> fail (TypeMismatch("prompt-tag", found))
+                bounceEval env (makeCPS env cont install) tagExpression
             | badform -> fail (NumArgs(1,badform))
+
+        let prompt env cont = function
+            | [tagExpression; handlerExpression; body] ->
+                let captureTag e c tag _ =
+                    match tag with
+                    | PromptTag id ->
+                        let captureHandler handlerEnv handlerCont handler _ =
+                            match handler with
+                            | Applicative _ ->
+                                bounceEval
+                                    handlerEnv
+                                    (promptContinuation
+                                        handlerEnv
+                                        handlerCont
+                                        (Some id)
+                                        (Some handler))
+                                    body
+                            | found -> fail (TypeMismatch("applicative handler", found))
+                        bounceEval e (makeCPS e c captureHandler) handlerExpression
+                    | found -> fail (TypeMismatch("prompt-tag", found))
+                bounceEval env (makeCPS env cont captureTag) tagExpression
+            | badform -> fail (NumArgs(3, badform))
          
         let primitiveOperatives = 
             Map.ofList [ 
@@ -261,6 +294,7 @@
                   (".get", dot_get);
                   (".set", dot_set);
                   ("reset", reset);
+                  ("prompt", prompt);
                   ]
         
         let callcc env cont  = function 
@@ -271,13 +305,98 @@
                 | badForm -> fail (TypeMismatch("continuation",badForm))
             | badForm -> fail (NumArgs(1,badForm))
 
+        let private captureShift env cont tag f =
+            match findPrompt tag cont with
+            | Some (continuationRecord, frame) ->
+                let captured =
+                    Continuation(continuationRecord, Some frame, Delimited)
+                let handlerCont =
+                    promptContinuation env frame.parentCont frame.tag frame.handler
+                bounceOperate env handlerCont f [captured]
+            | None ->
+                let description =
+                    match tag with
+                    | None -> "untagged prompt"
+                    | Some _ -> "matching tagged prompt"
+                fail (Default("shift requires a " + description))
+
         let shift env cont = function
-            | Applicative f::_ ->
-                match cont with
-                | Continuation(continuationRecord, Some parentCont, _) ->
-                    bounceOperate env (Continuation({closure = env; currentCont = None  ; nextCont = None; args = None} , Some parentCont, Full)) f [(Continuation(continuationRecord, None, Delimited ))]
-                | _ -> fail (Default("reset needs to be called before shift"))
+            | [Applicative f] -> captureShift env cont None f
+            | [PromptTag tag; Applicative f] ->
+                captureShift env cont (Some tag) f
             | bad -> fail (NumArgs(1, bad))
+
+        let makePromptTag env cont = function
+            | [] -> bounceContinue env cont (PromptTag(Guid.NewGuid()))
+            | bad -> fail (NumArgs(0, bad))
+
+        let perform env cont = function
+            | [PromptTag tag; value] ->
+                match findPrompt (Some tag) cont with
+                | Some (continuationRecord, { handler = Some handler } as frame) ->
+                    let captured =
+                        Continuation(continuationRecord, Some frame, Delimited)
+                    let resumption =
+                        Resumption
+                            { continuation = captured
+                              consumed = 0 }
+                    bounceOperate env frame.parentCont handler [value; resumption]
+                | Some _ -> fail (Default "matching prompt has no effect handler")
+                | None -> fail (Default "perform requires a matching tagged handler")
+            | [found; _] -> fail (TypeMismatch("prompt-tag", found))
+            | bad -> fail (NumArgs(2, bad))
+
+        let resume env cont = function
+            | [Resumption _ as resumption; value] ->
+                bounceOperate env cont resumption [value]
+            | [found; _] -> fail (TypeMismatch("resumption", found))
+            | bad -> fail (NumArgs(2, bad))
+
+        let private taskOutcome (completed: Task) =
+            try
+                completed.GetAwaiter().GetResult()
+                match completed with
+                | :? Task<LispVal> as typed -> returnM typed.Result
+                | :? Task<obj> as typed ->
+                    if isNull typed.Result then returnM Inert
+                    else returnM (Obj typed.Result)
+                | _ -> returnM Inert
+            with
+            | :? OperationCanceledException as error -> throwError (ClrException error)
+            | error -> throwError (ClrException error)
+
+        let awaitTask env cont = function
+            | _ when not (has HostAsync env) ->
+                fail (CapabilityDenied "await-task requires HostAsync")
+            | [Obj (:? Task as pending)] ->
+                Await
+                    { register =
+                        fun complete ->
+                            pending.ContinueWith(
+                                (fun completed -> complete (taskOutcome completed)),
+                                CancellationToken.None,
+                                TaskContinuationOptions.ExecuteSynchronously,
+                                TaskScheduler.Default)
+                            |> ignore
+                      resume =
+                        function
+                        | Choice1Of2 error -> fail error
+                        | Choice2Of2 value -> bounceContinue env cont value }
+            | [found] -> fail (TypeMismatch("Task", found))
+            | bad -> fail (NumArgs(1, bad))
+
+        let taskDelay env cont = function
+            | _ when not (has HostAsync env) ->
+                fail (CapabilityDenied "task-delay requires HostAsync")
+            | [Obj (:? int as milliseconds); value] when milliseconds >= 0 ->
+                let pending =
+                    task {
+                        do! Task.Delay(milliseconds)
+                        return value
+                    }
+                bounceContinue env cont (Obj(pending :> obj))
+            | [found; _] -> fail (TypeMismatch("non-negative int", found))
+            | bad -> fail (NumArgs(2, bad))
 
         let plus env cont args = numericBinOp env cont opAdd args
         let minus env cont args = numericBinOp env cont opMinus args
@@ -354,6 +473,11 @@
                   ("printf", printf');
                   ("show", show);
                   ("shift", shift);
+                  ("make-prompt-tag", makePromptTag);
+                  ("perform", perform);
+                  ("resume", resume);
+                  ("await-task", awaitTask);
+                  ("task-delay", taskDelay);
                   ("vector", vector);
                   ("vector?", isVector);
                   ("make-vector", make_vector);
@@ -381,6 +505,7 @@
                         { identity = None
                           invoke = func })
             let rawInteropNames = Set.ofList [ "."; "new"; ".get"; ".set" ]
+            let asyncNames = Set.ofList [ "await-task"; "task-delay" ]
             let operatives =
                 Map.toList primitiveOperatives
                 |> List.filter (fun (name, _) ->
@@ -392,7 +517,9 @@
                 |> List.filter (fun (name, _) ->
                     (name <> "load" || Set.contains SourceLoading capabilities)
                     && (not (Set.contains name (Set.ofList ["print"; "printf"; "show"]))
-                        || Set.contains HostIO capabilities))
+                        || Set.contains HostIO capabilities)
+                    && (not (Set.contains name asyncNames)
+                        || Set.contains HostAsync capabilities))
                 |> List.map makeApplicative
             let io =
                 if Set.contains HostIO capabilities then

--- a/IronKernel/Runtime.fs
+++ b/IronKernel/Runtime.fs
@@ -342,6 +342,8 @@
                     let resumption = Resumption record
                     // Abort (handler return without resume) must invalidate the
                     // one-shot resumption so a stored handle cannot restart later.
+                    // Successful resume bypasses this continuation and delivers
+                    // the delimited body's result straight to frame.parentCont.
                     let invalidateOnAbort e c result _ =
                         Interlocked.Exchange(&record.consumed, 1) |> ignore
                         bounceContinue e c result

--- a/IronKernel/Runtime.fs
+++ b/IronKernel/Runtime.fs
@@ -336,11 +336,20 @@
                 | Some (continuationRecord, ({ handler = Some handler } as frame)) ->
                     let captured =
                         Continuation(continuationRecord, Some frame, Delimited)
-                    let resumption =
-                        Resumption
-                            { continuation = captured
-                              consumed = 0 }
-                    bounceOperate env frame.parentCont handler [value; resumption]
+                    let record =
+                        { continuation = captured
+                          consumed = 0 }
+                    let resumption = Resumption record
+                    // Abort (handler return without resume) must invalidate the
+                    // one-shot resumption so a stored handle cannot restart later.
+                    let invalidateOnAbort e c result _ =
+                        Interlocked.Exchange(&record.consumed, 1) |> ignore
+                        bounceContinue e c result
+                    bounceOperate
+                        env
+                        (makeCPS env frame.parentCont invalidateOnAbort)
+                        handler
+                        [value; resumption]
                 | Some _ -> fail (Default "matching prompt has no effect handler")
                 | None -> fail (Default "perform requires a matching tagged handler")
             | [found; _] -> fail (TypeMismatch("prompt-tag", found))
@@ -355,12 +364,15 @@
         let private taskOutcome (completed: Task) =
             try
                 completed.GetAwaiter().GetResult()
-                match completed with
-                | :? Task<LispVal> as typed -> returnM typed.Result
-                | :? Task<obj> as typed ->
-                    if obj.ReferenceEquals(typed.Result, null) then returnM Inert
-                    else returnM (Obj typed.Result)
-                | _ -> returnM Inert
+                let taskType = completed.GetType()
+                if taskType.IsGenericType
+                   && taskType.GetGenericTypeDefinition() = typedefof<Task<_>> then
+                    match taskType.GetProperty("Result").GetValue(completed) with
+                    | null -> returnM Inert
+                    | :? LispVal as value -> returnM value
+                    | other -> returnM (Obj other)
+                else
+                    returnM Inert
             with
             | :? OperationCanceledException as error -> throwError (ClrException error)
             | error -> throwError (ClrException error)

--- a/IronKernel/Runtime.fs
+++ b/IronKernel/Runtime.fs
@@ -333,7 +333,7 @@
         let perform env cont = function
             | [PromptTag tag; value] ->
                 match findPrompt (Some tag) cont with
-                | Some (continuationRecord, { handler = Some handler } as frame) ->
+                | Some (continuationRecord, ({ handler = Some handler } as frame)) ->
                     let captured =
                         Continuation(continuationRecord, Some frame, Delimited)
                     let resumption =
@@ -358,7 +358,7 @@
                 match completed with
                 | :? Task<LispVal> as typed -> returnM typed.Result
                 | :? Task<obj> as typed ->
-                    if isNull typed.Result then returnM Inert
+                    if obj.ReferenceEquals(typed.Result, null) then returnM Inert
                     else returnM (Obj typed.Result)
                 | _ -> returnM Inert
             with

--- a/README.md
+++ b/README.md
@@ -124,6 +124,30 @@ interop values still check the authority of the environment where they are
 invoked, so copying a binding cannot grant host access. See
 [`docs/capabilities.md`](docs/capabilities.md) for the security model and limits.
 
+## Tagged handlers and async
+
+Prompt tags are unforgeable runtime values. Tagged `shift` selects the nearest
+matching `reset`, while `prompt` installs a deep effect handler:
+
+```scheme
+(define request (make-prompt-tag))
+
+(prompt request
+  (lambda (value k) (resume k (+ value 1)))
+  (+ 1 (perform request 40)))
+; ⇒ 42
+```
+
+`perform` supplies the operation value and a one-shot resumption to the handler.
+Resuming reinstalls the same tagged handler; attempting to resume twice is an
+error. Existing untagged `(reset body)` and `(shift handler)` remain multi-shot
+and backward compatible.
+
+The unrestricted profile also provides `(task-delay milliseconds value)` and
+`(await-task task)`. Task callbacks only publish an outcome; `Eval.runAsync`
+resumes the trampoline serially rather than evaluating on a CLR callback thread.
+See [`Examples/effects-async.scm`](Examples/effects-async.scm).
+
 ## VS Code extension and playground
 
 The extension in [`editors/vscode/`](editors/vscode/) provides IronKernel syntax

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -8,7 +8,7 @@ parents. Authority is not a Kernel value and cannot be introduced with
 
 - `minimal`: no source loading, host I/O, raw CLR reflection, or generated CLR bindings
 - `safe`: generated bindings from the reviewed `safe` manifest
-- `unrestricted`: all current host integration; the compatibility default
+- `unrestricted`: all current host integration, including CLR Task adapters; the compatibility default
 
 Child environments receive the intersection of their own creator's authority
 and every parent environment's authority. This prevents an empty or mixed-parent
@@ -45,3 +45,7 @@ They are not a CPU, memory, or termination sandbox. Run untrusted programs in a
 separate OS process with resource limits. The VS Code playground provides a
 timeout and output limits, but those are availability controls rather than a
 complete security boundary.
+
+`HostAsync` is unrestricted-only. Copying `await-task` or `task-delay` into a
+restricted environment still fails at invocation because both primitives check
+the current environment.

--- a/website/docs/getting-started.html
+++ b/website/docs/getting-started.html
@@ -42,6 +42,7 @@
           <li><a href="#packages">IKC packages</a></li>
           <li><a href="#errors">Read errors</a></li>
           <li><a href="#capabilities">Capabilities</a></li>
+          <li><a href="#effects">Effects &amp; async</a></li>
           <li><a href="#editor">VS Code</a></li>
           <li><a href="#next">Next steps</a></li>
         </ol>
@@ -137,7 +138,27 @@ dotnet run --project IronKernel -- run hello.ikc</code></pre>
           interop value into a safe environment does not copy its authority.
         </p>
 
-        <h2 id="editor">7. Explore in VS Code</h2>
+        <h2 id="effects">7. Handle effects and await tasks</h2>
+        <p>
+          Unforgeable prompt tags let handlers intercept only their own operations.
+          A handler can abort the captured computation or resume it once; resumption reinstalls
+          the same handler for later operations.
+        </p>
+        <div class="example">
+          <pre><code>(define request (make-prompt-tag))
+(prompt request
+  (lambda (value k) (resume k (+ value 1)))
+  (+ 1 (perform request 40)))
+; ⇒ 42
+
+(await-task (task-delay 25 "ready"))</code></pre>
+        </div>
+        <p>
+          Async host access is available only in the <code>unrestricted</code> profile.
+          Task callbacks enqueue outcomes; they never run the evaluator directly.
+        </p>
+
+        <h2 id="editor">8. Explore in VS Code</h2>
         <p>
           The repository includes an extension with syntax highlighting, snippets, source diagnostics,
           run and package commands, and a local playground powered by the real IronKernel CLI.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add unforgeable prompt tags and nearest-matching tagged `reset`/`shift`
- add deep `prompt`/`perform` handlers with one-shot resumptions
- preserve existing untagged multi-shot continuation behavior
- add `Eval.runAsync`, `await-task`, and `task-delay` without running evaluator code in Task callbacks
- gate async host adapters behind the unrestricted `HostAsync` capability

## Validation
- focused effects, continuations, and capabilities suite passes (19 tests)
- full Debug and Release suites pass (89 tests each)
- incomplete Task suspension remains non-blocking through `evalAsync`
- Task faults map to language errors
- CLI example produces `handled=42` and `async complete`
- safe profile reaches the pure handler and then rejects `await-task`
- CI passes

[tagged_handlers_async_walkthrough.mp4](https://cursor.com/agents/bc-c8498e3c-8e84-496a-bc69-85678d76f515/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftagged_handlers_async_walkthrough.mp4)

[IronKernel tagged handlers and async onboarding](https://cursor.com/agents/bc-c8498e3c-8e84-496a-bc69-85678d76f515/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftagged_handlers_async_onboarding.webp)

## Semantics
Effect handlers receive `(value, resumption)`. Returning aborts the captured computation; `resume` reinstalls the same handler. Resumptions are one-shot, while existing raw delimited continuations remain multi-shot. Async callbacks only publish outcomes to a `RunContinuationsAsynchronously` completion; they never invoke the evaluator directly.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8498e3c-8e84-496a-bc69-85678d76f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8498e3c-8e84-496a-bc69-85678d76f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786926537&installation_id=147070874&pr_number=13&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F13&signature=ce156c49b3322cace35d101453f72872c7a61918afbc87b4a6427db2c193f4f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->