### PR TITLE
ADR 0004 phase 4: make compiled bodies pay off

### DIFF
--- a/IronKernel.Runtime/RuntimeDispatch.fs
+++ b/IronKernel.Runtime/RuntimeDispatch.fs
@@ -24,28 +24,28 @@ module RuntimeDispatch =
     [<Sealed; AllowNullLiteral>]
     type ResolvedCallSite
         (
-            env: LispVal,
-            path: SymbolTable.VisitedFrame[],
-            cell: BindingCell,
+            resolution: SymbolTable.ChainResolution,
             version: int64,
             combiner: LispVal,
             eagerUnderlying: LispVal voption
         ) =
-        member _.Env = env
-        member _.Path = path
-        member _.Cell = cell
+        member _.Resolution = resolution
         member _.Version = version
         member _.Combiner = combiner
         member _.EagerUnderlying = eagerUnderlying
 
     /// Monomorphic inline cache for a compiled `(name operand ...)` call site.
     ///
-    /// The cache is valid while the invoking environment is the same instance,
-    /// every frame scanned during the original resolution still holds the same
-    /// number of bindings (frames only gain bindings, so an unchanged count
-    /// proves no new definition shadows the resolved cell), and the resolved
-    /// cell's version is unchanged (redefinition bumps it). Any mismatch falls
-    /// back to full resolution and refills the cache.
+    /// The cache is valid while resolving the name from the invoking environment
+    /// would still reach the same frame -- every nearer frame still lacks the name
+    /// and the owning frame is the same object -- and the resolved cell's version is
+    /// unchanged (redefinition bumps it). Any mismatch falls back to full resolution
+    /// and refills the cache.
+    ///
+    /// Validating the chain rather than the environment's identity is what makes the
+    /// cache usable inside a procedure body, where application binds parameters in a
+    /// fresh frame and no two calls ever share an environment instance. Chains that
+    /// are not a simple single-parent walk are dispatched without caching.
     ///
     /// When the cached combiner is an applicative over an ordinary combiner and
     /// every operand is a variable or a self-evaluating value, arguments are
@@ -80,16 +80,8 @@ module RuntimeDispatch =
                 | _ -> ValueNone
 
         let cacheValid (resolved: ResolvedCallSite) env =
-            obj.ReferenceEquals(env, resolved.Env)
-            && resolved.Cell.state.version = resolved.Version
-            && (let path = resolved.Path
-                let mutable consistent = true
-                let mutable index = 0
-                while consistent && index < path.Length do
-                    let entry = path.[index]
-                    consistent <- entry.frame.bindings.Count = entry.bindingCount
-                    index <- index + 1
-                consistent)
+            resolved.Resolution.cell.state.version = resolved.Version
+            && SymbolTable.chainResolutionHolds env name resolved.Resolution
 
         let rec evaluateSimpleOperands env evaluated remaining =
             match remaining with
@@ -113,20 +105,23 @@ module RuntimeDispatch =
             if not (isNull cached) && cacheValid cached env then
                 dispatch cached env cont
             else
-                match SymbolTable.resolveBindingCellWithPath env name with
-                | ValueNone -> Done(throwError (UnboundVar("Getting an unbound variable", name)))
-                | ValueSome(cell, visitedPath) ->
-                    let state = cell.state
+                match SymbolTable.tryResolveAlongChain env name with
+                | ValueSome resolution ->
+                    let state = resolution.cell.state
                     let resolved =
                         ResolvedCallSite(
-                            env,
-                            visitedPath,
-                            cell,
+                            resolution,
                             state.version,
                             state.value,
                             classifyEager state.value)
                     Volatile.Write(&cache, resolved)
                     dispatch resolved env cont
+                // Not a simple chain: dispatch without caching rather than storing a
+                // snapshot that could never be revalidated.
+                | ValueNone ->
+                    match getVar env name with
+                    | Choice1Of2 error -> Done(throwError error)
+                    | Choice2Of2 combiner -> bounceOperate env cont combiner operands
 
     type GeneratedFunc = Func<LispVal, LispVal, Step>
 

--- a/IronKernel.Runtime/SymbolTable.fs
+++ b/IronKernel.Runtime/SymbolTable.fs
@@ -94,6 +94,69 @@ module SymbolTable =
         bindingCount : int
     }
 
