### PR TITLE
Add operative contracts and guarded partial evaluation

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -22,6 +22,7 @@ dotnet run --project IronKernel -- run hello.ikc
 | `samples.scm` | Recursion and the `let` family | Prints intermediate values |
 | `continuations.scm` | Full continuations | Defines local output helpers |
 | `effects-async.scm` | Tagged deep handlers and CLR Task suspension | Requires `unrestricted` profile |
+| `contracts.scm` | Operative/applicative contracts and guarded folding | Prints validated results |
 | `coroutines.scm` | Cooperative scheduling experiment | Historical example; not yet covered by the compatibility suite |
 | `zipper.scm` | Delimited continuations | Functional zipper traversal |
 | `sqrt.scm` | Operative-based numeric procedure | Defines `sqrt`; intentionally produces no output |

--- a/Examples/contracts.scm
+++ b/Examples/contracts.scm
@@ -1,0 +1,10 @@
+; Optional contracts describe call policy and value shapes.
+
+(define double (lambda (x) (+ x x)))
+(contract double applicative (number) number pure #t)
+
+(define raw (vau operands _ operands))
+(contract raw operative (any) any pure #t)
+
+(printf "double={0}\n" (double 21))
+(show (raw (+ 1 2)))

--- a/IronKernel.Tests/ContractTests.fs
+++ b/IronKernel.Tests/ContractTests.fs
@@ -1,0 +1,106 @@
+module IronKernel.Tests.ContractTests
+
+open Xunit
+
+open IronKernel.Ast
+open IronKernel.Analyze
+open IronKernel.Compiler
+open IronKernel.Contracts
+open IronKernel.Ir
+open IronKernel.PartialEval
+open IronKernel.Tests.TestHelpers
+
+[<Fact>]
+let ``operative contract validates raw operand syntax`` () =
+    withKernel (fun env ->
+        ignore (evalIn env "(define raw (vau operands _ operands))")
+        ignore (evalIn env "(contract raw operative (any) any pure #t)")
+        assertEval env "(raw (+ 1 2))" (List [List [Atom "+"; Obj (1 :> obj); Obj (2 :> obj)]])
+
+        match evalRaw Interpreted env "(raw 1 2)" with
+        | Choice1Of2 (ContractViolation message) -> Assert.Contains("expected 1 operands", message)
+        | result -> failwithf "unexpected operative contract result: %A" result)
+
+[<Fact>]
+let ``applicative contract validates argument and result values`` () =
+    withKernel (fun env ->
+        ignore (evalIn env "(define double (lambda (x) (+ x x)))")
+        ignore (evalIn env "(contract double applicative (number) number pure #t)")
+        assertEval env "(double 21)" (Obj (42 :> obj))
+        assertEval
+            env
+            "(contract-of double)"
+            (List
+                [ Atom "applicative"
+                  List [Atom "number"]
+                  Atom "number"
+                  Atom "pure"
+                  Bool true
+                  Atom "asserted" ])
+
+        match evalRaw Interpreted env "(double \"wrong\")" with
+        | Choice1Of2 (ContractViolation message) -> Assert.Contains("operand 1 expected number", message)
+        | result -> failwithf "unexpected argument contract result: %A" result
+
+        ignore (evalIn env "(define bad (lambda (x) \"wrong\"))")
+        ignore (evalIn env "(contract bad applicative (number) number effectful #f)")
+        match evalRaw Interpreted env "(bad 1)" with
+        | Choice1Of2 (ContractViolation message) -> Assert.Contains("result expected number", message)
+        | result -> failwithf "unexpected result contract outcome: %A" result)
+
+[<Fact>]
+let ``contract mode must match the combiner`` () =
+    withKernel (fun env ->
+        ignore (evalIn env "(define raw (vau operands _ operands))")
+        match evalRaw Interpreted env "(contract raw applicative (any) any pure #t)" with
+        | Choice1Of2 (ContractViolation message) -> Assert.Contains("mode does not match", message)
+        | result -> failwithf "unexpected mode mismatch result: %A" result)
+
+[<Fact>]
+let ``wrap preserves contract metadata with eager argument policy`` () =
+    evalSessionKernel
+        [ "(define raw (vau operands _ operands))", Inert
+          "(contract raw operative (number) list pure #t)", Inert
+          "(define eager (wrap raw))", Inert
+          "(eager (+ 1 2))", List [Obj (3 :> obj)] ]
+
+[<Fact>]
+let ``certified primitive literals are partially evaluated behind a guard`` () =
+    let env = freshEnv ()
+    let fallback = analyzeGuarded env (parseOk "(+ 1 2)")
+    match partialEvaluate env fallback with
+    | CContractFold (guard, Obj (:? int as value), COperate (CVar "+", _)) ->
+        Assert.Equal(3, value)
+        Assert.True(contractGuardMatches env guard)
+    | other -> failwith (showCore other)
+
+[<Fact>]
+let ``contract fold falls back after rebinding`` () =
+    let env = freshEnv ()
+    let compiled = compileLispValGuarded env (parseOk "(+ 1 2)")
+
+    ignore (evalIn env "(define + (vau operands _ operands))")
+
+    match compiled.Invoke(env, newContinuation env) with
+    | Choice2Of2 (List [Obj (:? int as one); Obj (:? int as two)]) ->
+        Assert.Equal(1, one)
+        Assert.Equal(2, two)
+    | result -> failwithf "partial fold did not fall back: %A" result
+
+[<Fact>]
+let ``asserted contracts are never trusted for compile-time execution`` () =
+    withKernel (fun env ->
+        ignore (evalIn env "(define answer (lambda (x) 42))")
+        ignore (evalIn env "(contract answer applicative (number) number pure #t)")
+        match analyzeGuarded env (parseOk "(answer 1)") |> partialEvaluate env with
+        | COperate (CVar "answer", _) -> ()
+        | other -> failwithf "asserted contract was folded: %s" (showCore other))
+
+[<Fact>]
+let ``contracts preserve interpreter compiler parity`` () =
+    assertParitySession
+        [ "(load \"kernel.scm\")"
+          "(define double (lambda (x) (+ x x)))"
+          "(contract double applicative (number) number pure #t)"
+          "(double 21)"
+          "(+ 20 22)" ]

--- a/IronKernel.Tests/ContractTests.fs
+++ b/IronKernel.Tests/ContractTests.fs
@@ -65,6 +65,37 @@ let ``wrap preserves contract metadata with eager argument policy`` () =
           "(eager (+ 1 2))", List [Obj (3 :> obj)] ]
 
 [<Fact>]
+let ``wrap preserves applicative contract metadata without nesting`` () =
+    withKernel (fun env ->
+        ignore (evalIn env "(define double (lambda (x) (+ x x)))")
+        ignore (evalIn env "(contract double applicative (number) number pure #t)")
+        ignore (evalIn env "(define wrapped (wrap double))")
+        assertEval
+            env
+            "(contract-of wrapped)"
+            (List
+                [ Atom "applicative"
+                  List [Atom "number"]
+                  Atom "number"
+                  Atom "pure"
+                  Bool true
+                  Atom "asserted" ])
+        assertEval env "(wrapped 21)" (Obj (42 :> obj))
+
+        ignore (evalIn env "(define wrapped-plus (wrap +))")
+        assertEval
+            env
+            "(contract-of wrapped-plus)"
+            (List
+                [ Atom "applicative"
+                  List [Atom "any"; Atom "any"]
+                  Atom "any"
+                  Atom "pure"
+                  Bool true
+                  Atom "certified" ])
+        assertEval env "(wrapped-plus 20 22)" (Obj (42 :> obj)))
+
+[<Fact>]
 let ``certified primitive literals are partially evaluated behind a guard`` () =
     let env = freshEnv ()
     let fallback = analyzeGuarded env (parseOk "(+ 1 2)")

--- a/IronKernel.Tests/IronKernel.Tests.fsproj
+++ b/IronKernel.Tests/IronKernel.Tests.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="CapabilityTests.fs" />
     <Compile Include="InteropTests.fs" />
     <Compile Include="CompilerTests.fs" />
+    <Compile Include="ContractTests.fs" />
     <Compile Include="ConformanceTests.fs" />
     <Compile Include="CliTests.fs" />
     <Compile Include="ContinuationTests.fs" />

--- a/IronKernel/Analyze.fs
+++ b/IronKernel/Analyze.fs
@@ -19,6 +19,7 @@ module Analyze =
         | Encapsulation _
         | Environment _
         | PrimitiveOperative _
+        | ContractedCombiner _
         | Operative _
         | Applicative _
         | Continuation _
@@ -81,6 +82,7 @@ module Analyze =
         | CIntrinsicOperate (PrimitiveIf, operands) -> List (Atom "if" :: operands)
         | CIntrinsicOperate (PrimitiveDefine, operands) -> List (Atom "define" :: operands)
         | CGuarded (_, _, fallback) -> toLispVal fallback
+        | CContractFold (_, _, fallback) -> toLispVal fallback
         | CEval (e, x) -> List [Atom "eval"; toLispVal e; toLispVal x]
         | CReset x -> List [Atom "reset"; toLispVal x]
         | CResidual v -> v

--- a/IronKernel/Ast.fs
+++ b/IronKernel/Ast.fs
@@ -28,6 +28,39 @@ module Ast =
 
     type CapabilitySet = Set<HostCapability>
 
+    type ContractMode =
+        | RawOperands
+        | EvaluatedArguments
+
+    type ContractShape =
+        | AnyShape
+        | NumberShape
+        | IntegerShape
+        | StringShape
+        | BooleanShape
+        | AtomShape
+        | ListShape
+        | PromptTagShape
+        | ResumptionShape
+
+    type ContractEffect =
+        | Pure
+        | Effectful
+
+    type ContractTrust =
+        | Certified
+        | Asserted
+
+    type OperativeContract = {
+        name : string
+        mode : ContractMode
+        operands : ContractShape list
+        result : ContractShape
+        effect : ContractEffect
+        inlineable : bool
+        trust : ContractTrust
+    }
+
     type ContinuationType = Full | Delimited
 
     /// Trampoline step used by the CPS evaluator / compiler runtime.
@@ -80,6 +113,10 @@ module Ast =
         identity : PrimitiveIdentity option
         invoke : LispVal -> LispVal -> LispVal list -> Step
     }
