### PR TITLE
ADR 0004 phase 1: return Step from compiled code

### DIFF
--- a/IronKernel.Benchmarks/Program.fs
+++ b/IronKernel.Benchmarks/Program.fs
@@ -41,11 +41,11 @@ type CompilerBenchmarks() =
 
     [<Benchmark>]
     member _.CompiledGeneric() =
-        compiledGeneric.Invoke(env, newContinuation env)
+        run (compiledGeneric.Invoke(env, newContinuation env))
 
     [<Benchmark>]
     member _.CompiledFolded() =
-        compiledFolded.Invoke(env, newContinuation env)
+        run (compiledFolded.Invoke(env, newContinuation env))
 
 [<MemoryDiagnoser>]
 type SymbolLookupBenchmarks() =
@@ -248,7 +248,7 @@ type GuardSpecializationBenchmarks() =
         unguarded <- compileLispVal form
         guarded <- compileLispValGuarded env form
         let requireOne (func: KernelFunc) =
-            match func.Invoke(env, newContinuation env) with
+            match run (func.Invoke(env, newContinuation env)) with
             | Choice2Of2 (Obj (:? int as value)) when value = 1 -> ()
             | result -> invalidOp (sprintf "Guard benchmark setup failed: %A" result)
         requireOne unguarded
@@ -256,11 +256,11 @@ type GuardSpecializationBenchmarks() =
 
     [<Benchmark(Baseline = true)>]
     member _.Unguarded() =
-        unguarded.Invoke(env, newContinuation env)
+        run (unguarded.Invoke(env, newContinuation env))
 
     [<Benchmark>]
     member _.Guarded() =
-        guarded.Invoke(env, newContinuation env)
+        run (guarded.Invoke(env, newContinuation env))
 
     // The realistic case for code inside a procedure body: a fresh child frame per
     // call, so the named call-site cache misses and must re-resolve and refill.
@@ -268,12 +268,12 @@ type GuardSpecializationBenchmarks() =
     [<Benchmark>]
     member _.UnguardedFreshEnv() =
         let frame = newEnv [env]
-        unguarded.Invoke(frame, newContinuation frame)
+        run (unguarded.Invoke(frame, newContinuation frame))
 
     [<Benchmark>]
     member _.GuardedFreshEnv() =
         let frame = newEnv [env]
-        guarded.Invoke(frame, newContinuation frame)
+        run (guarded.Invoke(frame, newContinuation frame))
 
 [<EntryPoint>]
 let main args =

--- a/IronKernel.Runtime/RuntimeDispatch.fs
+++ b/IronKernel.Runtime/RuntimeDispatch.fs
@@ -10,10 +10,14 @@ module RuntimeDispatch =
     open Eval
     open SymbolTable
 
-    let appNamed env cont name (operands: LispVal[]) : ThrowsError<LispVal> =
+    /// Generated code returns `Step` so it runs inside the caller's trampoline
+    /// instead of starting a nested one. Nesting would cost CLR stack on every
+    /// Kernel tail call, trap escaping continuations behind a collapsed result,
+    /// and turn `Await` into a blocking wait. See ADR 0004.
+    let appNamed env cont name (operands: LispVal[]) : Step =
         match getVar env name with
-        | Choice1Of2 error -> throwError error
-        | Choice2Of2 combiner -> operate env cont combiner (Array.toList operands)
+        | Choice1Of2 error -> Done(throwError error)
+        | Choice2Of2 combiner -> bounceOperate env cont combiner (Array.toList operands)
 
     /// One call site's resolved binding, immutable once constructed so that it can
     /// be published to other threads with a single reference write.
@@ -100,17 +104,17 @@ module RuntimeDispatch =
             match resolved.EagerUnderlying with
             | ValueSome underlying ->
                 match evaluateSimpleOperands env [] operands with
-                | Choice1Of2 error -> throwError error
-                | Choice2Of2 args -> operate env cont underlying args
-            | ValueNone -> operate env cont resolved.Combiner operands
+                | Choice1Of2 error -> Done(throwError error)
+                | Choice2Of2 args -> bounceOperate env cont underlying args
+            | ValueNone -> bounceOperate env cont resolved.Combiner operands
 
-        member _.Invoke(env: LispVal, cont: LispVal) : ThrowsError<LispVal> =
+        member _.Invoke(env: LispVal, cont: LispVal) : Step =
             let cached = Volatile.Read(&cache)
             if not (isNull cached) && cacheValid cached env then
                 dispatch cached env cont
             else
                 match SymbolTable.resolveBindingCellWithPath env name with