+    /// A resolution along a simple single-parent chain: the cell, the frame holding
+    /// it, and how many frames were skipped to reach it.
+    ///
+    /// Call sites inside a procedure body see a *fresh* frame on every call, because
+    /// application binds parameters in a new environment. A cache keyed on
+    /// environment identity therefore never hits there. Revalidating a chain
+    /// resolution instead costs one dictionary miss per skipped frame and allocates
+    /// nothing, and stays valid as the frame changes.
+    type ChainResolution = {
+        cell : BindingCell
+        owner : EnvironmentRecord
+        depth : int
+    }
+
+    /// `ValueNone` when the walk meets a frame with anything other than exactly one
+    /// environment parent; such chains keep the general resolver.
+    let tryResolveAlongChain env var : ChainResolution voption =
+        let mutable current = env
+        let mutable depth = 0
+        let mutable result = ValueNone
+        let mutable running = true
+        while running do
+            match current with
+            | Environment record ->
+                match record.bindings.TryGetValue var with
+                | true, cell ->
+                    result <- ValueSome { cell = cell; owner = record; depth = depth }
+                    running <- false
+                | _ ->
+                    match record.parents with
+                    | [(Environment _ as parent)] ->
+                        depth <- depth + 1
+                        current <- parent
+                    | _ -> running <- false
+            | _ -> running <- false
+        result
+
+    /// True when resolving `var` from `env` would still reach `resolution.owner`:
+    /// every nearer frame must still lack the name, and the frame at that depth must
+    /// be the same object. Frames only gain bindings, so an absent name stays absent
+    /// unless something defines it, which this check sees.
+    let chainResolutionHolds env var (resolution: ChainResolution) =
+        let mutable current = env
+        let mutable remaining = resolution.depth
+        let mutable holds = false
+        let mutable running = true
+        while running do
+            match current with
+            | Environment record ->
+                if remaining = 0 then
+                    holds <- obj.ReferenceEquals(record, resolution.owner)
+                    running <- false
+                elif record.bindings.ContainsKey var then
+                    running <- false
+                else
+                    match record.parents with
+                    | [(Environment _ as parent)] ->
+                        remaining <- remaining - 1
+                        current <- parent
+                    | _ -> running <- false
+            | _ -> running <- false
+        holds
+
     /// Resolve a binding cell and record every frame scanned before the hit.
     /// Call-site inline caches revalidate against these snapshots instead of
     /// re-walking the environment chain.

--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -160,13 +160,15 @@ let ``partial evaluation handles deeply nested locations`` () =
 let ``environment-aware analysis guards primitive forms`` () =
     let env = freshEnv ()
 
+    // Guarded specialization lowers the sub-forms into Core so a compiled body does
+    // not hand them back to the interpreter.
     match analyzeGuarded env (parseOk "(if #t 1 2)") with
-    | CGuarded (guard, CIntrinsicOperate (PrimitiveIf, _), COperate (CVar "if", _)) ->
+    | CGuarded (guard, CIf (CLit (Bool true), CLit _, CLit _), COperate (CVar "if", _)) ->
         Assert.True(bindingGuardMatches env guard)
     | other -> failwith (showCore other)
 
     match analyzeGuarded env (parseOk "(define answer 42)") with
-    | CGuarded (guard, CIntrinsicOperate (PrimitiveDefine, _), COperate (CVar "define", _)) ->
+    | CGuarded (guard, CDefine (CVar "answer", CLit _), COperate (CVar "define", _)) ->
         Assert.True(bindingGuardMatches env guard)
     | other -> failwith (showCore other)
 

--- a/IronKernel/Analyze.fs
+++ b/IronKernel/Analyze.fs
@@ -76,7 +76,13 @@ module Analyze =
     let analyzeForms (forms: LispVal list) : CoreExpr list =
         List.map analyze forms
 
-    let analyzeGuarded env (value: LispVal) : CoreExpr =
+    /// Specialized `if` and `define` analyze their sub-forms into Core rather than
+    /// leaving them as operands for the runtime primitive. `CIntrinsicOperate` hands
+    /// the primitive raw syntax, which it then evaluates through the interpreter, so
+    /// leaving them there kept every conditional and every definition inside a
+    /// compiled body interpreted. The located analyzer below has always lowered them
+    /// this way; this makes the ordinary path agree.
+    let rec analyzeGuarded env (value: LispVal) : CoreExpr =
         let mutable current = value
         let mutable pendingOperands = []
         let mutable result = None