+    and ContractedCombinerRecord = {
+        combiner : LispVal
+        contract : OperativeContract
+    }
     and BindingState = {
         value : LispVal
         version : int64
@@ -101,6 +138,7 @@ module Ast =
         | Bool of bool
         | Environment of EnvironmentRecord
         | PrimitiveOperative of PrimitiveOperativeRecord
+        | ContractedCombiner of ContractedCombinerRecord
         | Operative of OperativeRecord
         | Applicative of LispVal
         | IOFunc of HostCapability * (LispVal list -> ThrowsError<LispVal>)
@@ -130,6 +168,7 @@ module Ast =
        | ClrException of System.Exception
        | LocatedError of SourceSpan * string option * LispError
        | CapabilityDenied of string
+       | ContractViolation of string
 
     and ThrowsError<'a> = Choice<LispError,'a>
 
@@ -190,6 +229,8 @@ module Ast =
         | DottedList(head,tail) -> "(" + unwordsList head + " & "  + showVal tail + ")"
         | Applicative(a) -> "<applicative " + showVal a + " >"
         | PrimitiveOperative _ -> "<primitive operative>"
+        | ContractedCombiner contracted ->
+            "<contracted " + contracted.contract.name + ">"
         | Operative({prms = args; body = body; closure = env}) 
                  -> "(vau (" + (showVal args) + "))"
         | Port _ -> "<IO port>"

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -13,6 +13,8 @@ module Compiler =
     open Analyze
     open Eval
     open SymbolTable
+    open Contracts
+    open PartialEval
     open Choice
 
     type KernelFunc = Func<LispVal, LispVal, ThrowsError<LispVal>>
@@ -141,6 +143,12 @@ module Compiler =
             KernelFunc(fun env cont ->
                 if bindingGuardMatches env guard then fast.Invoke(env, cont)
                 else generic.Invoke(env, cont))
+        | CContractFold (guard, folded, fallback) ->
+            let generic = compileToFunc fallback
+            KernelFunc(fun env cont ->
+                if contractGuardMatches env guard then
+                    continueEval env cont folded
+                else generic.Invoke(env, cont))
         | CResidual v ->
             KernelFunc(fun env cont -> eval env cont v)
         | other ->
@@ -148,7 +156,10 @@ module Compiler =
             KernelFunc(fun env cont -> eval env cont v)
 
     let compileLispVal (v: LispVal) = compileToFunc (analyze v)
-    let compileLispValGuarded env (v: LispVal) = compileToFunc (analyzeGuarded env v)
+    let compileLispValGuarded env (v: LispVal) =
+        analyzeGuarded env v
+        |> partialEvaluate env
+        |> compileToFunc
 
     let compileForms (forms: LispVal list) = List.map compileLispVal forms
     let compileFormsGuarded env forms = List.map (compileLispValGuarded env) forms

--- a/IronKernel/Contracts.fs
+++ b/IronKernel/Contracts.fs
@@ -1,0 +1,158 @@
+namespace IronKernel
+
+module Contracts =
+
+    open Ast
+    open SymbolTable
+
+    type ContractGuard = {
+        name : string
+        cellId : int64
+        version : int64
+        fingerprint : string
+    }
+
+    let shapeName = function
+        | AnyShape -> "any"
+        | NumberShape -> "number"
+        | IntegerShape -> "integer"
+        | StringShape -> "string"
+        | BooleanShape -> "boolean"
+        | AtomShape -> "atom"
+        | ListShape -> "list"
+        | PromptTagShape -> "prompt-tag"
+        | ResumptionShape -> "resumption"
+
+    let shapeMatches shape value =
+        match shape, value with
+        | AnyShape, _ -> true
+        | NumberShape, Obj (:? byte)
+        | NumberShape, Obj (:? int)
+        | NumberShape, Obj (:? int64)
+        | NumberShape, Obj (:? float32)
+        | NumberShape, Obj (:? double) -> true
+        | IntegerShape, Obj (:? byte)
+        | IntegerShape, Obj (:? int)
+        | IntegerShape, Obj (:? int64) -> true
+        | StringShape, Obj (:? string) -> true
+        | BooleanShape, Bool _ -> true
+        | AtomShape, Atom _ -> true
+        | ListShape, List _
+        | ListShape, DottedList _ -> true
+        | PromptTagShape, PromptTag _ -> true
+        | ResumptionShape, Resumption _ -> true
+        | _ -> false
+
+    let fingerprint contract =
+        let mode =
+            match contract.mode with
+            | RawOperands -> "raw"
+            | EvaluatedArguments -> "eager"
+        let effect =
+            match contract.effect with
+            | Pure -> "pure"
+            | Effectful -> "effectful"
+        let trust =
+            match contract.trust with
+            | Certified -> "certified"
+            | Asserted -> "asserted"
+        String.concat
+            "|"
+            [ contract.name
+              mode
+              contract.operands |> List.map shapeName |> String.concat ","
+              shapeName contract.result
+              effect
+              string contract.inlineable
+              trust ]
+
+    let validateArguments contract args =
+        if List.length contract.operands <> List.length args then
+            Some(
+                ContractViolation(
+                    sprintf
+                        "%s expected %d operands, found %d"
+                        contract.name
+                        (List.length contract.operands)
+                        (List.length args)))
+        else
+            List.zip contract.operands args
+            |> List.tryFindIndex (fun (shape, value) -> not (shapeMatches shape value))
+            |> Option.map (fun index ->
+                let expected = contract.operands.[index] |> shapeName
+                ContractViolation(
+                    sprintf "%s operand %d expected %s" contract.name (index + 1) expected))
+
+    let validateResult contract value =
+        if shapeMatches contract.result value then None
+        else
+            Some(
+                ContractViolation(
+                    sprintf "%s result expected %s" contract.name (shapeName contract.result)))
+
+    let rec stripContract = function
+        | ContractedCombiner contracted -> stripContract contracted.combiner
+        | value -> value
+
+    let tryGetContract = function
+        | ContractedCombiner contracted -> Some contracted.contract
+        | Applicative (ContractedCombiner contracted) -> Some contracted.contract
+        | _ -> None
+
+    let attach contract value =
+        let normalized =
+            match value with
+            | Applicative underlying -> Applicative(stripContract underlying)
+            | other -> stripContract other
+        match contract.mode, normalized with
+        | RawOperands, Applicative _ -> None
+        | EvaluatedArguments, Applicative underlying ->
+            Some(
+                Applicative(
+                    ContractedCombiner
+                        { combiner = underlying
+                          contract = contract }))
+        | RawOperands, (Operative _ | PrimitiveOperative _ | CompiledCombiner _) ->
+            Some(
+                ContractedCombiner
+                    { combiner = normalized
+                      contract = contract })
+        | _ -> None
+
+    let tryCreateContractGuard env name =
+        match resolveBindingCell env name with
+        | Some cell ->
+            let state = cell.state
+            match tryGetContract state.value with
+            | Some contract
+                when contract.mode = EvaluatedArguments
+                     && contract.effect = Pure
+                     && contract.inlineable
+                     && contract.trust = Certified ->
+                Some(
+                    { name = name
+                      cellId = cell.id
+                      version = state.version
+                      fingerprint = fingerprint contract },
+                    contract)
+            | _ -> None
+        | None -> None
+
+    let contractGuardMatches env guard =
+        match resolveBindingCell env guard.name with
+        | Some cell ->
+            let state = cell.state
+            cell.id = guard.cellId
+            && state.version = guard.version
+            && (tryGetContract state.value
+                |> Option.exists (fun contract -> fingerprint contract = guard.fingerprint))
+        | None -> false
+
+    let certifiedApplicative name operands result =
+        { name = name
+          mode = EvaluatedArguments
+          operands = operands
+          result = result
+          effect = Pure
+          inlineable = true
+          trust = Certified }

--- a/IronKernel/Errors.fs
+++ b/IronKernel/Errors.fs
@@ -24,6 +24,7 @@ module Errors =
         | Default(msg) -> msg
         | ClrException ex -> ex.Message
         | CapabilityDenied message -> "Capability denied: " + message
+        | ContractViolation message -> "Contract violation: " + message
         | LocatedError(span, sourceLine, error) ->
             let source =
                 if String.IsNullOrWhiteSpace span.sourceName then "<input>"

--- a/IronKernel/Eval.fs
+++ b/IronKernel/Eval.fs
@@ -158,7 +158,7 @@ module Eval =
                 let validate e c value _ =
                     match validateResult contracted.contract value with
                     | Some error -> fail error
-                    | None -> bounceContinue e c value
+                    | None -> More (fun () -> continueEvalStep e c value)
                 More (fun () ->
                     operateStep
                         _env

--- a/IronKernel/Eval.fs
+++ b/IronKernel/Eval.fs
@@ -9,6 +9,7 @@ module Eval =
     open Errors
     open SymbolTable
     open Capabilities
+    open Contracts
 
     let inline ok (x: LispVal) : Step = Done (returnM x)
     let inline fail (e: LispError) : Step = Done (throwError e)
@@ -150,6 +151,20 @@ module Eval =
         match func with
         | PrimitiveOperative primitive -> primitive.invoke _env cont args
         | CompiledCombiner f -> f _env cont args
+        | ContractedCombiner contracted ->
+            match validateArguments contracted.contract args with
+            | Some error -> fail error
+            | None ->
+                let validate e c value _ =
+                    match validateResult contracted.contract value with
+                    | Some error -> fail error
+                    | None -> bounceContinue e c value
+                More (fun () ->
+                    operateStep
+                        _env
+                        (makeCPS _env cont validate)
+                        contracted.combiner
+                        args)
         | IOFunc (requiredCapability, f) ->
             if not (has requiredCapability _env) then
                 fail (CapabilityDenied(sprintf "I/O requires %A" requiredCapability))

--- a/IronKernel/Ir.fs
+++ b/IronKernel/Ir.fs
@@ -6,6 +6,7 @@ module Ir =
 
     open Ast
     open SymbolTable
+    open Contracts
 
     /// Explicit core forms after analysis. Residual wraps trees that stay interpreted.
     type CoreExpr =
@@ -20,6 +21,7 @@ module Ir =
         | COperate of op: CoreExpr * operands: LispVal list
         | CIntrinsicOperate of identity: PrimitiveIdentity * operands: LispVal list
         | CGuarded of guard: BindingGuard * specialized: CoreExpr * fallback: CoreExpr
+        | CContractFold of guard: ContractGuard * folded: LispVal * fallback: CoreExpr
         | CEval of envExpr: CoreExpr * expr: CoreExpr
         | CReset of CoreExpr
         | CResidual of LispVal
@@ -56,6 +58,8 @@ module Ir =
         | CIntrinsicOperate (identity, _) -> sprintf "(intrinsic %A ...)" identity
         | CGuarded (guard, specialized, _) ->
             sprintf "(guard %s@%d %s)" guard.name guard.version (showCore specialized)
+        | CContractFold (guard, folded, _) ->
+            sprintf "(contract-fold %s@%d %s)" guard.name guard.version (showVal folded)
         | CEval (e, x) -> sprintf "(eval %s %s)" (showCore e) (showCore x)
         | CReset x -> sprintf "(reset %s)" (showCore x)
         | CResidual v -> "residual:" + showVal v

--- a/IronKernel/IronKernel.fsproj
+++ b/IronKernel/IronKernel.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="Errors.fs" />
     <Compile Include="Parser.fs" />
     <Compile Include="SymbolTable.fs" />
+    <Compile Include="Contracts.fs" />
     <Compile Include="Ir.fs" />
     <Compile Include="Analyze.fs" />
     <Compile Include="Eval.fs" />
@@ -22,6 +23,7 @@
     <Compile Include="Interop.fs" />
     <Compile Include="Generated\Bindings.Safe.fs" />
     <Compile Include="Runtime.fs" />
+    <Compile Include="PartialEval.fs" />
     <Compile Include="Compiler.fs" />
     <Compile Include="Emit.fs" />
     <Compile Include="Repl.fs" />

--- a/IronKernel/PartialEval.fs
+++ b/IronKernel/PartialEval.fs
@@ -1,0 +1,50 @@
+namespace IronKernel
+
+module PartialEval =
+
+    open Ast
+    open Contracts
+    open Eval
+    open Ir
+
+    let private isStaticLiteral = function
+        | Bool _
+        | Inert
+        | Nil
+        | Keyword _
+        | List [] -> true
+        | Obj value ->
+            isNull value
+            || value :? string
+            || value :? byte
+            || value :? int
+            || value :? int64
+            || value :? float32
+            || value :? double
+        | _ -> false
+
+    let private isFoldedValue = isStaticLiteral
+
+    let rec partialEvaluate env expression =
+        match expression with
+        | COperate(CVar name, operands) as fallback
+            when List.forall isStaticLiteral operands ->
+            match tryCreateContractGuard env name with
+            | Some (guard, _) ->
+                match eval env (newContinuation env) (List(Atom name :: operands)) with
+                | Choice2Of2 value when isFoldedValue value ->
+                    CContractFold(guard, value, fallback)
+                | _ -> fallback
+            | None -> fallback
+        | CIf(condition, consequent, alternative) ->
+            CIf(
+                partialEvaluate env condition,
+                partialEvaluate env consequent,
+                partialEvaluate env alternative)
+        | CSeq expressions ->
+            CSeq(List.map (partialEvaluate env) expressions)
+        | CDefine(lhs, rhs) ->
+            CDefine(lhs, partialEvaluate env rhs)
+        | CGuarded(guard, specialized, fallback) ->
+            CGuarded(guard, partialEvaluate env specialized, fallback)
+        | other -> other

--- a/IronKernel/Runtime.fs
+++ b/IronKernel/Runtime.fs
@@ -11,6 +11,7 @@
     open Interop
     open Eval
     open Capabilities
+    open Contracts
     open IronKernel.Generated
 
     module Runtime = 
@@ -191,9 +192,29 @@
         
         open Arithmetic
 
-        let wrap env cont (a::_)  =  bounceContinue env cont (Applicative a) 
+        let wrap env cont (a::_) =
+            let wrapped =
+                match a with
+                | ContractedCombiner contracted ->
+                    Applicative(
+                        ContractedCombiner
+                            { contracted with
+                                contract =
+                                    { contracted.contract with
+                                        mode = EvaluatedArguments } })
+                | _ -> Applicative a
+            bounceContinue env cont wrapped
 
         let unwrap env cont = function
+            | Applicative (ContractedCombiner contracted) :: _ ->
+                bounceContinue
+                    env
+                    cont
+                    (ContractedCombiner
+                        { contracted with
+                            contract =
+                                { contracted.contract with
+                                    mode = RawOperands } })
             | Applicative c :: _ -> bounceContinue env cont c
             | a :: _ -> fail (TypeMismatch("applicative",a))
             | [] -> fail (NumArgs(1, []))
@@ -250,6 +271,87 @@
                 bounceEval env (makeCPS env cont cps) r 
             | badForm -> fail (BadSpecialForm("invalid arguments",List(badForm)))
 
+        let private parseContractShape = function
+            | Atom "any" -> Some AnyShape
+            | Atom "number" -> Some NumberShape
+            | Atom "integer" -> Some IntegerShape
+            | Atom "string" -> Some StringShape
+            | Atom "boolean" -> Some BooleanShape
+            | Atom "atom" -> Some AtomShape
+            | Atom "list" -> Some ListShape
+            | Atom "prompt-tag" -> Some PromptTagShape
+            | Atom "resumption" -> Some ResumptionShape
+            | _ -> None
+
+        let attachContract env cont = function
+            | [ Atom name;
+                Atom modeName;
+                List operandSpecs;
+                resultSpec;
+                Atom effectName;
+                Bool inlineable ] ->
+                let mode =
+                    match modeName with
+                    | "operative" -> Some RawOperands
+                    | "applicative" -> Some EvaluatedArguments
+                    | _ -> None
+                let effect =
+                    match effectName with
+                    | "pure" -> Some Pure
+                    | "effectful" -> Some Effectful
+                    | _ -> None
+                let operands = operandSpecs |> List.map parseContractShape
+                match mode, effect, parseContractShape resultSpec, getVar env name with
+                | Some mode, Some effect, Some result, Choice2Of2 value
+                    when List.forall Option.isSome operands ->
+                    let contract =
+                        { name = name
+                          mode = mode
+                          operands = operands |> List.choose id
+                          result = result
+                          effect = effect
+                          inlineable = inlineable
+                          trust = Asserted }
+                    match Contracts.attach contract value with
+                    | Some contracted ->
+                        match defineVar env name contracted with
+                        | Choice1Of2 error -> fail error
+                        | Choice2Of2 _ -> bounceContinue env cont Inert
+                    | None ->
+                        fail (ContractViolation(name + " contract mode does not match its combiner"))
+                | _, _, _, Choice1Of2 error -> fail error
+                | _ -> fail (ContractViolation("invalid contract specification for " + name))
+            | bad -> fail (NumArgs(6, bad))
+
+        let contractOf env cont = function
+            | [value] ->
+                match tryGetContract value with
+                | None -> bounceContinue env cont (Bool false)
+                | Some contract ->
+                    let mode =
+                        match contract.mode with
+                        | RawOperands -> Atom "operative"
+                        | EvaluatedArguments -> Atom "applicative"
+                    let effect =
+                        match contract.effect with
+                        | Pure -> Atom "pure"
+                        | Effectful -> Atom "effectful"
+                    let trust =
+                        match contract.trust with
+                        | Certified -> Atom "certified"
+                        | Asserted -> Atom "asserted"
+                    bounceContinue
+                        env
+                        cont
+                        (List
+                            [ mode
+                              List(List.map (shapeName >> Atom) contract.operands)
+                              Atom(shapeName contract.result)
+                              effect
+                              Bool contract.inlineable
+                              trust ])
+            | bad -> fail (NumArgs(1, bad))
+
         let reset env cont = function
             | [body] ->
                 bounceEval env (promptContinuation env cont None None) body
@@ -295,6 +397,7 @@
                   (".set", dot_set);
                   ("reset", reset);
                   ("prompt", prompt);
+                  ("contract", attachContract);
                   ]
         
         let callcc env cont  = function 
@@ -486,6 +589,7 @@
                   ("print", print);
                   ("printf", printf');
                   ("show", show);
+                  ("contract-of", contractOf);
                   ("shift", shift);
                   ("make-prompt-tag", makePromptTag);
                   ("perform", perform);
@@ -513,11 +617,25 @@
                     { identity = operativeIdentity name
                       invoke = func }
             let makeApplicative (name, func) =
-                name,
-                Applicative
-                    (PrimitiveOperative
-                        { identity = None
-                          invoke = func })
+                let applicative =
+                    Applicative(
+                        PrimitiveOperative
+                            { identity = None
+                              invoke = func })
+                let contract =
+                    match name with
+                    | "+" | "-" | "*" | "/" ->
+                        Some(certifiedApplicative name [NumberShape; NumberShape] NumberShape)
+                    | "<" | "<=" | ">" ->
+                        Some(certifiedApplicative name [NumberShape; NumberShape] BooleanShape)
+                    | _ -> None
+                let value =
+                    match contract with
+                    | Some contract ->
+                        Contracts.attach contract applicative
+                        |> Option.defaultValue applicative
+                    | None -> applicative
+                name, value
             let rawInteropNames = Set.ofList [ "."; "new"; ".get"; ".set" ]
             let asyncNames = Set.ofList [ "await-task"; "task-delay" ]
             let operatives =

--- a/IronKernel/Runtime.fs
+++ b/IronKernel/Runtime.fs
@@ -193,15 +193,18 @@
         open Arithmetic
 
         let wrap env cont (a::_) =
+            let withEagerMode contracted =
+                { contracted with
+                    contract =
+                        { contracted.contract with
+                            mode = EvaluatedArguments } }
             let wrapped =
                 match a with
                 | ContractedCombiner contracted ->
-                    Applicative(
-                        ContractedCombiner
-                            { contracted with
-                                contract =
-                                    { contracted.contract with
-                                        mode = EvaluatedArguments } })
+                    Applicative(ContractedCombiner(withEagerMode contracted))
+                | Applicative (ContractedCombiner contracted) ->
+                    // Already applicative-contracted; avoid nesting Applicative.
+                    Applicative(ContractedCombiner(withEagerMode contracted))
                 | _ -> Applicative a
             bounceContinue env cont wrapped
 

--- a/IronKernel/Runtime.fs
+++ b/IronKernel/Runtime.fs
@@ -624,7 +624,9 @@
                               invoke = func })
                 let contract =
                     match name with