-                | ValueNone -> throwError (UnboundVar("Getting an unbound variable", name))
+                | ValueNone -> Done(throwError (UnboundVar("Getting an unbound variable", name)))
                 | ValueSome(cell, visitedPath) ->
                     let state = cell.state
                     let resolved =
@@ -124,45 +128,77 @@ module RuntimeDispatch =
                     Volatile.Write(&cache, resolved)
                     dispatch resolved env cont
 
-    type GeneratedFunc = Func<LispVal, LispVal, ThrowsError<LispVal>>
+    type GeneratedFunc = Func<LispVal, LispVal, Step>
 
+    /// Sub-evaluations that must produce a *value* before the caller can proceed
+    /// resume through `makeCPS` rather than collapsing a nested trampoline. The
+    /// continuation handed to the callback is the caller's own, so the final form
+    /// of each construct stays in tail position.
     let runOperate env cont (operator: GeneratedFunc) (operands: LispVal[]) =
-        match operator.Invoke(env, newContinuation env) with
-        | Choice1Of2 error -> throwError error
-        | Choice2Of2 combiner -> operate env cont combiner (Array.toList operands)
+        operator.Invoke(
+            env,
+            makeCPS env cont (fun e c combiner _ ->
+                bounceOperate e c combiner (Array.toList operands)))
 
     let runIf env cont (condition: GeneratedFunc) (consequent: GeneratedFunc) (alternative: GeneratedFunc) =
-        match condition.Invoke(env, newContinuation env) with
-        | Choice2Of2 (Bool true) -> consequent.Invoke(env, cont)
-        | Choice2Of2 (Bool false) -> alternative.Invoke(env, cont)
-        | Choice2Of2 found -> throwError (TypeMismatch("bool", found))
-        | Choice1Of2 error -> throwError error
+        condition.Invoke(
+            env,
+            makeCPS env cont (fun e c value _ ->
+                match value with
+                | Bool true -> consequent.Invoke(e, c)
+                | Bool false -> alternative.Invoke(e, c)
+                | found -> Done(throwError (TypeMismatch("bool", found)))))
 
     let runDefine env cont name (rhs: GeneratedFunc) =
-        match rhs.Invoke(env, newContinuation env) with
-        | Choice1Of2 error -> throwError error
-        | Choice2Of2 value ->
-            match defineVar env name value with
-            | Choice1Of2 error -> throwError error
-            | Choice2Of2 _ -> continueEval env cont Inert
+        rhs.Invoke(
+            env,
+            makeCPS env cont (fun e c value _ ->
+                match defineVar e name value with
+                | Choice1Of2 error -> Done(throwError error)
+                | Choice2Of2 _ -> bounceContinue e c Inert))
 
     let runSequence env cont (forms: GeneratedFunc[]) =
-        let mutable index = 0
-        let mutable result = Choice2Of2 Inert
-        let mutable running = true
-        while index < forms.Length && running do
-            let nextCont = if index = forms.Length - 1 then cont else newContinuation env
-            result <- forms.[index].Invoke(env, nextCont)
-            running <- match result with Choice2Of2 _ -> true | Choice1Of2 _ -> false
-            index <- index + 1
-        if forms.Length = 0 then continueEval env cont Inert else result
+        if forms.Length = 0 then bounceContinue env cont Inert
+        else
+            let rec step index e c =
+                if index = forms.Length - 1 then forms.[index].Invoke(e, c)
+                else forms.[index].Invoke(e, makeCPS e c (fun se sc _ _ -> step (index + 1) se sc))
+            step 0 env cont
 
     let runGuard env cont name expectedIdentity (specialized: GeneratedFunc) (fallback: GeneratedFunc) =
         if bindingHasPrimitiveIdentity env name expectedIdentity then specialized.Invoke(env, cont)
         else fallback.Invoke(env, cont)
 
+    /// Attaches a source span to an error raised *while this form is evaluating*.
+    ///
+    /// Errors short-circuit the trampoline as `Done`, bypassing continuations, so
+    /// the span has to be applied by inspecting the step chain rather than by a
+    /// continuation frame. The chain a compiled form returns also covers whatever
+    /// runs after it, because CPS hands the form the caller's own continuation.
+    /// Attributing all of that to this span would make an operator's span swallow
+    /// errors from the operands evaluated after it. Interpreting collapsed each
+    /// sub-evaluation against a fresh continuation, which bounded the span
+    /// naturally; `reached` restores that boundary by recording when control
+    /// passes out of the form to `cont`.
+    ///
+    /// Each case rebuilds one layer and returns immediately, so the trampoline
+    /// keeps its constant stack. An already-located error keeps its inner span.
     let runLocated env cont span sourceLine (body: GeneratedFunc) =