@@ -91,7 +97,10 @@ module Analyze =
                         Some(
                             CGuarded(
                                 guard,
-                                CIntrinsicOperate(PrimitiveIf, [condition; consequent; alternative]),
+                                CIf(
+                                    analyzeGuarded env condition,
+                                    analyzeGuarded env consequent,
+                                    analyzeGuarded env alternative),
                                 fallback))
                 | None -> result <- Some fallback
             | List (Atom "define" :: [Atom name; rhs] as form) ->
@@ -102,7 +111,7 @@ module Analyze =
                         Some(
                             CGuarded(
                                 guard,
-                                CIntrinsicOperate(PrimitiveDefine, [Atom name; rhs]),
+                                CDefine(CVar name, analyzeGuarded env rhs),
                                 fallback))
                 | None -> result <- Some fallback
             | List (Atom name :: operands) ->
@@ -168,7 +177,7 @@ module Analyze =
                     let expression = analyzeGuarded env (Source.toLispVal located)
                     match located.kind, expression with
                     | Source.LList [_; condition; consequent; alternative],
-                      CGuarded (guard, CIntrinsicOperate (PrimitiveIf, _), fallback) ->
+                      CGuarded (guard, CIf _, fallback) ->
                         pending <-
                             AnalyzeLocated condition
                             :: AnalyzeLocated consequent
@@ -176,7 +185,7 @@ module Analyze =
                             :: BuildLocatedIf(located.span, sourceLine, guard, fallback)
                             :: pending
                     | Source.LList [_; { kind = Source.LAtom name }; rhs],
-                      CGuarded (guard, CIntrinsicOperate (PrimitiveDefine, _), fallback) ->
+                      CGuarded (guard, CDefine _, fallback) ->
                         pending <-
                             AnalyzeLocated rhs
                             :: BuildLocatedDefine(located.span, sourceLine, guard, name, fallback)

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -6,7 +6,6 @@ namespace IronKernel
 module Compiler =
 
     open System
-    open System.Linq.Expressions
     open Ast
     open Errors
     open Ir
@@ -81,51 +80,14 @@ module Compiler =
         static member AppNamed(env: LispVal, cont: LispVal, name: string, operands: LispVal[]) : Step =
             RuntimeDispatch.appNamed env cont name operands
 
-    let private resolveHelper name parameterTypes =
-        let methodInfo =
-            typeof<Helpers>.GetMethod(
-                name,
-                Reflection.BindingFlags.Public ||| Reflection.BindingFlags.Static,
-                null,
-                parameterTypes,
-                null)
-        if isNull methodInfo || methodInfo.ReturnType <> typeof<Step> then
-            invalidOp (sprintf "Compiler helper '%s' has an incompatible signature" name)
-        methodInfo
+    // Plain closures rather than expression trees. `Expression.Lambda(...).Compile()`
+    // costs tens of microseconds per node, which was affordable when only top-level
+    // forms were compiled once. Procedure bodies are compiled per operative
+    // (ADR 0004 phase 3), and combiners built and applied once -- every `let`
+    // expands to one -- would pay that cost with nothing to amortise it against.
+    let private compileLiteral v = KernelFunc(fun env cont -> Helpers.Continue(env, cont, v))
 
-    let private continueMethod =
-        resolveHelper "Continue" [| typeof<LispVal>; typeof<LispVal>; typeof<LispVal> |]
-
-    let private lookupMethod =
-        resolveHelper "Lookup" [| typeof<LispVal>; typeof<LispVal>; typeof<string> |]
-
-    let private ifThenElseMethod =
-        resolveHelper
-            "IfThenElse"
-            [| typeof<LispVal>; typeof<LispVal>; typeof<KernelFunc>; typeof<KernelFunc>; typeof<KernelFunc> |]
-
-    let private appMethod =
-        resolveHelper
-            "App"
-            [| typeof<LispVal>; typeof<LispVal>; typeof<KernelFunc>; typeof<LispVal[]> |]
-
-    let private compileLiteral v =
-        let envP = Expression.Parameter(typeof<LispVal>, "env")
-        let contP = Expression.Parameter(typeof<LispVal>, "cont")
-        let call =
-            Expression.Call(
-                continueMethod,
-                envP, contP, Expression.Constant(v, typeof<LispVal>))
-        Expression.Lambda<KernelFunc>(call, envP, contP).Compile()
-
-    let private compileVariable name =
-        let envP = Expression.Parameter(typeof<LispVal>, "env")
-        let contP = Expression.Parameter(typeof<LispVal>, "cont")
-        let call =
-            Expression.Call(
-                lookupMethod,
-                envP, contP, Expression.Constant(name))
-        Expression.Lambda<KernelFunc>(call, envP, contP).Compile()
+    let private compileVariable name = KernelFunc(fun env cont -> Helpers.Lookup(env, cont, name))
 
     let compileToFunc (expr: CoreExpr) : KernelFunc =
         let mutable pending = [CompileExpression expr]
