### PR TITLE
Fix REPL piped stdin and coroutines example; add ADR 0004 on compiling procedure bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,16 +24,36 @@ promo site (`python3 -m http.server -d website 8080`) and is not part of the app
 - Standard commands are in `README.md`. Debug (dev) is the default for
   `dotnet build`/`dotnet test`; CI (`.github/workflows/ci.yml`) uses `-c Release`.
 - There is no separate linter; the F# compiler warnings emitted during
-  `dotnet build` are the lint signal (the build currently has warnings, 0 errors).
+  `dotnet build` are the lint signal. `IronKernel`, `IronKernel.Runtime`, and
+  `IronKernel.Tests` all set `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`,
+  so the build is warning-clean by construction — a new warning fails the build.
+  Keep it that way rather than adding `NoWarn` entries.
+
+### Compilation reach (non-obvious, affects optimization work)
+- Only **top-level** forms are compiled (`evalCompiled` / `compileFormsGuarded`).
+  Procedure bodies are stored as raw `KernelCode` and interpreted form by form by
+  `evalStep`; the `CompiledCombiner` case exists in `Ast.fs` but is **never
+  constructed**. `define` also evaluates its right-hand side through `bounceEval`,
+  so `(define f (vau ...))` never reaches the analyzer's specializations.
+- Consequence for `Analyze.analyzeGuarded`: adding `PrimitiveIdentity` cases is
+  currently a **pessimization, not a win**. Guards re-resolve the binding by name on
+  every invocation, whereas the `COperate` fallback's `NamedCallSite` cache
+  validates by environment reference equality and always hits when the environment
+  is stable — which is the only situation compiled code sees today. Measured with
+  `GuardSpecializationBenchmarks`: guarded is ~10% slower with a shared environment
+  and ~12% faster only with a fresh frame per call, a case the runtime never
+  produces. Compile procedure bodies first; then extending guards pays off.
 
 ### REPL gotchas (non-obvious)
 - `dotnet run --project IronKernel` loads `kernel.ikr` and `promises.ikr` from
   the current directory when present, then falls back to the application output
   directory. Running from the repository root is supported.
 - The REPL uses the `Mono.Terminal` line editor, which needs a **real TTY**.
-  Piping stdin (`printf ... | dotnet run`) crashes with a `System.Console`
-  `SetCursorPosition` exception. For scripted/interactive REPL testing, drive it
-  through a pty (e.g. a `tmux` session with `send-keys`).
+  When stdin or stdout is redirected the REPL now detects it and falls back to
+  plain `Console.ReadLine`, so piping works:
+  `printf '(+ 1 2)\nquit\n' | dotnet run --project IronKernel`. End of input exits
+  cleanly, so the trailing `quit` is optional. Use a pty (e.g. `tmux send-keys`)
+  only when testing line-editing behaviour itself (history, completion, arrows).
 - IronKernel is **Kernel, not Scheme**. Use `define`/`defn`, `lambda`, `if`,
   `letrec`. `+` and `*` are **binary** (exactly 2 args). `display`, `=?`, and
   `$let` are not bound; print via .NET interop, e.g.