-        match body.Invoke(env, cont) with
-        | Choice1Of2 (LocatedError _ as error) -> throwError error
-        | Choice1Of2 error -> throwError (LocatedError(span, sourceLine, error))
-        | Choice2Of2 value -> Choice2Of2 value
+        let mutable reached = false
+        let boundary =
+            makeCPS env cont (fun e c value _ ->
+                reached <- true
+                bounceContinue e c value)
+        let rec locate step =
+            match step with
+            | Done (Choice1Of2 (LocatedError _)) -> step
+            | Done (Choice1Of2 error) ->
+                if reached then step
+                else Done(throwError (LocatedError(span, sourceLine, error)))
+            | Done (Choice2Of2 _) -> step
+            | More next -> More(fun () -> locate (next ()))
+            | Await request ->
+                Await
+                    { register = request.register
+                      resume = fun outcome -> locate (request.resume outcome) }
+        locate (body.Invoke(env, boundary))

--- a/IronKernel.Tests/CliTests.fs
+++ b/IronKernel.Tests/CliTests.fs
@@ -601,3 +601,30 @@ let ``repl exits cleanly at end of piped input`` () =
     let exitCode, _, stderr = runReplWithInput "(+ 1 2)\n"
     Assert.Equal(0, exitCode)
     Assert.DoesNotContain("Unhandled exception", stderr)
+
+[<Fact>]
+let ``runtime diagnostics do not attribute operand errors to the operator`` () =
+    // The operator is evaluated before the operands, and compiled code hands it
+    // the caller's own continuation. Its span must stop at that hand-off, or it
+    // swallows every later error and reports column 2 for the whole program.
+    match bootstrapEnv () with
+    | Choice1Of2 error -> failwith (showError error)
+    | Choice2Of2 env ->
+        match runSource env "operand-error.ikr" "(define ready #t)\n(+ 1 missing)" with
+        | Choice2Of2 value -> failwithf "unexpectedly returned %A" value
+        | Choice1Of2 error ->
+            let diagnostic = showError error
+            Assert.Contains("operand-error.ikr:2:1", diagnostic)
+            Assert.Contains("^^^^^^^^^^^^^", diagnostic)
+
+[<Fact>]
+let ``runtime diagnostics keep the enclosing span for errors after an if condition`` () =
+    match bootstrapEnv () with
+    | Choice1Of2 error -> failwith (showError error)
+    | Choice2Of2 env ->
+        match runSource env "if-condition.ikr" "(if 5 1 2)" with
+        | Choice2Of2 value -> failwithf "unexpectedly returned %A" value
+        | Choice1Of2 error ->
+            let diagnostic = showError error
+            Assert.Contains("if-condition.ikr:1:1", diagnostic)
+            Assert.Contains("^^^^^^^^^^", diagnostic)

--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -175,13 +175,13 @@ let ``compiled guard deoptimizes after primitive rebinding`` () =
     let env = freshEnv ()
     let compiled = compileLispValGuarded env (parseOk "(if #t 1 2)")
 
-    match compiled.Invoke(env, newContinuation env) with
+    match run (compiled.Invoke(env, newContinuation env)) with
     | Choice2Of2 (Obj (:? int as value)) -> Assert.Equal(1, value)
     | result -> failwithf "unexpected guarded result: %A" result
 
     ignore (evalIn env "(define if (vau operands caller operands))")
 
-    match compiled.Invoke(env, newContinuation env) with
+    match run (compiled.Invoke(env, newContinuation env)) with
     | Choice2Of2 (List [Bool true; Obj (:? int as one); Obj (:? int as two)]) ->
         Assert.Equal(1, one)
         Assert.Equal(2, two)
@@ -214,7 +214,7 @@ let ``compiled guard detects a new shadowing binding`` () =
 
     ignore (evalIn child "(define if (vau operands caller operands))")
 
-    match compiled.Invoke(child, newContinuation child) with
+    match run (compiled.Invoke(child, newContinuation child)) with
     | Choice2Of2 (List [Bool true; Obj (:? int as one); Obj (:? int as two)]) ->
         Assert.Equal(1, one)
         Assert.Equal(2, two)