@@ -225,16 +187,10 @@ module Compiler =
             | BuildIf ->
                 match takeCompleted 3 with
                 | [condition; consequent; alternative] ->
-                    let envP = Expression.Parameter(typeof<LispVal>, "env")
-                    let contP = Expression.Parameter(typeof<LispVal>, "cont")
-                    let call =
-                        Expression.Call(
-                            ifThenElseMethod,
-                            envP, contP,
-                            Expression.Constant(condition),
-                            Expression.Constant(consequent),
-                            Expression.Constant(alternative))
-                    completed <- Expression.Lambda<KernelFunc>(call, envP, contP).Compile() :: completed
+                    completed <-
+                        KernelFunc(fun env cont ->
+                            Helpers.IfThenElse(env, cont, condition, consequent, alternative))
+                        :: completed
                 | _ -> invalidOp "Conditional compilation is incomplete"
             | BuildSequence count ->
                 let functions = takeCompleted count |> List.toArray
@@ -255,15 +211,9 @@ module Compiler =
             | BuildApp operands ->
                 match takeCompleted 1 with
                 | [operator] ->
-                    let envP = Expression.Parameter(typeof<LispVal>, "env")
-                    let contP = Expression.Parameter(typeof<LispVal>, "cont")
-                    let call =
-                        Expression.Call(
-                            appMethod,
-                            envP, contP,
-                            Expression.Constant(operator),
-                            Expression.Constant(operands))
-                    completed <- Expression.Lambda<KernelFunc>(call, envP, contP).Compile() :: completed
+                    completed <-
+                        KernelFunc(fun env cont -> Helpers.App(env, cont, operator, operands))
+                        :: completed
                 | _ -> invalidOp "Application compilation is incomplete"
             | BuildOperation operands ->
                 match takeCompleted 1 with

--- a/docs/adr/0004-compiling-procedure-bodies.md
+++ b/docs/adr/0004-compiling-procedure-bodies.md
@@ -138,15 +138,50 @@ One further trap found here: operands must not be partially evaluated. Constant
 folding an operand raises errors from expressions that may never be evaluated, and
 `(and? #f (/ 1 0))` must short-circuit.
 
-**Phase 4 (revised) — make call-site caching work in fresh frames.** The blocker is
-the validation strategy, not how much of the body is compiled. Resolution from a
-call frame walks a short prefix of fresh frames into a stable closure chain, so a
-cache can validate by confirming the name is absent from that prefix and that the
-frame where resolution lands is the same object, instead of demanding the whole
-environment be identical. That reduces the common case to a dictionary miss and a
-reference comparison, and it makes compiled bodies, compiled operands, and binding
-guards all worth having. It is a change to a concurrency-sensitive component and
-should be measured against the same workload before anything else is compiled.
+**Phase 4 (revised) — implemented.** Three changes, each measured separately.
+
+*Call-site validation across fresh frames.* `NamedCallSite` now validates that
+resolving the name from the invoking environment still reaches the same frame --
+every nearer frame still lacks the name, and the owning frame is the same object --
+rather than requiring the environment to be the same instance. Hit rate inside a
+procedure body went from 0% to 67%. Chains that are not a simple single-parent walk
+are dispatched without caching rather than cached and never revalidated.
+
+*Lowering guarded `if` and `define` into Core.* `analyzeGuarded` produced
+`CIntrinsicOperate`, which hands the runtime primitive raw syntax that it then
+evaluates through the interpreter. Every conditional and every definition inside a
+compiled body was therefore interpreted. The located analyzer had always lowered
+them to `CIf` and `CDefine`; the ordinary path now agrees.
+
+*Plain closures instead of expression trees.* `Expression.Lambda(...).Compile()`
+costs tens of microseconds per node. That was affordable when only top-level forms
+were compiled once, but phase 3 compiles a body per operative, and a combiner built
+and applied once -- every `let` expands to one -- has nothing to amortise it
+against. Lowering `if` while still emitting expression trees made
+`LambdaLiteralCall` 4.5x slower; replacing them with closures removed that and left
+every benchmark at or better than master.
+
+Compiling operand trees stays rejected. Retried on top of the fixed cache it was
+still 2.4x slower, so the cost is in the dispatch path rather than in cache misses,
+and it needs profiling rather than another attempt.
+
+## Results
+
+Against master, with 237 tests passing and diagnostics byte-identical:
+
+| Measurement | master | now |
+|---|---|---|
+| Body-heavy workload | 23.0 s | 20.5 s (-11%) |
+| `NamedLambdaCall` | 905 ns | 695 ns (-23%) |
+| `NamedVauCall` | 902 ns | 680 ns (-25%) |
+| `DirectEffectHandler` | 1040 ns | 799 ns (-23%) |
+| `EffectHandlerAbort` | 2021 ns | 1774 ns (-12%) |
+| `LambdaLiteralCall` | 29.7 us | 28.9 us (-3%) |
+
+Allocation on a named call falls 22%. Continuation-heavy paths are within 1-2% of
+master. Phase 1's cost on `CompiledGeneric` and `CompiledFolded` remains: those
+measure a single top-level form, where the extra continuation threading is not
+offset by anything a body would gain.
 
 **Phase 5 — revisit analyzer specialization.** Re-measure with
 `GuardSpecializationBenchmarks`. Fresh-frame invocation becomes the common case

