### PR TITLE
ADR 0004 phase 3: compile operative bodies lazily

### DIFF
--- a/IronKernel.Runtime/Ast.fs
+++ b/IronKernel.Runtime/Ast.fs
@@ -84,11 +84,12 @@ module Ast =
         envarg  : string;
         body    : LispVal list;
         closure : LispVal
-        /// Compiled form of `body`, used in preference to interpreting it. Always
-        /// `None` today: ADR 0004 phase 3 fills it in lazily on first application.
-        /// `body` stays authoritative so anything reading a combiner's source, and
-        /// any artifact built without the compiler, keeps working.
-        compiledBody : ((LispVal -> LispVal -> Step) list) option
+        /// Compiled form of `body`, used in preference to interpreting it. Filled in
+        /// lazily on first application (ADR 0004). `body` stays authoritative so
+        /// anything reading a combiner's source, and any artifact built without the
+        /// compiler, keeps working. The write is a single reference assignment and
+        /// recompiling is pure, so a race can only duplicate work, never corrupt.
+        mutable compiledBody : ((LispVal -> LispVal -> Step) list) option
     }
     and NativeFuncRecord = { 
         cont : LispVal -> LispVal -> LispVal -> (LispVal list) option -> Step

--- a/IronKernel.Runtime/Eval.fs
+++ b/IronKernel.Runtime/Eval.fs
@@ -12,6 +12,15 @@ module Eval =
     open Contracts
     open ClrSugar
 
+    /// Compiles an operative body to a list of compiled forms, one per body form.
+    /// Installed by the tool: ADR 0002 keeps the compiler out of
+    /// `IronKernel.Runtime`, so artifacts published without it simply keep
+    /// interpreting bodies. Takes the operative's closure environment and its body.
+    let mutable private bodyCompiler
+        : (LispVal -> LispVal list -> (LispVal -> LispVal -> Step) list) option = None
+
+    let configureBodyCompiler compile = bodyCompiler <- Some compile
+
     let inline ok (x: LispVal) : Step = Done (returnM x)
     let inline fail (e: LispError) : Step = Done (throwError e)
     let inline ofResult (r: ThrowsError<LispVal>) : Step = Done r
@@ -283,7 +292,11 @@ module Eval =
                 More (fun () -> operateStep _env resumeCont resumption.continuation [argument])
             | [_] -> fail (Default "resumption has already been consumed")
             | _ -> fail (NumArgs(1, args))
-        | Operative { prms = prms; envarg = envarg; body = body; closure = closure; compiledBody = compiledBody } ->
+        | Operative operative ->
+            let prms = operative.prms
+            let envarg = operative.envarg
+            let body = operative.body
+            let closure = operative.closure
             let evalBody env =
                 let continuationAfterBody =
                     match cpr with
@@ -295,10 +308,22 @@ module Eval =
                     | { currentCont = Some (KernelCode []); nextCont = nextCont }
                     | { currentCont = Some (CompiledCode []); nextCont = nextCont } -> nextCont
                     | _ -> Some (Continuation (cpr, None, Full))
+                // Compile the body on first application and memoise it. Compiling a
+                // form costs less than interpreting it once, so there is nothing to
+                // gain from a hotness heuristic. A compiler failure falls back to
+                // interpretation rather than failing the call.
                 let deferredBody =
-                    match compiledBody with
+                    match operative.compiledBody with
                     | Some forms -> CompiledCode forms
-                    | None -> KernelCode body
+                    | None ->
+                        match bodyCompiler with
+                        | None -> KernelCode body
+                        | Some compile ->
+                            match (try Some(compile closure body) with _ -> None) with
+                            | Some forms ->
+                                operative.compiledBody <- Some forms
+                                CompiledCode forms
+                            | None -> KernelCode body
                 More (fun () ->
                     continueEvalStep env
                         (Continuation ({ closure = env; currentCont = Some deferredBody; nextCont = continuationAfterBody; args = None }, metaCont, ct))

--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -720,3 +720,22 @@ let ``continuation captured inside a compiled body resumes the remaining forms``
         assertEval env "(record)" (Obj (1 :> obj))
         ignore (evalIn env "((vector-ref saved 0) 0)")
         assertEval env "(vector-ref store 0)" (Obj (2 :> obj)))
+
+[<Fact>]
+let ``operative bodies are compiled on first application`` () =
+    withKernel (fun env ->
+        ignore (evalIn env "(define twice (lambda (n) (+ n n)))")
+        let operativeOf name =
+            match getVar' env name with
+            | Some (Applicative (Operative record)) -> record
+            | other -> failwithf "expected an applicative operative, got %A" other
+
+        // Nothing is compiled until the combiner is actually applied.
+        Assert.True((operativeOf "twice").compiledBody.IsNone)
+        assertEval env "(twice 21)" (Obj (42 :> obj))
+        Assert.True((operativeOf "twice").compiledBody.IsSome)
+
+        // The memo is reused rather than recompiled per call.
+        let compiled = (operativeOf "twice").compiledBody
+        assertEval env "(twice 1)" (Obj (2 :> obj))
+        Assert.Same(Option.get compiled, Option.get (operativeOf "twice").compiledBody))

--- a/IronKernel.Tests/TestHelpers.fs
+++ b/IronKernel.Tests/TestHelpers.fs
@@ -14,6 +14,7 @@ open IronKernel.Parser
 /// Isolated primitive environment (does not share REPL state).
 let freshEnv () =
     IronKernel.RuntimeSourceServices.configure ()
+    installBodyCompiler ()
     makePrimitiveBindings ()
 
 let evalIn env expr =

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -315,6 +315,18 @@ module Compiler =
     let evalCompiled env cont (v: LispVal) =
         compileLispValGuarded env v |> fun f -> run (f.Invoke(env, cont))
 
+    /// Installs body compilation for operative application (ADR 0004 phase 3).
+    /// The runtime cannot reference this assembly, so the tool injects it, exactly
+    /// as `RuntimeSourceServices` injects the parser. Bodies are compiled against
+    /// the operative's closure environment; guards and call-site caches revalidate
+    /// per call, so the child frame each application creates is handled already.
+    let installBodyCompiler () =
+        Eval.configureBodyCompiler (fun closure body ->
+            body
+            |> List.map (fun form ->
+                let compiled = compileLispValGuarded closure form
+                fun (env: LispVal) (cont: LispVal) -> compiled.Invoke(env, cont)))
+
     let analyzeAndCompile (source: string) : ThrowsError<KernelFunc list> =
         match Parser.readExprList source with
         | Choice1Of2 e -> throwError e

--- a/IronKernel/Emit.fs
+++ b/IronKernel/Emit.fs
@@ -85,6 +85,7 @@ module Emit =
 
     let bootstrapEnvForProfile profile =
         RuntimeSourceServices.configure ()
+        Compiler.installBodyCompiler ()
         let env = makePrimitiveBindingsForProfile profile
         let loadFile name =
             let legacyName = Path.ChangeExtension(name, ".scm")

--- a/docs/adr/0004-compiling-procedure-bodies.md
+++ b/docs/adr/0004-compiling-procedure-bodies.md
@@ -98,7 +98,31 @@ managed artifacts to exclude the compiler and FParsec. The body compiler is
 therefore injected the way `RuntimeSourceServices` already injects the parser.
 Artifacts that do not install it fall back to interpretation.
 
-**Phase 4 — revisit analyzer specialization.** Re-measure with
+**Phase 3 outcome.** Bodies are compiled and memoised as designed, but the gain
+is about 1.3% on a body-heavy workload, not the 2.3x-4.0x projected above. The
+projection came from `CompilerBenchmarks` measuring a single flat form, which is
+not representative of a procedure body.
+
+The reason is structural: the compiler never descends into operand position. Every
+combination case in `compileToFunc` converts its operands back to raw `LispVal`
+and hands them to the runtime, because `COperate` deliberately retains operand
+syntax so combiner dispatch can tell operatives from applicatives. Compiling a
+body therefore compiles only the shell of each form; all nested evaluation stays
+interpreted, and nested evaluation is where the time goes.
+
+Across `ControlFlowBenchmarks`, repeated named procedure calls are 15-16% faster
+with 17% less allocation, and continuation-heavy paths are 4-6% slower. That does
+not repay phase 1's cost, so the premise that phase 3 pays for phase 1 does not
+hold as stated.
+
+**Phase 4 — compile operand trees.** The remaining lever is teaching the compiler
+to descend into operands while preserving Kernel's operative/applicative
+distinction: operands may only be pre-compiled once the combiner in operator
+position is known to be applicative, which the binding guards and call-site cache
+already establish. This is a larger change than phases 1-3 and should be measured
+against the same body-heavy workload before being adopted.
+
+**Phase 5 — revisit analyzer specialization.** Re-measure with
 `GuardSpecializationBenchmarks`. Fresh-frame invocation becomes the common case
 once bodies are compiled, and guards measured 12% faster there, so extending
 `PrimitiveIdentity` should be reconsidered then, with evidence.

--- a/docs/adr/0004-compiling-procedure-bodies.md
+++ b/docs/adr/0004-compiling-procedure-bodies.md
@@ -36,8 +36,11 @@ compiled form is therefore a nested trampoline. For one-shot top-level forms thi
 is harmless. For procedure bodies it breaks three guarantees:
 
 - **Proper tail calls.** A tail-recursive procedure one million calls deep runs in
-  constant stack today. Nested trampolines would turn each Kernel tail call into
-  CLR stack growth.
+  constant stack today. Each nested `run` is a loop entered from inside another
+  loop's thunk, so compiling bodies against collapsing functions would turn each
+  Kernel tail call into CLR stack growth. Note this is specific to *nested
+  trampolines*. Once compiled code returns `Step` there is a second, independent
+  tail-call obligation that costs heap rather than stack; see phase 2.
 - **First-class continuations.** `run` collapses `Step` into a value, so a
   continuation captured inside a compiled body cannot escape past that boundary
   or be resumed back into the middle of the body.
@@ -57,16 +60,31 @@ mechanical, and the type checker locates every site. It alters no observable
 behaviour and is validated by the existing suite plus deep tail recursion.
 
 **Phase 2 — represent compiled bodies in continuations.** Add
-`CompiledCode of KernelFunc list` beside `KernelCode` in `DeferredCode` and
-mirror the existing stepping in `continueEvalValidStep`: evaluate the head form,
-retain the remaining forms in `currentCont`, and let the final form inherit
-`nextCont`. Keeping the body a list rather than one opaque delegate is what
-preserves proper tail calls structurally, exactly as the interpreter does.
-`DeferredCode` appears in only ten places across `Ast.fs` and `Eval.fs`, two of
-them its own declaration. `appendContinuationRecord` and
-`findPrompt` manipulate only the `nextCont` chain and never inspect the payload
+`CompiledCode` beside `KernelCode` in `DeferredCode`, holding the body as a list
+of compiled forms. It is typed as a plain function rather than the compiler's
+`KernelFunc` so `IronKernel.Runtime` stays free of a compiler dependency. Mirror
+the existing stepping in `continueEvalValidStep`: evaluate the head form, retain
+the remaining forms in `currentCont`, and let the final form inherit `nextCont`.
+Keeping the body a list rather than one opaque delegate is what preserves proper
+tail calls structurally, exactly as the interpreter does. `appendContinuationRecord`
+and `findPrompt` manipulate only the `nextCont` chain and never inspect the payload
 of `currentCont`, so continuation splicing, `call/cc`, `shift`/`reset`, and
 `prompt`/`perform`/`resume` require no changes.
+
+Operative application detects a tail call by observing that the caller's body is
+exhausted, and matches `KernelCode []` to do it. A compiled caller reports an
+exhausted body as `CompiledCode []`, so that case must be added or a frame is
+retained on every tail call out of compiled code.
+
+This second tail-call obligation costs heap, not stack, and the distinction
+matters for how it is tested. Once compiled code returns `Step`, the trampoline
+keeps the CLR stack flat whether or not the tail call is recognised, and the
+program still computes the right answer; what grows is the retained continuation
+chain. A test that merely runs many iterations and checks the result therefore
+passes either way. The property is only visible structurally: capture a
+continuation at the deepest point of a self-recursive compiled body and measure
+its `nextCont` depth, which stays bounded when the tail call is recognised and
+grows with the iteration count when it is not.
 
 **Phase 3 — compile bodies lazily.** Give `OperativeRecord` a mutable memo and
 compile on first application with `analyzeFormsGuarded` against the closure
@@ -88,7 +106,19 @@ once bodies are compiled, and guards measured 12% faster there, so extending
 ## Consequences
 
 Phases 1 and 2 change no observable behaviour and land independently; the
-performance benefit arrives only with Phase 3. Until then, adding
+performance benefit arrives only with Phase 3. Phase 1 is a measured cost until
+then: threading continuations where nested trampolines previously ran tight inner
+loops costs about 7% on `CompiledGeneric` and 15% on `CompiledFolded`, at 10-27%
+more allocation. If phases 2 and 3 do not land, phase 1 should be reverted rather
+than left in place.
+
+Phase 1 also constrains how a located span may be applied. Errors short-circuit
+the trampoline as `Done` and bypass continuations, so `runLocated` has to inspect
+the step chain. Under CPS that chain also covers everything that runs after the
+form, so a span applied naively reaches past its own form and an operator's span
+swallows errors raised by the operands evaluated after it. Interpreting bounded
+each sub-evaluation with a fresh continuation; the compiled path has to restore
+that boundary explicitly by recording when control passes out of the form. Until then, adding
 `PrimitiveIdentity` cases is a measured pessimization rather than an
 optimization: guards re-resolve the binding by name on every invocation, whereas
 the `COperate` fallback's call-site cache validates by environment reference


### PR DESCRIPTION
Third of four stacked PRs for [ADR 0004](docs/adr/0004-compiling-procedure-bodies.md). **Requires phase 2.**

## What

`OperativeRecord.compiledBody` becomes a memo, filled on first application by a body compiler the tool injects the way `RuntimeSourceServices` injects the parser. Artifacts published without the compiler keep interpreting bodies, and a compiler failure falls back to interpretation rather than failing the call. A test confirms nothing compiles until a combiner is applied, then the memo is reused.

Also corrects two things in ADR 0004 that implementing the earlier phases proved wrong.

## Honest measurement

On its own this is worth **~1.3%** on a body-heavy workload, not the 2.3×–4.0× the ADR projected. Isolated directly: same workload with body compilation on vs off, 22.80 s vs 23.10 s.

Two reasons, both since addressed in phase 4:

- The compiler never descends into operand position — every combination case converts operands back to raw `LispVal`, because `COperate` retains operand syntax so dispatch can distinguish operatives from applicatives. Compiling a body compiles only each form's *shell*.
- `analyzeGuarded` lowered specialized `if`/`define` to `CIntrinsicOperate`, which hands the runtime primitive raw syntax to evaluate through the interpreter, so every conditional in a compiled body stayed interpreted. Phase 4 fixes this.

The 2.3×–4.0× figure came from `CompilerBenchmarks` measuring a single flat form, which is not representative of a procedure body.

**This PR alone does not repay phase 1.** It is a prerequisite for phase 4, which does.

## ADR corrections included

- The tail-call obligation in phase 2 costs retained continuation frames, not CLR stack. The ADR attributed every tail-call obligation to stack growth; that holds only for nested trampolines.
- Records phase 1's measured cost and the located-span boundary CPS made necessary.

## Verification

237 tests pass, 0 warnings, diagnostics identical to master, all examples green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789307186&installation_model_id=427656&pr_number=29&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F29&signature=9f67f0267229ccae6593d86bc592cd29deefd6d4025192b182eceb7cc8fa4dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operative evaluation and continuation representation for compiled bodies; continuation/tail-call behavior is tested but continuation-heavy paths showed small regressions in benchmarks.
> 
> **Overview**
> **ADR 0004 phase 3** adds lazy compilation of operative bodies: `OperativeRecord.compiledBody` is a **mutable memo** filled on **first application** when an injected `bodyCompiler` is configured (`Eval.configureBodyCompiler` / `Compiler.installBodyCompiler`), otherwise bodies stay on `KernelCode`. Compiler failures fall back to interpretation; the memo is reused on later calls.
> 
> The tool wires the compiler like the parser—`installBodyCompiler` in test `freshEnv` and `Emit.bootstrapEnvForProfile`—so runtime-only artifacts keep interpreting. Operative dispatch still treats an exhausted compiled caller as tail (`CompiledCode []`).
> 
> **ADR 0004** is updated with measured phase 3 outcome (~1.3% on body-heavy work, not flat-form benchmarks), rephased plan (operand trees as phase 4), and corrections on heap vs stack tail calls and phase 1 cost.
> 
> A test asserts no compile until apply, then stable memo across calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 623d7984f47b350da55b60fe26979d6c093a88ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->