@@ -228,7 +228,7 @@ let ``compiled guard deoptimizes after parent binding mutation`` () =
 
     ignore (evalIn parent "(define if (vau operands caller operands))")
 
-    match compiled.Invoke(child, newContinuation child) with
+    match run (compiled.Invoke(child, newContinuation child)) with
     | Choice2Of2 (List [Bool true; Obj (:? int as one); Obj (:? int as two)]) ->
         Assert.Equal(1, one)
         Assert.Equal(2, two)
@@ -253,7 +253,7 @@ let ``compiled define guard deoptimizes after binding changes`` () =
             mutate compiledEnv
 
             let interpreted = evalRaw Interpreted interpretedEnv source |> observe
-            let compiledResult = compiled.Invoke(compiledEnv, newContinuation compiledEnv) |> observe
+            let compiledResult = run (compiled.Invoke(compiledEnv, newContinuation compiledEnv)) |> observe
             if interpreted <> compiledResult then
                 failwithf
                     "%s define guard mismatch for %s\ninterpreted: %A\ncompiled: %A"
@@ -298,7 +298,7 @@ let ``located compiled guard retains the generic fallback`` () =
 
     ignore (evalIn env "(define if (vau operands caller operands))")
 
-    match compiled.Invoke(env, newContinuation env) with
+    match run (compiled.Invoke(env, newContinuation env)) with
     | Choice2Of2 (List [Bool true; Obj (:? int as one); Obj (:? int as two)]) ->
         Assert.Equal(1, one)
         Assert.Equal(2, two)
@@ -342,7 +342,7 @@ let ``expression tree helpers compile their live core shapes`` () =
     let env = freshEnv ()
     let invoke expression =
         compileToFunc expression
-        |> fun compiled -> compiled.Invoke(env, newContinuation env)
+        |> fun compiled -> run (compiled.Invoke(env, newContinuation env))
 
     match invoke (CLit (Obj 1)) with
     | Choice2Of2 (Obj (:? int as value)) -> Assert.Equal(1, value)
@@ -529,7 +529,7 @@ let ``static backend emits direct managed entry points without source compilatio
         Assert.DoesNotContain("Expression.Compile", source)
 
 let private invokeSite (compiled: KernelFunc) env =
-    match compiled.Invoke(env, newContinuation env) with
+    match run (compiled.Invoke(env, newContinuation env)) with
     | Choice2Of2 value -> value
     | Choice1Of2 error -> failwith (showError error)
 
@@ -603,7 +603,7 @@ let ``inline cache dispatches per environment under concurrent invocation`` () =
         500_000,
         System.Action<int>(fun index ->
             let env, expected = if index % 2 = 0 then envA, 1 else envB, 2
-            match compiled.Invoke(env, newContinuation env) with
+            match run (compiled.Invoke(env, newContinuation env)) with
             | Choice2Of2 (Obj (:? int as actual)) when actual = expected -> ()
             | _ -> System.Threading.Interlocked.Increment(&mismatches.contents) |> ignore))
     |> ignore
@@ -614,7 +614,7 @@ let ``inline cache dispatches per environment under concurrent invocation`` () =
 let ``inline cache reports unbound operand variables`` () =
     let env = freshEnv ()
     let compiled = compileLispValGuarded env (parseOk "(+ missing 1)")
-    match compiled.Invoke(env, newContinuation env) with
+    match run (compiled.Invoke(env, newContinuation env)) with
     | Choice1Of2 (UnboundVar(_, "missing")) -> ()
     | result -> failwithf "expected unbound operand error, got %A" result
     // Binding the operand afterwards must succeed through the same site.

--- a/IronKernel.Tests/ContractTests.fs
+++ b/IronKernel.Tests/ContractTests.fs
@@ -6,6 +6,7 @@ open IronKernel.Ast
 open IronKernel.Analyze
 open IronKernel.Compiler
 open IronKernel.Contracts
+open IronKernel.Eval
 open IronKernel.Ir
 open IronKernel.PartialEval
 open IronKernel.SymbolTable
@@ -149,7 +150,7 @@ let ``contract fold falls back after rebinding`` () =
 
     ignore (evalIn env "(define + (vau operands _ operands))")
 
-    match compiled.Invoke(env, newContinuation env) with
+    match run (compiled.Invoke(env, newContinuation env)) with
     | Choice2Of2 (List [Obj (:? int as one); Obj (:? int as two)]) ->
         Assert.Equal(1, one)
         Assert.Equal(2, two)