--- a/docs/adr/0004-compiling-procedure-bodies.md
+++ b/docs/adr/0004-compiling-procedure-bodies.md
@@ -115,12 +115,38 @@ with 17% less allocation, and continuation-heavy paths are 4-6% slower. That doe
 not repay phase 1's cost, so the premise that phase 3 pays for phase 1 does not
 hold as stated.
 
-**Phase 4 — compile operand trees.** The remaining lever is teaching the compiler
-to descend into operands while preserving Kernel's operative/applicative
-distinction: operands may only be pre-compiled once the combiner in operator
-position is known to be applicative, which the binding guards and call-site cache
-already establish. This is a larger change than phases 1-3 and should be measured
-against the same body-heavy workload before being adopted.
+**Phase 4 — compile operand trees. Attempted and rejected.** Operands were
+compiled and dispatched once the call site resolved to an applicative, preserving
+the operative distinction. It was correct but 2.4x *slower* on the body-heavy
+workload, 55s against 23s, and the cost scaled with iteration count rather than
+being one-time compilation.
+
+Instrumenting the call-site cache during that run explains why, and invalidates
+the premise of phases 3 and 4 together: **0 hits against 150,393 misses**.
+`NamedCallSite.cacheValid` requires `obj.ReferenceEquals(env, resolved.Env)`, and
+every procedure call binds its parameters in a fresh frame, so a call site
+evaluated inside a procedure body never sees the same environment twice. Each
+compiled operand therefore pays full `resolveBindingCellWithPath`, a
+`ResolvedCallSite` allocation, and a volatile publish, where the interpreter pays
+one `getVar'`. Compiling more of the body simply buys more cache misses.
+
+This is the same effect measured earlier by `GuardSpecializationBenchmarks`, where
+guards only paid off against a fresh frame per call, and it is why phase 3 returned
+1.3% rather than the projected multiple.
+
+One further trap found here: operands must not be partially evaluated. Constant
+folding an operand raises errors from expressions that may never be evaluated, and
+`(and? #f (/ 1 0))` must short-circuit.
+
+**Phase 4 (revised) — make call-site caching work in fresh frames.** The blocker is
+the validation strategy, not how much of the body is compiled. Resolution from a
+call frame walks a short prefix of fresh frames into a stable closure chain, so a
+cache can validate by confirming the name is absent from that prefix and that the
+frame where resolution lands is the same object, instead of demanding the whole
+environment be identical. That reduces the common case to a dictionary miss and a
+reference comparison, and it makes compiled bodies, compiled operands, and binding
+guards all worth having. It is a change to a concurrency-sensitive component and
+should be measured against the same workload before anything else is compiled.
 
 **Phase 5 — revisit analyzer specialization.** Re-measure with
 `GuardSpecializationBenchmarks`. Fresh-frame invocation becomes the common case


### PR DESCRIPTION
Last of four stacked PRs for [ADR 0004](docs/adr/0004-compiling-procedure-bodies.md). **Requires phase 3.** This is where the stack becomes net positive against master.

## Results vs master

237 tests pass, 0 warnings, diagnostics byte-identical, all examples green, 1M tail recursion intact.