--- a/Examples/coroutines.ikr
+++ b/Examples/coroutines.ikr
@@ -1,38 +1,55 @@
-﻿
-(define display 
-	(lambda (x) 
+
+(define display
+	(lambda (x)
 	(. System.Console Write x)))
 
-(define newline 
-	(lambda () 
+(define newline
+	(lambda ()
 	(. System.Console WriteLine "")))
 
 
-(defn (hefty-computation do-other-stuff) 
-    (letrec ((loop (lambda (n)  
-      (display "Hefty computation: ") 
-      (display n) 
-      (newline) 
-      (set! (get-current-environment) do-other-stuff (call/cc do-other-stuff)) 
-      (display "Hefty computation (b)")  
-      (newline) 
-      (set! (get-current-environment) do-other-stuff (call/cc do-other-stuff)) 
-      (display "Hefty computation (c)") 
-      (newline) 
-      (set! (get-current-environment) do-other-stuff (call/cc do-other-stuff)) 
-      (if (> n 0) 
-          (loop (- n 1)))))) (loop 5))) 
+; Two coroutines pass control back and forth by exchanging continuations.
+; Each captures the continuation of its own `call/cc` and hands it to the other,
+; so `do-other-stuff` always names "resume the partner".
+;
+; `set!` is Kernel's $set!: it *defines* the symbol in the environment given by
+; its first operand. That environment must be the frame where `do-other-stuff`
+; actually lives -- the procedure's own frame, captured once as `home`. Using
+; `(get-current-environment)` from inside the loop instead would define a fresh
+; shadowing binding in each iteration's frame, and the exchanged continuation
+; would be lost on the next pass.
+
+(defn (hefty-computation do-other-stuff)
+    (define home (get-current-environment))
+    (letrec ((loop (lambda (n)
+      (display "Hefty computation: ")
+      (display n)
+      (newline)
+      (set! home do-other-stuff (call/cc do-other-stuff))
+      (display "Hefty computation (b)")
+      (newline)
+      (set! home do-other-stuff (call/cc do-other-stuff))
+      (display "Hefty computation (c)")
+      (newline)
+      (set! home do-other-stuff (call/cc do-other-stuff))
+      (if (> n 0)
+          (loop (- n 1))
+          #inert))))
+      (loop 5)))
 
 
-;; notionally displays a clock 
-(defn (superfluous-computation do-other-stuff) 
-    (letrec ((loop ( lambda () 
-      (for-each (lambda (graphic) 
-                  (display graphic) 
-                  (newline) 
-                  (set! (get-current-environment) do-other-stuff (call/cc do-other-stuff))) 
-                '("Straight up." "Quarter after." "Half past."  "Quarter til.")) 
-      ))) (loop ()))) 
-	  
-	  
-(hefty-computation superfluous-computation) 	  
+;; notionally displays a clock
+(defn (superfluous-computation do-other-stuff)
+    (define home (get-current-environment))
+    (letrec ((loop (lambda ()
+      ; for-each takes the collection first, then the combiner.
+      (for-each '("Straight up." "Quarter after." "Half past."  "Quarter til.")
+                (lambda (graphic)
+                  (display graphic)
+                  (newline)
+                  (set! home do-other-stuff (call/cc do-other-stuff))))
+      (loop))))
+      (loop)))
+
+
+(hefty-computation superfluous-computation)

--- a/IronKernel.Benchmarks/Program.fs
+++ b/IronKernel.Benchmarks/Program.fs
@@ -218,6 +218,63 @@ type ControlFlowBenchmarks() =
     member _.EffectHandlerResume() =
         evaluate effectResume
 
+/// Before/after for guarded `vau` specialization. `Unguarded` is the plain
+/// `analyze` path (COperate through the named call-site cache); `Guarded` is the
+/// binding-guarded intrinsic.
+///
+/// Measures when guarded specialization actually pays, which decides whether
+/// extending `PrimitiveIdentity` to further primitives is worthwhile. The two
+/// environment configurations differ sharply:
+///
+///   * Shared `env` (top-level forms): the call-site cache validates by reference
+///     equality and always hits, so the guard's name re-resolution is pure
+///     overhead and the guarded path loses.
+///   * Fresh child frame per call: the call-site cache misses and must re-resolve
+///     and refill, which the guard beats.
+///
+/// Only the shared case occurs today. Procedure bodies are stored as raw
+/// `KernelCode` and interpreted, and `CompiledCombiner` is never constructed, so
+/// no compiled expression is ever invoked against a fresh frame. Until bodies are
+/// compiled, added guards are measured pessimizations rather than wins.
+[<MemoryDiagnoser>]
+type GuardSpecializationBenchmarks() =
+    let env = makePrimitiveBindings ()
+    let form = parse "(if #t 1 2)"
+    let mutable unguarded = Unchecked.defaultof<KernelFunc>
+    let mutable guarded = Unchecked.defaultof<KernelFunc>
+
+    [<GlobalSetup>]
+    member _.Setup() =
+        unguarded <- compileLispVal form
+        guarded <- compileLispValGuarded env form
+        let requireOne (func: KernelFunc) =
+            match func.Invoke(env, newContinuation env) with
+            | Choice2Of2 (Obj (:? int as value)) when value = 1 -> ()
+            | result -> invalidOp (sprintf "Guard benchmark setup failed: %A" result)
+        requireOne unguarded
+        requireOne guarded
+
+    [<Benchmark(Baseline = true)>]
+    member _.Unguarded() =
+        unguarded.Invoke(env, newContinuation env)
+
+    [<Benchmark>]
+    member _.Guarded() =
+        guarded.Invoke(env, newContinuation env)
+
+    // The realistic case for code inside a procedure body: a fresh child frame per
+    // call, so the named call-site cache misses and must re-resolve and refill.
+    // The child-frame allocation is common to both and cancels in the ratio.
+    [<Benchmark>]
+    member _.UnguardedFreshEnv() =
+        let frame = newEnv [env]
+        unguarded.Invoke(frame, newContinuation frame)
+
+    [<Benchmark>]
+    member _.GuardedFreshEnv() =
+        let frame = newEnv [env]
+        guarded.Invoke(frame, newContinuation frame)
+
 [<EntryPoint>]
 let main args =
     BenchmarkSwitcher.FromAssembly(typeof<CompilerBenchmarks>.Assembly).Run(args) |> ignore

--- a/IronKernel.Tests/CliTests.fs
+++ b/IronKernel.Tests/CliTests.fs
@@ -562,3 +562,42 @@ let ``run with non-source args forwards them to the discovered project`` () =
         Assert.DoesNotContain("Parser error", stderr)
     finally
         Directory.Delete(root, true)
+
+/// Drives the REPL with stdin redirected, which is exactly the case the
+/// Mono.Terminal line editor cannot handle.
+let private runReplWithInput (input: string) =
+    let startInfo = ProcessStartInfo("dotnet")
+    startInfo.WorkingDirectory <- repoRoot
+    startInfo.UseShellExecute <- false
+    startInfo.RedirectStandardInput <- true
+    startInfo.RedirectStandardError <- true
+    startInfo.RedirectStandardOutput <- true
+    startInfo.ArgumentList.Add "run"
+    startInfo.ArgumentList.Add "--project"
+    startInfo.ArgumentList.Add "IronKernel"
+    startInfo.ArgumentList.Add "-c"
+    startInfo.ArgumentList.Add buildConfiguration
+    startInfo.ArgumentList.Add "--no-build"
+    use child = Process.Start startInfo
+    child.StandardInput.Write input
+    child.StandardInput.Close()
+    let stdout = child.StandardOutput.ReadToEnd()
+    let stderr = child.StandardError.ReadToEnd()
+    child.WaitForExit()
+    child.ExitCode, stdout, stderr
+
+[<Fact>]
+let ``repl evaluates piped stdin without a tty`` () =
+    let exitCode, stdout, stderr = runReplWithInput "(+ 1 2)\n(* 6 7)\nquit\n"
+    Assert.Equal(0, exitCode)
+    Assert.DoesNotContain("Unhandled exception", stderr)
+    Assert.DoesNotContain("SetCursorPosition", stderr)
+    Assert.DoesNotContain("DivideByZeroException", stderr)
+    Assert.Contains("3", stdout)
+    Assert.Contains("42", stdout)
+
+[<Fact>]
+let ``repl exits cleanly at end of piped input`` () =
+    let exitCode, _, stderr = runReplWithInput "(+ 1 2)\n"
+    Assert.Equal(0, exitCode)
+    Assert.DoesNotContain("Unhandled exception", stderr)

--- a/IronKernel.Tests/ExampleTests.fs
+++ b/IronKernel.Tests/ExampleTests.fs
@@ -1,5 +1,6 @@
 module IronKernel.Tests.ExampleTests
 
+open System
 open System.IO
 open Xunit
 open IronKernel.Ast
@@ -38,3 +39,45 @@ let ``samples.ikr packages without execution`` () =
     match compileFileToPackage path outp with
     | Choice1Of2 e -> failwith (showError e)
     | Choice2Of2 p -> Assert.True(File.Exists p)
+
+/// Runs an example in-process and returns whatever it wrote to stdout.
+/// Continuation-heavy examples only fail when actually executed, so packaging
+/// them is not enough to keep them working.
+let private runExampleCapturingOutput name =
+    let path = Path.Combine(examplesDir (), name)
+    let original = Console.Out
+    use writer = new StringWriter()
+    Console.SetOut writer
+    try
+        match bootstrapEnv () with
+        | Choice1Of2 e -> failwith (showError e)
+        | Choice2Of2 env ->
+            match runSourceFile env path with
+            | Choice1Of2 e -> failwith (showError e)
+            | Choice2Of2 _ -> ()
+    finally
+        Console.SetOut original
+    writer.ToString().Replace("\r\n", "\n")
+
+[<Fact>]
+let ``coroutines.ikr interleaves both computations and terminates`` () =
+    let output = runExampleCapturingOutput "coroutines.ikr"
+
+    // Both coroutines must run, alternating rather than one draining first.
+    Assert.Contains("Hefty computation: 5", output)
+    Assert.Contains("Hefty computation (b)", output)
+    Assert.Contains("Hefty computation (c)", output)
+    Assert.Contains("Straight up.", output)
+    Assert.Contains("Quarter til.", output)
+
+    // The countdown must reach 0, proving the exchanged continuation survives
+    // across iterations instead of being lost to a shadowing binding.
+    Assert.Contains("Hefty computation: 0", output)
+
+    let lines = output.Split('\n') |> Array.filter (fun line -> line.Trim() <> "")
+    let hefty = lines |> Array.filter (fun l -> l.StartsWith "Hefty computation: ")
+    Assert.Equal(6, hefty.Length)
+    Assert.Equal<string[]>(
+        [| "Hefty computation: 5"; "Hefty computation: 4"; "Hefty computation: 3"
+           "Hefty computation: 2"; "Hefty computation: 1"; "Hefty computation: 0" |],
+        hefty)

--- a/IronKernel/Repl.fs
+++ b/IronKernel/Repl.fs
@@ -24,8 +24,24 @@ module Repl =
     let putStrLn (str:String) =
       Console.WriteLine(str)
 
-    let readPrompt prompt = 
-      fun _ -> lineEditor.Edit(prompt, "")
+    /// The Mono.Terminal line editor drives the cursor directly, so it needs a real
+    /// TTY. With stdin or stdout redirected `Console.WindowWidth` is 0 and rendering
+    /// divides by zero, which used to crash piped and scripted sessions.
+    let isInteractiveConsole () =
+      not Console.IsInputRedirected
+      && not Console.IsOutputRedirected
+      && (try Console.WindowWidth > 0 with :? IO.IOException -> false)
+
+    /// Plain reads keep non-interactive sessions working; `until` already stops on the
+    /// null that `ReadLine` returns at end of input.
+    let readPrompt (prompt: string) =
+      if isInteractiveConsole () then
+        fun _ -> lineEditor.Edit(prompt, "")
+      else
+        fun _ ->
+          Console.Write prompt
+          Console.Out.Flush()
+          Console.ReadLine()
 
     let evalString env cont expr = 
         let evaled = 

--- a/docs/adr/0004-compiling-procedure-bodies.md
+++ b/docs/adr/0004-compiling-procedure-bodies.md
@@ -1,0 +1,106 @@
+# ADR 0004: Compiling procedure bodies
+
+Status: Proposed
+
+## Decision
+
+Compiled code will return `Step` rather than a collapsed `ThrowsError<LispVal>`,
+and operative bodies will be compiled lazily and carried in the continuation
+representation as a list of compiled forms. Until compiled functions participate
+in the caller's trampoline, procedure bodies must stay interpreted, and further
+analyzer specialization must not be added.
+
+## Problem
+
+Only top-level forms are compiled today, through `evalCompiled` and
+`compileFormsGuarded`. Operative application binds a fresh frame and evaluates
+the body as `KernelCode`, a list of raw `LispVal` forms driven form by form by
+`evalStep`. The `CompiledCombiner` case in `Ast.fs` is matched in three places
+but is never constructed anywhere. Because `define` evaluates its right-hand side
+through `bounceEval`, `(define f (vau ...))` never reaches the analyzer's
+specializations either. Effectively all real work runs interpreted.
+
+The measured gap is large. On an identical form, `CompilerBenchmarks` reports
+interpreted evaluation at 369.9 ns and 1832 B, generic compiled evaluation at
+160.2 ns and 712 B, and constant-folded compiled evaluation at 93.5 ns and 240 B
+— 2.3x to 4.0x faster with 2.6x to 7.6x less allocation. Compiling a form costs
+86.2 ns, less than a single interpreted evaluation, so compilation pays for
+itself within roughly one call.
+
+## Why bodies cannot be compiled today
+
+`KernelFunc` is `Func<LispVal, LispVal, ThrowsError<LispVal>>`. It returns a
+finished value, not a trampoline step. Every compiled leaf bottoms out in `eval`,
+`continueEval`, `operate`, or `bind`, and each of those calls `run`. Each
+compiled form is therefore a nested trampoline. For one-shot top-level forms this
+is harmless. For procedure bodies it breaks three guarantees:
+
+- **Proper tail calls.** A tail-recursive procedure one million calls deep runs in
+  constant stack today. Nested trampolines would turn each Kernel tail call into
+  CLR stack growth.
+- **First-class continuations.** `run` collapses `Step` into a value, so a
+  continuation captured inside a compiled body cannot escape past that boundary
+  or be resumed back into the middle of the body.
+- **Asynchrony.** `run` ends in `GetAwaiter().GetResult()`. An `Await` raised
+  inside a compiled body would block a thread instead of suspending.
+
+## Plan
+
+**Phase 1 — return `Step` from compiled code.** Change `KernelFunc` and
+`GeneratedFunc` to `Func<LispVal, LispVal, Step>` and replace collapsing calls
+with the `bounceEval`, `bounceContinue`, `bounceOperate`, and `bounceBind`
+variants that already exist for exactly this purpose. A single `run` remains at
+the top-level entry points. This touches roughly twenty call sites in
+`Compiler.fs` and `RuntimeDispatch.fs`, the seven emitted helpers used by
+generated artifacts, and the `StaticEmit` source strings. The change is wide but
+mechanical, and the type checker locates every site. It alters no observable
+behaviour and is validated by the existing suite plus deep tail recursion.
+
+**Phase 2 — represent compiled bodies in continuations.** Add
+`CompiledCode of KernelFunc list` beside `KernelCode` in `DeferredCode` and
+mirror the existing stepping in `continueEvalValidStep`: evaluate the head form,
+retain the remaining forms in `currentCont`, and let the final form inherit
+`nextCont`. Keeping the body a list rather than one opaque delegate is what
+preserves proper tail calls structurally, exactly as the interpreter does.
+`DeferredCode` appears in only ten places across `Ast.fs` and `Eval.fs`, two of
+them its own declaration. `appendContinuationRecord` and
+`findPrompt` manipulate only the `nextCont` chain and never inspect the payload
+of `currentCont`, so continuation splicing, `call/cc`, `shift`/`reset`, and
+`prompt`/`perform`/`resume` require no changes.
+
+**Phase 3 — compile bodies lazily.** Give `OperativeRecord` a mutable memo and
+compile on first application with `analyzeFormsGuarded` against the closure
+environment. Because compilation costs less than one interpreted evaluation, no
+tiering or hotness heuristic is warranted. Invalidation already works: binding
+guards key on cell version, and the named call-site cache validates frame binding
+counts, so a body that defines locally invalidates correctly.
+
+`IronKernel.Runtime` cannot reference the compiler, since ADR 0002 requires
+managed artifacts to exclude the compiler and FParsec. The body compiler is
+therefore injected the way `RuntimeSourceServices` already injects the parser.
+Artifacts that do not install it fall back to interpretation.
+
+**Phase 4 — revisit analyzer specialization.** Re-measure with
+`GuardSpecializationBenchmarks`. Fresh-frame invocation becomes the common case
+once bodies are compiled, and guards measured 12% faster there, so extending
+`PrimitiveIdentity` should be reconsidered then, with evidence.
+
+## Consequences
+
+Phases 1 and 2 change no observable behaviour and land independently; the
+performance benefit arrives only with Phase 3. Until then, adding
+`PrimitiveIdentity` cases is a measured pessimization rather than an
+optimization: guards re-resolve the binding by name on every invocation, whereas
+the `COperate` fallback's call-site cache validates by environment reference
+equality and always hits when the environment is stable, which is the only
+situation compiled code encounters today.
+
+Continuation-heavy behaviour is the primary regression risk, and it is exercised
+by examples rather than by unit tests. `Examples/coroutines.ikr` is now executed
+in CI rather than merely packaged; the remaining continuation examples should
+gain equivalent coverage before Phase 2 begins.
+
+Compiled bodies are immutable lists of compiled forms, so re-entry through a
+multi-shot continuation stays safe. Debuggability changes: body frames will
+report through compiled delegates, and located spans must be preserved through
+`CLocated` for diagnostics to survive.


### PR DESCRIPTION
Work from validating an external code review. Three of the review's eight points held up; the rest were stale or mistaken, and are noted below so they don't get re-filed.

## Fixes

**REPL crashed on piped stdin.** The Mono.Terminal line editor drives the cursor directly and needs a real TTY. With stdin or stdout redirected, `Console.WindowWidth` is 0 and rendering threw `DivideByZeroException`, so every piped or scripted session died. The REPL now detects redirection and falls back to `Console.ReadLine`. End of input already terminated the read loop, so a trailing `quit` is now optional:

```bash
printf '(+ 1 2)\nquit\n' | dotnet run --project IronKernel
```

**`Examples/coroutines.ikr` was broken on master.** Four defects: `(loop ())` passed an argument to a zero-parameter lambda; `(if (> n 0) (loop (- n 1)))` omitted the alternative that IronKernel's `if` requires; `for-each` was called in Scheme order rather than IronKernel's collection-first order (every other caller, including `lib/IronKernel.Amb`, already uses collection-first); and the exchanged continuation was lost each iteration. That last one was the real bug — `set!` is Kernel's `$set!`, defining into the environment it is given, so passing `(get-current-environment)` from inside the loop created a fresh shadowing binding per iteration. The procedure's own frame is now captured once and `set!` targets that.

## Coverage gap this exposed

`ExampleTests` only packaged three examples and never executed any, which is how a fully broken example survived on master. This adds an executing test asserting both coroutines interleave and the countdown reaches 0. Verified it fails against the old file.

Still uncovered: `yingyang.ikr`, `continuations.ikr`, `zipper.ikr`, and the two `constant-width` programs. ADR 0004 names closing this as a precondition for its Phase 2.

## Analyzer specialization: measured, not extended

The review proposed extending `analyzeGuarded` beyond `if`/`define` to `$sequence`/`begin`, `lambda`/`vau`, and `let`. Most of those targets do not exist as primitives — `sequence`, `begin`, `lambda`, and `let` are defined in `kernel.ikr`, and binding-identity guards require a `PrimitiveIdentity`, which only true primitives carry.

I implemented the extension for `vau` (a real primitive) end to end, then benchmarked it: **27% slower**. `GuardSpecializationBenchmarks` explains why, on the existing `if` guard:

| Configuration | Unguarded | Guarded | |
|---|---|---|---|
| Shared env (what actually happens) | 162.0 ns | 177.6 ns | 10% slower |
| Fresh frame per call | 235.6 ns | 207.8 ns | 12% faster |

Guards re-resolve the binding by name every invocation; the `COperate` fallback's call-site cache validates by environment reference equality and always hits when the environment is stable. Stable is the only case compiled code sees today, because procedure bodies are stored as raw `KernelCode` and interpreted, and `CompiledCombiner` is never constructed anywhere. The `vau` change was reverted; the benchmark is kept as the harness for evaluating any future guard proposal.

## ADR 0004

Records why procedure bodies cannot be compiled today — compiled functions return a collapsed `ThrowsError<LispVal>`, so every compiled form starts a nested trampoline, which is incompatible with proper tail calls (1M-deep tail recursion currently runs in constant stack), first-class continuations, and `Await` — and the phased plan to change it. Compiled bodies would be worth 2.3x–4.0x on the measured benchmarks, and compiling a form costs less than one interpreted evaluation.

## Review points that did not hold up

- **"Accumulated compiler warnings."** The build is 0 warnings / 0 errors on a clean `--no-incremental` rebuild. The only suppressions are `NU5128` (NuGet packaging) and `FS988` (empty test main); neither masks code lint. `AGENTS.md` was simply stale, and is corrected here.
- **"`Examples/` may not be committed."** It is — 24 files, copied into the test output and referenced by CI.
- **"Expand `ConformanceTests.fs` toward R⁻¹RK."** It is an interpreter/compiler parity harness with randomized expression generation, not a conformance suite. A conformance matrix would be new work, not an expansion.

## Verification

Clean `--no-incremental` rebuild: 0 warnings, 0 errors. Full suite: 229 passed, 0 failed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789273436&installation_model_id=427656&pr_number=26&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F26&signature=4525ad18b37bdf29fdc1159c7a6c3a43ad99d3e1585a518d37160985b9a58218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are REPL I/O fallback, example fixes, tests, benchmarks, and documentation; no auth or core eval semantics beyond the REPL read path.
> 
> **Overview**
> Fixes **REPL crashes** when stdin/stdout are redirected: `Repl.fs` detects non-interactive consoles and uses `Console.ReadLine` instead of Mono.Terminal (which threw on zero `WindowWidth`). CLI tests cover piped evaluation and EOF exit without `quit`.
> 
> Repairs **`Examples/coroutines.ikr`** (wrong `for-each` argument order, incomplete `if`, `set!` targeting a per-iteration env so exchanged continuations were lost). **`ExampleTests`** now **runs** that example and checks interleaving and countdown to 0.
> 
> Adds **`GuardSpecializationBenchmarks`** and documents in **`AGENTS.md`** that guarded analyzer specialization is currently slower for stable envs; **`docs/adr/0004-compiling-procedure-bodies.md`** records why procedure bodies stay interpreted and a phased plan to compile them later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 178401e4ad3fca1bbfedee7f894fed9b5c96c428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->