@@ -169,7 +170,7 @@ let ``contract folds deoptimize across environment binding changes`` () =
             mutate compiledEnv operator
 
             let interpreted = evalRaw Interpreted interpretedEnv source |> observe
-            let compiledResult = compiled.Invoke(compiledEnv, newContinuation compiledEnv) |> observe
+            let compiledResult = run (compiled.Invoke(compiledEnv, newContinuation compiledEnv)) |> observe
             if interpreted <> compiledResult then
                 failwithf
                     "%s contract fold mismatch for %s\ninterpreted: %A\ncompiled: %A"

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -17,7 +17,11 @@ module Compiler =
     open PartialEval
     open Choice
 
-    type KernelFunc = Func<LispVal, LispVal, ThrowsError<LispVal>>
+    /// Compiled code returns `Step`, so it runs inside the caller's trampoline
+    /// rather than starting a nested one. A nested trampoline would consume CLR
+    /// stack on every Kernel tail call, collapse escaping continuations into a
+    /// finished value, and block on `Await`. See ADR 0004.
+    type KernelFunc = Func<LispVal, LispVal, Step>
 
     type private CompilationWork =
         | CompileExpression of CoreExpr
@@ -32,48 +36,49 @@ module Compiler =
         | BuildLocated of SourceSpan * string option
 
     type Helpers =
-        static member Continue(env: LispVal, cont: LispVal, v: LispVal) : ThrowsError<LispVal> =
-            continueEval env cont v
-        static member Lookup(env: LispVal, cont: LispVal, name: string) : ThrowsError<LispVal> =
+        static member Continue(env: LispVal, cont: LispVal, v: LispVal) : Step =
+            bounceContinue env cont v
+        static member Lookup(env: LispVal, cont: LispVal, name: string) : Step =
             match SymbolTable.getVar env name with
-            | Choice2Of2 r -> continueEval env cont r
-            | Choice1Of2 e -> throwError e
-        static member IfThenElse(env: LispVal, cont: LispVal, fc: KernelFunc, fa: KernelFunc, fb: KernelFunc) : ThrowsError<LispVal> =
-            match fc.Invoke(env, newContinuation env) with
-            | Choice2Of2 (Bool true) -> fa.Invoke(env, cont)
-            | Choice2Of2 (Bool false) -> fb.Invoke(env, cont)
-            | Choice2Of2 found -> throwError (TypeMismatch("bool", found))
-            | Choice1Of2 e -> throwError e
-        static member Seq(env: LispVal, cont: LispVal, forms: KernelFunc[]) : ThrowsError<LispVal> =
-            let rec loop i =
-                if i >= forms.Length then continueEval env cont Inert
-                elif i = forms.Length - 1 then forms.[i].Invoke(env, cont)
-                else
-                    match forms.[i].Invoke(env, newContinuation env) with
-                    | Choice1Of2 e -> throwError e
-                    | Choice2Of2 _ -> loop (i + 1)
-            loop 0
-        static member Define(env: LispVal, cont: LispVal, name: string, fr: KernelFunc) : ThrowsError<LispVal> =
-            match fr.Invoke(env, newContinuation env) with
-            | Choice1Of2 e -> throwError e
-            | Choice2Of2 v ->
-                match SymbolTable.defineVar env name v with
-                | Choice1Of2 e -> throwError e
-                | Choice2Of2 _ -> continueEval env cont Inert
-        static member EvalForms(env: LispVal, cont: LispVal, fe: KernelFunc, fx: KernelFunc) : ThrowsError<LispVal> =
-            match fe.Invoke(env, newContinuation env) with
-            | Choice1Of2 e -> throwError e
-            | Choice2Of2 envVal ->
-                match fx.Invoke(env, newContinuation env) with
-                | Choice1Of2 e -> throwError e
-                | Choice2Of2 code -> eval envVal cont code
+            | Choice2Of2 r -> bounceContinue env cont r
+            | Choice1Of2 e -> Done(throwError e)
+        static member IfThenElse(env: LispVal, cont: LispVal, fc: KernelFunc, fa: KernelFunc, fb: KernelFunc) : Step =
+            fc.Invoke(
+                env,
+                makeCPS env cont (fun e c value _ ->
+                    match value with
+                    | Bool true -> fa.Invoke(e, c)
+                    | Bool false -> fb.Invoke(e, c)
+                    | found -> Done(throwError (TypeMismatch("bool", found)))))
+        static member Seq(env: LispVal, cont: LispVal, forms: KernelFunc[]) : Step =
+            if forms.Length = 0 then bounceContinue env cont Inert
+            else
+                let rec step index e c =
+                    if index = forms.Length - 1 then forms.[index].Invoke(e, c)
+                    else forms.[index].Invoke(e, makeCPS e c (fun se sc _ _ -> step (index + 1) se sc))
+                step 0 env cont
+        static member Define(env: LispVal, cont: LispVal, name: string, fr: KernelFunc) : Step =
+            fr.Invoke(
+                env,
+                makeCPS env cont (fun e c value _ ->
+                    match SymbolTable.defineVar e name value with
+                    | Choice1Of2 error -> Done(throwError error)
+                    | Choice2Of2 _ -> bounceContinue e c Inert))
+        static member EvalForms(env: LispVal, cont: LispVal, fe: KernelFunc, fx: KernelFunc) : Step =
+            fe.Invoke(
+                env,
+                makeCPS env cont (fun e c environmentValue _ ->
+                    fx.Invoke(
+                        e,
+                        makeCPS e c (fun _ xc code _ -> bounceEval environmentValue xc code))))
         /// Kernel combination: evaluate operator, then operate with *unevaluated* operands.
         /// Applicatives evaluate their arguments inside `operate`; operatives see raw trees.