-                    | "+" | "-" | "*" | "/" ->
+                    | "+" | "-" ->
+                        Some(certifiedApplicative name [AnyShape; AnyShape] AnyShape)
+                    | "*" | "/" ->
                         Some(certifiedApplicative name [NumberShape; NumberShape] NumberShape)
                     | "<" | "<=" | ">" ->
                         Some(certifiedApplicative name [NumberShape; NumberShape] BooleanShape)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,33 @@ The unrestricted profile also provides `(task-delay milliseconds value)` and
 resumes the trampoline serially rather than evaluating on a CLR callback thread.
 See [`Examples/effects-async.scm`](Examples/effects-async.scm).
 
+## Operative contracts and partial evaluation
+
+Contracts are optional combiner metadata. They distinguish raw operative
+operands from evaluated applicative arguments and validate fixed value shapes:
+
+```scheme
+(define double (lambda (x) (+ x x)))
+(contract double applicative (number) number pure #t)
+
+(define raw (vau operands _ operands))
+(contract raw operative (any) any pure #t)
+```
+
+Supported shapes are `any`, `number`, `integer`, `string`, `boolean`, `atom`,
+`list`, `prompt-tag`, and `resumption`. The final fields declare the effect
+summary (`pure` or `effectful`) and whether the combiner is intended to be
+inlineable.
+
+User contracts are asserted metadata and are never executed by the compiler.
+Reviewed primitive contracts are certified; pure literal calls such as
+`(+ 20 22)` may be folded behind a binding-cell/version/contract fingerprint
+guard. Rebinding the operator selects the untouched generic combination before
+any operand effects occur. Dynamic `eval`, control effects, CLR calls, and async
+operations remain residual.
+
+See [`Examples/contracts.scm`](Examples/contracts.scm).
+
 ## VS Code extension and playground
 
 The extension in [`editors/vscode/`](editors/vscode/) provides IronKernel syntax

