### PR TITLE
ADR 0004 phase 2: carry compiled bodies in the continuation

### DIFF
--- a/IronKernel.Runtime/Ast.fs
+++ b/IronKernel.Runtime/Ast.fs
@@ -79,11 +79,16 @@ module Ast =
         resume : ThrowsError<LispVal> -> Step
     }
 
-    and OperativeRecord = { 
+    and OperativeRecord = {
         prms    : LispVal ;
         envarg  : string;
-        body    : LispVal list; 
+        body    : LispVal list;
         closure : LispVal
+        /// Compiled form of `body`, used in preference to interpreting it. Always
+        /// `None` today: ADR 0004 phase 3 fills it in lazily on first application.
+        /// `body` stays authoritative so anything reading a combiner's source, and
+        /// any artifact built without the compiler, keeps working.
+        compiledBody : ((LispVal -> LispVal -> Step) list) option
     }
     and NativeFuncRecord = { 
         cont : LispVal -> LispVal -> LispVal -> (LispVal list) option -> Step
@@ -91,6 +96,13 @@ module Ast =
     }
     and DeferredCode =
         | KernelCode of (LispVal list)
+        /// A compiled procedure body, kept as a *list* of compiled forms rather
+        /// than one delegate. Continuation capture and the stepping rule both work
+        /// on the remaining-forms tail, so keeping the list preserves proper tail
+        /// calls and lets a captured continuation resume mid-body, exactly as
+        /// `KernelCode` does. Typed as a plain function so `IronKernel.Runtime`
+        /// stays independent of the compiler (ADR 0002).
+        | CompiledCode of (LispVal -> LispVal -> Step) list
         | NativeCode of NativeFuncRecord
     and ContinuationRecord = {
         closure     : LispVal

--- a/IronKernel.Runtime/Eval.fs
+++ b/IronKernel.Runtime/Eval.fs
@@ -125,22 +125,36 @@ module Eval =
             More (fun () -> f e (Continuation (ncr, metaCont, ct)) value args)
         | Continuation ({ closure = e; currentCont = Some (KernelCode cBody); nextCont = nextCont }, metaCont, ct) ->
             match cBody with
-            | [] ->
-                match nextCont with
-                | Some (Continuation (cr, None, _)) ->
-                    More (fun () -> continueEvalStep e (Continuation (cr, metaCont, ct)) value)
-                | None ->
-                    match metaCont with
-                    | Some frame -> More (fun () -> continueEvalStep e frame.parentCont value)
-                    | None -> ok value
-                | Some _ ->
-                    fail (Default "Internal Error: metacontinuation in wrong position")
+            | [] -> finishDeferredBody e nextCont metaCont ct value
             | p :: tail ->
                 More (fun () ->
                     evalStep e
                         (Continuation ({ closure = e; currentCont = Some (KernelCode tail); nextCont = nextCont; args = None }, metaCont, ct))
                         p)
+        // Same rule as KernelCode: the head form runs against a continuation holding
+        // the remaining forms, so the final form inherits `nextCont` and stays in
+        // tail position.
+        | Continuation ({ closure = e; currentCont = Some (CompiledCode forms); nextCont = nextCont }, metaCont, ct) ->
+            match forms with
+            | [] -> finishDeferredBody e nextCont metaCont ct value
+            | form :: tail ->
+                More (fun () ->
+                    form
+                        e
+                        (Continuation ({ closure = e; currentCont = Some (CompiledCode tail); nextCont = nextCont; args = None }, metaCont, ct)))
         | _ -> fail (TypeMismatch ("continuation", cont))
+
+    /// A deferred body ran out of forms: hand the value to whatever follows.
+    and private finishDeferredBody e nextCont metaCont ct value : Step =
+        match nextCont with
+        | Some (Continuation (cr, None, _)) ->
+            More (fun () -> continueEvalStep e (Continuation (cr, metaCont, ct)) value)
+        | None ->
+            match metaCont with
+            | Some frame -> More (fun () -> continueEvalStep e frame.parentCont value)
+            | None -> ok value
+        | Some _ ->
+            fail (Default "Internal Error: metacontinuation in wrong position")
 
     and evalStep env cont value : Step =
         match env, cont with
@@ -269,26 +283,26 @@ module Eval =
                 More (fun () -> operateStep _env resumeCont resumption.continuation [argument])
             | [_] -> fail (Default "resumption has already been consumed")
             | _ -> fail (NumArgs(1, args))
-        | Operative { prms = prms; envarg = envarg; body = body; closure = closure } ->
+        | Operative { prms = prms; envarg = envarg; body = body; closure = closure; compiledBody = compiledBody } ->
             let evalBody env =
-                match cpr with
-                | { currentCont = Some (KernelCode cBody); nextCont = nextCont } ->
-                    match cBody with
-                    | [] ->
-                        More (fun () ->
-                            continueEvalStep env
-                                (Continuation ({ closure = env; currentCont = Some (KernelCode body); nextCont = nextCont; args = None }, metaCont, ct))
-                                Nil)
-                    | _ ->
-                        More (fun () ->
-                            continueEvalStep env
-                                (Continuation ({ closure = env; currentCont = Some (KernelCode body); nextCont = Some (Continuation (cpr, None, Full)); args = None }, metaCont, ct))
-                                Nil)
-                | _ ->
-                    More (fun () ->
-                        continueEvalStep env
-                            (Continuation ({ closure = env; currentCont = Some (KernelCode body); nextCont = Some (Continuation (cpr, None, Full)); args = None }, metaCont, ct))
-                            Nil)
+                let continuationAfterBody =
+                    match cpr with
+                    // The caller has no forms left to run, so this call is in tail
+                    // position: inherit its continuation instead of stacking a frame
+                    // on it. A compiled caller reports an exhausted body the same way,
+                    // and missing that case would grow the continuation on every tail
+                    // call out of compiled code.
+                    | { currentCont = Some (KernelCode []); nextCont = nextCont }
+                    | { currentCont = Some (CompiledCode []); nextCont = nextCont } -> nextCont
+                    | _ -> Some (Continuation (cpr, None, Full))
+                let deferredBody =
+                    match compiledBody with
+                    | Some forms -> CompiledCode forms
+                    | None -> KernelCode body
+                More (fun () ->
+                    continueEvalStep env
+                        (Continuation ({ closure = env; currentCont = Some deferredBody; nextCont = continuationAfterBody; args = None }, metaCont, ct))
+                        Nil)
 
             let newEnv = newEnv [closure]
             match bind newEnv (newContinuation _env) prms (List args) with

--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -301,7 +301,7 @@
 
         let vau _env cont xs = 
             match xs with
-            | prms :: Atom e :: body   -> bounceContinue _env cont (Operative{ prms = prms; envarg = e; body = body; closure = _env} ) 
+            | prms :: Atom e :: body   -> bounceContinue _env cont (Operative{ prms = prms; envarg = e; body = body; closure = _env; compiledBody = None} ) 
             | _ -> fail (Default("invalid arguments"))
 
         let define env cont xs = 

--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -622,3 +622,101 @@ let ``inline cache reports unbound operand variables`` () =
     | Choice1Of2 error -> failwith (showError error)
     | Choice2Of2 _ -> ()
     assertEqv (invokeSite compiled env) (Obj (42 :> obj))
+
+// ADR 0004 phase 2: compiled procedure bodies live in the continuation as a list
+// of compiled forms. Phase 3 fills `compiledBody` in automatically; these build it
+// by hand so the representation and its tail-call rule are exercised now.
+
+/// Compiles each source form and adapts it to the plain function `CompiledCode` holds.
+let private compiledBody env sources =
+    sources
+    |> List.map (fun source ->
+        let compiled = compileLispValGuarded env (parseOk source)
+        fun (e: LispVal) (c: LispVal) -> compiled.Invoke(e, c))
+
+/// Defines `name` as an applicative whose body is compiled rather than interpreted.
+let private defineCompiledProcedure env name formals sources =
+    let operative =
+        Operative
+            { prms = parseOk formals
+              envarg = "_"
+              body = List.map parseOk sources
+              closure = env
+              compiledBody = Some(compiledBody env sources) }
+    match defineVar env name (Applicative operative) with
+    | Choice1Of2 error -> failwith (showError error)
+    | Choice2Of2 _ -> ()
+
+[<Fact>]
+let ``compiled body runs its forms in order and yields the last value`` () =
+    let env = freshEnv ()
+    defineCompiledProcedure env "run" "()" [ "(define a 1)"; "(define b 2)"; "(+ a b)" ]
+    assertEval env "(run)" (Obj (3 :> obj))
+
+[<Fact>]
+let ``compiled body propagates errors from any form`` () =
+    let env = freshEnv ()
+    defineCompiledProcedure env "run" "()" [ "(define a 1)"; "missing"; "(define b 2)" ]
+    match evalRaw Compiled env "(run)" with
+    | Choice1Of2 (UnboundVar (_, "missing")) -> ()
+    | result -> failwithf "unexpected error result: %A" result
+
+[<Fact>]
+let ``compiled body sees its own frame and the caller's arguments`` () =
+    let env = freshEnv ()
+    defineCompiledProcedure env "twice" "(n)" [ "(+ n n)" ]
+    assertEval env "(twice 21)" (Obj (42 :> obj))
+
+/// Length of a continuation's `nextCont` chain. Proper tail calls keep this
+/// bounded; a missed tail call adds one frame per iteration.
+let rec private continuationDepth value =
+    match value with
+    | Continuation (record, _, _) ->
+        match record.nextCont with
+        | Some next -> 1 + continuationDepth next
+        | None -> 1
+    | _ -> 0
+
+[<Fact>]
+let ``self tail call through a compiled body does not grow the continuation`` () =
+    // The last form of a compiled body leaves `CompiledCode []` as the caller's
+    // continuation. If operative application does not treat that as a tail call, a
+    // frame is retained per iteration. The trampoline keeps the CLR stack flat
+    // either way and still returns the right answer, so the leak is only visible in
+    // the continuation captured at the deepest point.
+    withKernel (fun env ->
+        ignore (evalIn env "(define captured (vector 0))")
+        defineCompiledProcedure
+            env
+            "countdown"
+            "(n)"
+            [ "(if (eqv? n 0) (vector-set! captured 0 (call/cc (lambda (k) k))) (countdown (- n 1)))" ]
+
+        let depthAfter iterations =
+            ignore (evalIn env (sprintf "(countdown %d)" iterations))
+            match evalIn env "(vector-ref captured 0)" with
+            | Continuation _ as continuation -> continuationDepth continuation
+            | other -> failwithf "expected a captured continuation, got %A" other
+
+        let shallow = depthAfter 10
+        let deep = depthAfter 1000
+        Assert.Equal(shallow, deep))
+
+[<Fact>]
+let ``continuation captured inside a compiled body resumes the remaining forms`` () =
+    // Resuming re-enters the body part-way through, which is why a body stays a list
+    // of compiled forms rather than one opaque delegate.
+    withKernel (fun env ->
+        ignore (evalIn env "(define store (vector 0))")
+        ignore (evalIn env "(define saved (vector 0))")
+        defineCompiledProcedure
+            env
+            "record"
+            "()"
+            [ "(vector-set! saved 0 (call/cc (lambda (k) k)))"
+              "(vector-set! store 0 (+ (vector-ref store 0) 1))"
+              "(vector-ref store 0)" ]
+
+        assertEval env "(record)" (Obj (1 :> obj))
+        ignore (evalIn env "((vector-ref saved 0) 0)")
+        assertEval env "(vector-ref store 0)" (Obj (2 :> obj)))

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -167,7 +167,7 @@ module Compiler =
                     let bodyLv = List.map toLispVal body
                     completed <-
                         KernelFunc(fun env cont ->
-                            let op = Operative { prms = formals; envarg = envarg; body = bodyLv; closure = env }
+                            let op = Operative { prms = formals; envarg = envarg; body = bodyLv; closure = env; compiledBody = None }
                             bounceContinue env cont op)
                         :: completed
                 | CEval (environmentExpression, valueExpression) ->


### PR DESCRIPTION
Second of four stacked PRs for [ADR 0004](docs/adr/0004-compiling-procedure-bodies.md). **Requires phase 1.**

## What

Adds `CompiledCode` beside `KernelCode` in `DeferredCode`, holding a procedure body as a *list* of compiled forms rather than one delegate. The stepping rule mirrors `KernelCode`: the head form runs against a continuation holding the remaining forms, so the final form inherits `nextCont` and stays in tail position, and a captured continuation can resume mid-body.

Continuation splicing needed **no changes** — `appendContinuationRecord` and `findPrompt` only walk `nextCont` and never inspect the payload of `currentCont`, so `call/cc`, `shift`/`reset`, and `prompt`/`perform`/`resume` are untouched.

It is typed as a plain function, not the compiler's `KernelFunc`, so `IronKernel.Runtime` stays free of a compiler dependency (ADR 0002).

## The bug this exposed

Operative application detects a tail call by observing that the caller's body is exhausted — and matched `KernelCode []` only. A compiled caller reports an exhausted body as `CompiledCode []`, so it fell through and retained a frame on **every tail call out of compiled code**. Now fixed, with the empty-body case shared as `finishDeferredBody`.

## Testing note

This obligation costs heap, not stack. The trampoline keeps the CLR stack flat either way and the program still returns the right answer, so a test that runs many iterations and checks the result passes whether or not the tail call is recognised — I wrote that test twice before noticing.

The test therefore measures it structurally: capture a continuation at the deepest point of a self-recursive compiled body and measure its `nextCont` depth. **13 with the fix, 1003 without** at 1000 iterations. Verified failing before the fix was restored.

`OperativeRecord` gains `compiledBody`, always `None` here; phase 3 fills it lazily. `body` stays authoritative so anything reading a combiner's source, and artifacts built without the compiler, are unaffected.

## Verification

236 tests pass, 0 warnings, diagnostics identical to master, all examples green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789307183&installation_model_id=427656&pr_number=28&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F28&signature=76c3904553e58d7d5931174740dd56fbd1d47287651ffc868581778dfa4015e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CPS evaluation and operative tail-call rules in the trampoline; behavior is well-tested but touches continuation representation and every operative invocation path.
> 
> **Overview**
> Adds **`CompiledCode`** next to **`KernelCode`** in **`DeferredCode`**, storing a procedure body as a list of compiled step functions (not one delegate) so tail calls and mid-body **`call/cc`** resume behave like interpreted bodies. **`OperativeRecord`** gains optional **`compiledBody`** (always **`None`** in this phase; **`body`** stays authoritative).
> 
> The evaluator steps **`CompiledCode`** like **`KernelCode`**, with shared **`finishDeferredBody`** when the form list is exhausted. Operative application now treats **`CompiledCode []`** like **`KernelCode []`** for tail-position continuation inheritance—fixing continuation growth on every tail call out of compiled callers.
> 
> **`vau`** and compiler **`CVau`** set **`compiledBody = None`**. Tests manually attach compiled bodies to exercise ordering, errors, tail-call depth, and continuation resume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86917afa3dd0811eec31d9e3a309c5cfad34bcc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->