-        static member App(env: LispVal, cont: LispVal, fop: KernelFunc, operands: LispVal[]) : ThrowsError<LispVal> =
-            match fop.Invoke(env, newContinuation env) with
-            | Choice1Of2 e -> throwError e
-            | Choice2Of2 combiner -> operate env cont combiner (Array.toList operands)
-        static member AppNamed(env: LispVal, cont: LispVal, name: string, operands: LispVal[]) : ThrowsError<LispVal> =
+        static member App(env: LispVal, cont: LispVal, fop: KernelFunc, operands: LispVal[]) : Step =
+            fop.Invoke(
+                env,
+                makeCPS env cont (fun e c combiner _ ->
+                    bounceOperate e c combiner (Array.toList operands)))
+        static member AppNamed(env: LispVal, cont: LispVal, name: string, operands: LispVal[]) : Step =
             RuntimeDispatch.appNamed env cont name operands
 
     let private resolveHelper name parameterTypes =
@@ -84,7 +89,7 @@ module Compiler =
                 null,
                 parameterTypes,
                 null)
-        if isNull methodInfo || methodInfo.ReturnType <> typeof<ThrowsError<LispVal>> then
+        if isNull methodInfo || methodInfo.ReturnType <> typeof<Step> then
             invalidOp (sprintf "Compiler helper '%s' has an incompatible signature" name)
         methodInfo
 
@@ -163,7 +168,7 @@ module Compiler =
                     completed <-
                         KernelFunc(fun env cont ->
                             let op = Operative { prms = formals; envarg = envarg; body = bodyLv; closure = env }
-                            continueEval env cont op)
+                            bounceContinue env cont op)
                         :: completed
                 | CEval (environmentExpression, valueExpression) ->
                     pending <-
@@ -175,7 +180,7 @@ module Compiler =
                     // Delimited continuations must go through the trampoline interpreter so
                     // shift sees the proper meta-continuation chain (including under begin/applicatives).
                     let form = List [Atom "reset"; toLispVal body]
-                    completed <- KernelFunc(fun env cont -> eval env cont form) :: completed
+                    completed <- KernelFunc(fun env cont -> bounceEval env cont form) :: completed
                 | CApp (operator, args) ->
                     let operands = List.map toLispVal args |> List.toArray
                     pending <- CompileExpression operator :: BuildApp operands :: pending
@@ -196,8 +201,8 @@ module Compiler =
                     completed <-
                         KernelFunc(fun env cont ->
                             match identity with
-                            | PrimitiveIf -> run (Runtime.if_then_else env cont operands)
-                            | PrimitiveDefine -> run (Runtime.define env cont operands))
+                            | PrimitiveIf -> Runtime.if_then_else env cont operands
+                            | PrimitiveDefine -> Runtime.define env cont operands)
                         :: completed
                 | CGuarded (guard, specialized, fallback) ->
                     pending <-
@@ -211,12 +216,12 @@ module Compiler =
                         :: BuildContractFold(guard, folded)
                         :: pending
                 | CResidual v ->