| Measurement | master | now |
|---|---|---|
| Body-heavy workload | 23.0 s | **20.5 s (−11%)** |
| `NamedLambdaCall` | 905 ns | **695 ns (−23%)** |
| `NamedVauCall` | 902 ns | **680 ns (−25%)** |
| `DirectEffectHandler` | 1040 ns | **799 ns (−23%)** |
| `EffectHandlerAbort` | 2021 ns | **1774 ns (−12%)** |
| `LambdaLiteralCall` | 29.7 µs | 28.9 µs (−3%) |

Allocation on a named call falls 22%. Continuation-heavy paths are within 1–2%.

## Three changes, each measured separately

**Call-site validation across fresh frames.** `NamedCallSite` validated its cache by requiring the invoking environment to be the same *instance*. Application binds parameters in a fresh frame, so a call site inside a procedure body never saw the same environment twice — instrumentation showed **0 hits against 150,393 misses**. It now validates that resolution from the invoking environment still reaches the same frame: every nearer frame still lacks the name, and the owning frame is the same object. That costs one dictionary miss per skipped frame and allocates nothing. Hit rate 0% → 67%. Chains that are not a simple single-parent walk dispatch uncached rather than caching a snapshot that could never revalidate.

**Lowering guarded `if`/`define` into Core.** `analyzeGuarded` produced `CIntrinsicOperate`, which hands the runtime primitive raw syntax that it evaluates through the interpreter — so every conditional and definition inside a compiled body was interpreted. It now lowers them to `CIf`/`CDefine`, which the located analyzer has always done.

**Plain closures instead of expression trees.** Doing the above alone made `LambdaLiteralCall` **4.5× slower**, because `CIf` compiled through `Expression.Lambda(...).Compile()` — tens of microseconds per node. Affordable when only top-level forms compiled once; ruinous now that phase 3 compiles a body per operative and a combiner applied once (every `let` expands to one) has nothing to amortise it against. Literals, variables, conditionals, and applications now compile to plain closures. This also removed the `resolveHelper` reflection plumbing, so `Helpers` is called directly.

## Also included: why compiling operand trees was rejected

The ADR's original phase 4 was implemented and measured **2.4× slower**, with cost scaling per iteration. It was retried on top of the fixed cache — since cache misses were the stated explanation — and was *still* 2.4× slower. So the cost is in the dispatch path itself, not cache misses. It needs profiling rather than another attempt, and the ADR records that.

One trap worth keeping: operands must not be partially evaluated. Constant folding an operand raises errors from expressions that may never run — `(and? #f (/ 1 0))` must short-circuit. The existing stdlib test caught it.

## Remaining

Phase 1's cost on `CompiledGeneric`/`CompiledFolded` (~7–15%) persists. Those measure a single top-level form, where the extra continuation threading is not offset by anything a body would gain. It is now the only place the stack is behind master.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes binding resolution caching and compiled dispatch on every named call in bodies; incorrect chain revalidation could invoke stale combiners, though version checks and shadowing detection mirror prior path semantics.
> 
> **Overview**
> Makes **compiled procedure bodies** net faster against master by fixing why named-call inline caches never hit inside bodies, fully compiling guarded `if`/`define`, and dropping per-node expression-tree compilation.
> 
> **Call-site cache (`NamedCallSite`).** Cache entries now store a **`ChainResolution`** (owning frame + depth) instead of environment identity and a visited-frame path. Revalidation uses **`chainResolutionHolds`** so each fresh parameter frame can still hit when resolution would reach the same owner frame. Non–single-parent chains skip caching and fall back to **`getVar`**.
> 
> **Analyzer (`analyzeGuarded`).** Guarded **`if`** and **`define`** lower to **`CIf`** / **`CDefine`** with analyzed sub-expressions, matching the located path—so bodies no longer route every conditional and definition through **`CIntrinsicOperate`** and the interpreter.
> 
> **Compiler.** Literals, variables, conditionals, and applications compile to **`KernelFunc`** closures instead of **`Expression.Lambda(...).Compile()`**, removing reflection **`resolveHelper`** plumbing and the tens-of-microseconds-per-node compile cost that hurt per-operative body compilation.
> 
> The ADR documents rejected **operand-tree compilation** (still ~2.4× slower even with the fixed cache) and records benchmark wins (~11% body-heavy workload, ~22–25% on named calls).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a47bcf53324f91fd2dab76c63dd7fc3d6b7f0b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789307194&installation_model_id=427656&pr_number=30&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F30&signature=d5ef175479b4f2027a890440340d96370c9b11a421aef0befab7bbedb0d4aea4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->