--- a/editors/vscode/snippets/ironkernel.code-snippets
+++ b/editors/vscode/snippets/ironkernel.code-snippets
@@ -30,6 +30,13 @@
     ],
     "description": "Create an operative receiving raw operands"
   },
+  "Attach contract": {
+    "prefix": "contract",
+    "body": [
+      "(contract ${1:name} ${2|operative,applicative|} (${3:any}) ${4:any} ${5|pure,effectful|} ${6|#t,#f|})"
+    ],
+    "description": "Attach an optional combiner contract"
+  },
   "Unless operative": {
     "prefix": "unless",
     "body": [

--- a/editors/vscode/syntaxes/ironkernel.tmLanguage.json
+++ b/editors/vscode/syntaxes/ironkernel.tmLanguage.json
@@ -65,7 +65,7 @@
       "patterns": [
         {
           "name": "keyword.control.ironkernel",
-          "match": "(?<![:!#$%|*+\\-./<=>?@^_~\\p{L}\\p{N}])(?:vau|ϝ|lambda|λ|define|defn|if|cond|let|let\\*|letrec|letrec\\*|begin|sequence|quote|eval|reset|shift|call/cc)(?![:!#$%|*+\\-./<=>?@^_~\\p{L}\\p{N}])"
+          "match": "(?<![:!#$%|*+\\-./<=>?@^_~\\p{L}\\p{N}])(?:vau|ϝ|lambda|λ|define|defn|contract|if|cond|let|let\\*|letrec|letrec\\*|begin|sequence|quote|eval|reset|shift|call/cc)(?![:!#$%|*+\\-./<=>?@^_~\\p{L}\\p{N}])"
         }
       ]
     },

--- a/website/docs/getting-started.html
+++ b/website/docs/getting-started.html
@@ -43,6 +43,7 @@
           <li><a href="#errors">Read errors</a></li>
           <li><a href="#capabilities">Capabilities</a></li>
           <li><a href="#effects">Effects &amp; async</a></li>
+          <li><a href="#contracts">Contracts</a></li>
           <li><a href="#editor">VS Code</a></li>
           <li><a href="#next">Next steps</a></li>
         </ol>
@@ -158,7 +159,24 @@ dotnet run --project IronKernel -- run hello.ikc</code></pre>
           Task callbacks enqueue outcomes; they never run the evaluator directly.
         </p>
 
-        <h2 id="editor">8. Explore in VS Code</h2>
+        <h2 id="contracts">8. Add contracts without changing semantics</h2>
+        <p>
+          Optional contracts document whether a combiner sees raw syntax or evaluated values,
+          then check operand and result shapes at the call boundary.
+        </p>
+        <div class="example">
+          <pre><code>(define double (lambda (x) (+ x x)))
+(contract double applicative (number) number pure #t)
+
+(define raw (vau operands _ operands))
+(contract raw operative (any) any pure #t)</code></pre>
+        </div>
+        <p>
+          User contracts remain runtime assertions. Only compiler-certified pure primitives are
+          partially evaluated, and every folded call retains an exact guarded fallback.
+        </p>
+
+        <h2 id="editor">9. Explore in VS Code</h2>
         <p>
           The repository includes an extension with syntax highlighting, snippets, source diagnostics,
           run and package commands, and a local playground powered by the real IronKernel CLI.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add optional operative/applicative contracts with fixed operand and result shapes
- validate raw syntax at operative boundaries and evaluated values at applicative boundaries
- preserve metadata through `wrap`/`unwrap` and expose `contract-of`
- certify pure arithmetic primitives and fold static literal calls behind binding/version/contract guards
- retain the exact generic combination when any assumption fails
- keep user-asserted contracts runtime-only and residualize effects, async, dynamic eval, and host calls

## Validation
- focused contracts/compiler/effects suite passes (29 tests)
- full Debug and Release suites pass (100 tests each)
- rebinding a folded operator exercises the untouched generic fallback
- asserted pure user contracts are proven not to execute at compile time
- end-to-end contracts example prints validated applicative and raw operative results
- VS Code typecheck, 12 tests, VSIX packaging, and CI pass

[operative_contracts_demo.mp4](https://cursor.com/agents/bc-c8498e3c-8e84-496a-bc69-85678d76f515/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foperative_contracts_demo.mp4)

[IronKernel operative contracts onboarding](https://cursor.com/agents/bc-c8498e3c-8e84-496a-bc69-85678d76f515/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foperative_contracts_onboarding.webp)

## Safety
Only runtime-owned `Certified` contracts can trigger compile-time execution. User contracts remain `Asserted`, even when marked pure and inlineable. Contract guards run before operator or operand effects, and folded errors are residualized rather than moved to compile time.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8498e3c-8e84-496a-bc69-85678d76f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8498e3c-8e84-496a-bc69-85678d76f515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786936747&installation_id=147070874&pr_number=14&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F14&signature=0d0694a0997473164f1ec0bb76e7790be340880145df4c7cdfef0e0114716ada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->