-                    completed <- KernelFunc(fun env cont -> eval env cont v) :: completed
+                    completed <- KernelFunc(fun env cont -> bounceEval env cont v) :: completed
                 | CLocated (span, sourceLine, inner) ->
                     pending <- CompileExpression inner :: BuildLocated(span, sourceLine) :: pending
                 | other ->
                     let value = toLispVal other
-                    completed <- KernelFunc(fun env cont -> eval env cont value) :: completed
+                    completed <- KernelFunc(fun env cont -> bounceEval env cont value) :: completed
             | BuildIf ->
                 match takeCompleted 3 with
                 | [condition; consequent; alternative] ->
@@ -279,7 +284,7 @@ module Compiler =
                 | [fallback] ->
                     completed <-
                         KernelFunc(fun env cont ->
-                            if contractGuardMatches env guard then continueEval env cont folded
+                            if contractGuardMatches env guard then bounceContinue env cont folded
                             else fallback.Invoke(env, cont))
                         :: completed
                 | _ -> invalidOp "Contract fold compilation is incomplete"
@@ -288,10 +293,7 @@ module Compiler =
                 | [inner] ->
                     completed <-
                         KernelFunc(fun env cont ->
-                            match inner.Invoke(env, cont) with
-                            | Choice1Of2 (LocatedError _ as error) -> throwError error
-                            | Choice1Of2 error -> throwError (LocatedError(span, sourceLine, error))
-                            | Choice2Of2 value -> returnM value)
+                            RuntimeDispatch.runLocated env cont span sourceLine inner)
                         :: completed
                 | _ -> invalidOp "Located compilation is incomplete"
 
@@ -308,7 +310,10 @@ module Compiler =
     let compileForms (forms: LispVal list) = List.map compileLispVal forms
     let compileFormsGuarded env forms = List.map (compileLispValGuarded env) forms
 
-    let evalCompiled env cont (v: LispVal) = compileLispValGuarded env v |> fun f -> f.Invoke(env, cont)
+    /// Single trampoline entry for compiled code. Everything below this point
+    /// returns `Step` and shares this one loop.
+    let evalCompiled env cont (v: LispVal) =
+        compileLispValGuarded env v |> fun f -> run (f.Invoke(env, cont))
 
     let analyzeAndCompile (source: string) : ThrowsError<KernelFunc list> =
         match Parser.readExprList source with

--- a/IronKernel/Emit.fs
+++ b/IronKernel/Emit.fs
@@ -19,7 +19,7 @@ module Emit =
             match fs with
             | [] -> returnM last
             | f :: rest ->
-                match f.Invoke(env, cont) with
+                match run (f.Invoke(env, cont)) with
                 | Choice1Of2 e -> throwError e
                 | Choice2Of2 v -> loop rest v
         loop forms Inert
@@ -30,7 +30,7 @@ module Emit =
             match remaining with
             | [] -> returnM last
             | form :: rest ->
-                match form.func.Invoke(env, cont) with
+                match run (form.func.Invoke(env, cont)) with
                 | Choice1Of2 (LocatedError _ as error) -> throwError error
                 | Choice1Of2 error ->
                     throwError (LocatedError(form.span, form.sourceLine, error))

--- a/IronKernel/StaticCompiler.fs
+++ b/IronKernel/StaticCompiler.fs
@@ -97,13 +97,13 @@ module StaticCompiler =
             | CLit value
             | CQuote value ->
                 emitValue value
-                |> Option.map (fun emitted -> generated ("continueEval env cont (" + emitted + ")"))
+                |> Option.map (fun emitted -> generated ("bounceContinue env cont (" + emitted + ")"))
             | CVar name ->
                 Some(
                     generated(
                     "match getVar env " + quote name
-                    + " with | Choice1Of2 error -> throwError error"
-                    + " | Choice2Of2 value -> continueEval env cont value"))
+                    + " with | Choice1Of2 error -> Done(throwError error)"
+                    + " | Choice2Of2 value -> bounceContinue env cont value"))
             | COperate(operator, operands) ->
                 match operands |> List.map emitValue |> sequenceOptions with
                 | Some emitted ->
@@ -155,13 +155,13 @@ module StaticCompiler =
                 |> List.map emitValue
                 |> sequenceOptions
                 |> Option.map (fun values ->
-                    generated("run (if_then_else env cont [" + String.concat "; " values + "])") )
+                    generated("if_then_else env cont [" + String.concat "; " values + "]") )
             | CIntrinsicOperate(PrimitiveDefine, operands) ->
                 operands
                 |> List.map emitValue
                 |> sequenceOptions
                 |> Option.map (fun values ->
-                    generated("run (define env cont [" + String.concat "; " values + "])") )
+                    generated("define env cont [" + String.concat "; " values + "]") )
             | CLocated(span, sourceLine, inner) ->
                 emit inner
                 |> Option.map (fun innerFunc ->
@@ -206,7 +206,7 @@ module StaticCompiler =
             output.AppendLine("    let mutable index = 0") |> ignore
             output.AppendLine("    let mutable running = true") |> ignore
             output.AppendLine("    while index < forms.Length && running do") |> ignore
-            output.AppendLine("        result <- forms.[index].Invoke(env, cont)") |> ignore
+            output.AppendLine("        result <- run (forms.[index].Invoke(env, cont))") |> ignore
             output.AppendLine("        running <- match result with Choice2Of2 _ -> true | Choice1Of2 _ -> false") |> ignore
             output.AppendLine("        index <- index + 1") |> ignore
             output.AppendLine("    match result with") |> ignore


### PR DESCRIPTION
First of four stacked PRs implementing [ADR 0004](docs/adr/0004-compiling-procedure-bodies.md). **Merge in order: this → phase 2 → phase 3 → phase 4.** The performance payoff arrives in phase 4; phases 1–3 are prerequisites.

## Why

Compiled functions returned `ThrowsError<LispVal>`, so every compiled form bottomed out in `eval`/`continueEval`/`operate`/`bind` — each of which calls `run`. Every compiled form was therefore its own nested trampoline, which is incompatible with proper tail calls, escaping continuations, and `Await`. That is why procedure bodies could not be compiled.

## What

`KernelFunc` and `GeneratedFunc` now return `Step`. Sub-evaluations that need a value before proceeding (`if` condition, `define` RHS, non-final sequence forms, the operator of a combination) resume through `makeCPS` instead of collapsing. A single `run` remains at the top-level drivers in `Emit` and `evalCompiled`. The static backend's generated source and main loop move with them.

## The one subtle part

Bounding the located-error span needed care. Errors short-circuit the trampoline as `Done` and bypass continuations, so a span is applied by inspecting the step chain. Under CPS that chain also covers everything running *after* the form, so an operator's span would swallow errors from operands evaluated after it — reporting column 2 for the whole program. Interpreting bounded each sub-evaluation with a fresh continuation; `runLocated` now restores that boundary explicitly.

Diagnostics are verified byte-identical to master across nine erroring programs. Two tests were added for the boundary case, which nothing previously covered.

## Cost

No behaviour change. Costs ~7% on `CompiledGeneric` and ~15% on `CompiledFolded` — threading continuations where nested trampolines previously ran tight inner loops. Phase 4 repays this and more.

## Verification

Clean `--no-incremental` rebuild: 0 warnings, 0 errors. 231 tests pass. 1M-deep tail recursion, all examples, and the managed-artifact tests (which cover the generated code changed here) all verified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789307174&installation_model_id=427656&pr_number=27&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F27&signature=602b8df48a7234e3580b592f3957157c41d515a2ad925c08abcac2ac7eb77267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core eval/compile dispatch and error attribution across interpreter parity tests; no auth/data boundaries, but regressions would show as wrong results, broken continuations, or misleading diagnostics.
> 
> **Overview**
> **ADR 0004 phase 1:** compiled code no longer finishes as `ThrowsError<LispVal>` inside nested `run` loops. `KernelFunc` and `GeneratedFunc` return **`Step`** so evaluation stays in the **caller’s trampoline** (see ADR 0004).
> 
> Sub-evaluations that need a value first (`if` condition, `define` RHS, non-final `begin` forms, combination operators) resume through **`makeCPS`** instead of collapsing a nested trampoline. **`bounceContinue` / `bounceOperate` / `bounceEval`** replace direct `continueEval` / `operate` / `eval` in compiler helpers, `RuntimeDispatch`, and emitted static artifacts. Top-level drivers (`Emit`, `evalCompiled`, benchmarks, tests) wrap invocation with a single **`run`**.
> 
> **`runLocated`** walks the returned step chain to attach source spans and uses a **`reached`** boundary so an operator’s span does not swallow errors from operands evaluated later (e.g. `(+ 1 missing)`). Two CLI tests lock that behavior.
> 
> Expected short-term benchmark cost on compiled paths; behavior otherwise unchanged for callers that already use `run` at the edge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc58d2ef57b70e0ab6b6d85ff4592f70327aaf4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->