### PR TITLE
ADR 0004 phases 2-4: land the rest of the stack on master

### DIFF
--- a/IronKernel.Runtime/Ast.fs
+++ b/IronKernel.Runtime/Ast.fs
@@ -84,11 +84,12 @@ module Ast =
         envarg  : string;
         body    : LispVal list;
         closure : LispVal
-        /// Compiled form of `body`, used in preference to interpreting it. Always
-        /// `None` today: ADR 0004 phase 3 fills it in lazily on first application.
-        /// `body` stays authoritative so anything reading a combiner's source, and
-        /// any artifact built without the compiler, keeps working.
-        compiledBody : ((LispVal -> LispVal -> Step) list) option
+        /// Compiled form of `body`, used in preference to interpreting it. Filled in
+        /// lazily on first application (ADR 0004). `body` stays authoritative so
+        /// anything reading a combiner's source, and any artifact built without the
+        /// compiler, keeps working. The write is a single reference assignment and
+        /// recompiling is pure, so a race can only duplicate work, never corrupt.
+        mutable compiledBody : ((LispVal -> LispVal -> Step) list) option
     }
     and NativeFuncRecord = { 
         cont : LispVal -> LispVal -> LispVal -> (LispVal list) option -> Step

--- a/IronKernel.Runtime/Ast.fs
+++ b/IronKernel.Runtime/Ast.fs
@@ -79,11 +79,16 @@ module Ast =
         resume : ThrowsError<LispVal> -> Step
     }
 
-    and OperativeRecord = { 
+    and OperativeRecord = {
         prms    : LispVal ;
         envarg  : string;
-        body    : LispVal list; 
+        body    : LispVal list;
         closure : LispVal
+        /// Compiled form of `body`, used in preference to interpreting it. Always
+        /// `None` today: ADR 0004 phase 3 fills it in lazily on first application.
+        /// `body` stays authoritative so anything reading a combiner's source, and
+        /// any artifact built without the compiler, keeps working.
+        compiledBody : ((LispVal -> LispVal -> Step) list) option
     }
     and NativeFuncRecord = { 
         cont : LispVal -> LispVal -> LispVal -> (LispVal list) option -> Step
@@ -91,6 +96,13 @@ module Ast =
     }
     and DeferredCode =
         | KernelCode of (LispVal list)
+        /// A compiled procedure body, kept as a *list* of compiled forms rather
+        /// than one delegate. Continuation capture and the stepping rule both work
+        /// on the remaining-forms tail, so keeping the list preserves proper tail
+        /// calls and lets a captured continuation resume mid-body, exactly as
+        /// `KernelCode` does. Typed as a plain function so `IronKernel.Runtime`
+        /// stays independent of the compiler (ADR 0002).
+        | CompiledCode of (LispVal -> LispVal -> Step) list
         | NativeCode of NativeFuncRecord
     and ContinuationRecord = {
         closure     : LispVal

--- a/IronKernel.Runtime/Eval.fs
+++ b/IronKernel.Runtime/Eval.fs
@@ -12,6 +12,15 @@ module Eval =
     open Contracts
     open ClrSugar
 
+    /// Compiles an operative body to a list of compiled forms, one per body form.
+    /// Installed by the tool: ADR 0002 keeps the compiler out of
+    /// `IronKernel.Runtime`, so artifacts published without it simply keep
+    /// interpreting bodies. Takes the operative's closure environment and its body.
+    let mutable private bodyCompiler
+        : (LispVal -> LispVal list -> (LispVal -> LispVal -> Step) list) option = None
+
+    let configureBodyCompiler compile = bodyCompiler <- Some compile
+
     let inline ok (x: LispVal) : Step = Done (returnM x)
     let inline fail (e: LispError) : Step = Done (throwError e)
     let inline ofResult (r: ThrowsError<LispVal>) : Step = Done r
@@ -283,7 +292,11 @@ module Eval =
                 More (fun () -> operateStep _env resumeCont resumption.continuation [argument])
             | [_] -> fail (Default "resumption has already been consumed")
             | _ -> fail (NumArgs(1, args))
-        | Operative { prms = prms; envarg = envarg; body = body; closure = closure; compiledBody = compiledBody } ->
+        | Operative operative ->
+            let prms = operative.prms
+            let envarg = operative.envarg
+            let body = operative.body
+            let closure = operative.closure
             let evalBody env =
                 let continuationAfterBody =
                     match cpr with
@@ -295,10 +308,22 @@ module Eval =
                     | { currentCont = Some (KernelCode []); nextCont = nextCont }
                     | { currentCont = Some (CompiledCode []); nextCont = nextCont } -> nextCont
                     | _ -> Some (Continuation (cpr, None, Full))
+                // Compile the body on first application and memoise it. Compiling a
+                // form costs less than interpreting it once, so there is nothing to
+                // gain from a hotness heuristic. A compiler failure falls back to
+                // interpretation rather than failing the call.
                 let deferredBody =
-                    match compiledBody with
+                    match operative.compiledBody with
                     | Some forms -> CompiledCode forms
-                    | None -> KernelCode body
+                    | None ->
+                        match bodyCompiler with
+                        | None -> KernelCode body
+                        | Some compile ->
+                            match (try Some(compile closure body) with _ -> None) with
+                            | Some forms ->
+                                operative.compiledBody <- Some forms
+                                CompiledCode forms
+                            | None -> KernelCode body
                 More (fun () ->
                     continueEvalStep env
                         (Continuation ({ closure = env; currentCont = Some deferredBody; nextCont = continuationAfterBody; args = None }, metaCont, ct))

--- a/IronKernel.Runtime/Eval.fs
+++ b/IronKernel.Runtime/Eval.fs
@@ -125,22 +125,36 @@ module Eval =
             More (fun () -> f e (Continuation (ncr, metaCont, ct)) value args)
         | Continuation ({ closure = e; currentCont = Some (KernelCode cBody); nextCont = nextCont }, metaCont, ct) ->
             match cBody with
-            | [] ->
-                match nextCont with
-                | Some (Continuation (cr, None, _)) ->
-                    More (fun () -> continueEvalStep e (Continuation (cr, metaCont, ct)) value)
-                | None ->
-                    match metaCont with
-                    | Some frame -> More (fun () -> continueEvalStep e frame.parentCont value)
-                    | None -> ok value
-                | Some _ ->
-                    fail (Default "Internal Error: metacontinuation in wrong position")
+            | [] -> finishDeferredBody e nextCont metaCont ct value
             | p :: tail ->
                 More (fun () ->
                     evalStep e
                         (Continuation ({ closure = e; currentCont = Some (KernelCode tail); nextCont = nextCont; args = None }, metaCont, ct))
                         p)
+        // Same rule as KernelCode: the head form runs against a continuation holding
+        // the remaining forms, so the final form inherits `nextCont` and stays in
+        // tail position.
+        | Continuation ({ closure = e; currentCont = Some (CompiledCode forms); nextCont = nextCont }, metaCont, ct) ->
+            match forms with
+            | [] -> finishDeferredBody e nextCont metaCont ct value
+            | form :: tail ->
+                More (fun () ->
+                    form
+                        e
+                        (Continuation ({ closure = e; currentCont = Some (CompiledCode tail); nextCont = nextCont; args = None }, metaCont, ct)))
         | _ -> fail (TypeMismatch ("continuation", cont))
+
+    /// A deferred body ran out of forms: hand the value to whatever follows.
+    and private finishDeferredBody e nextCont metaCont ct value : Step =
+        match nextCont with
+        | Some (Continuation (cr, None, _)) ->
+            More (fun () -> continueEvalStep e (Continuation (cr, metaCont, ct)) value)
+        | None ->
+            match metaCont with
+            | Some frame -> More (fun () -> continueEvalStep e frame.parentCont value)
+            | None -> ok value
+        | Some _ ->
+            fail (Default "Internal Error: metacontinuation in wrong position")
 
     and evalStep env cont value : Step =
         match env, cont with
@@ -269,26 +283,26 @@ module Eval =
                 More (fun () -> operateStep _env resumeCont resumption.continuation [argument])
             | [_] -> fail (Default "resumption has already been consumed")
             | _ -> fail (NumArgs(1, args))
-        | Operative { prms = prms; envarg = envarg; body = body; closure = closure } ->
+        | Operative { prms = prms; envarg = envarg; body = body; closure = closure; compiledBody = compiledBody } ->
             let evalBody env =
-                match cpr with
-                | { currentCont = Some (KernelCode cBody); nextCont = nextCont } ->
-                    match cBody with
-                    | [] ->
-                        More (fun () ->
-                            continueEvalStep env
-                                (Continuation ({ closure = env; currentCont = Some (KernelCode body); nextCont = nextCont; args = None }, metaCont, ct))
-                                Nil)
-                    | _ ->
-                        More (fun () ->
-                            continueEvalStep env
-                                (Continuation ({ closure = env; currentCont = Some (KernelCode body); nextCont = Some (Continuation (cpr, None, Full)); args = None }, metaCont, ct))
-                                Nil)
-                | _ ->
-                    More (fun () ->
-                        continueEvalStep env
-                            (Continuation ({ closure = env; currentCont = Some (KernelCode body); nextCont = Some (Continuation (cpr, None, Full)); args = None }, metaCont, ct))
-                            Nil)
+                let continuationAfterBody =
+                    match cpr with
+                    // The caller has no forms left to run, so this call is in tail
+                    // position: inherit its continuation instead of stacking a frame
+                    // on it. A compiled caller reports an exhausted body the same way,
+                    // and missing that case would grow the continuation on every tail
+                    // call out of compiled code.
+                    | { currentCont = Some (KernelCode []); nextCont = nextCont }
+                    | { currentCont = Some (CompiledCode []); nextCont = nextCont } -> nextCont
+                    | _ -> Some (Continuation (cpr, None, Full))
+                let deferredBody =
+                    match compiledBody with
+                    | Some forms -> CompiledCode forms
+                    | None -> KernelCode body
+                More (fun () ->
+                    continueEvalStep env
+                        (Continuation ({ closure = env; currentCont = Some deferredBody; nextCont = continuationAfterBody; args = None }, metaCont, ct))
+                        Nil)
 
             let newEnv = newEnv [closure]
             match bind newEnv (newContinuation _env) prms (List args) with

--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -301,7 +301,7 @@
 
         let vau _env cont xs = 
             match xs with
-            | prms :: Atom e :: body   -> bounceContinue _env cont (Operative{ prms = prms; envarg = e; body = body; closure = _env} ) 
+            | prms :: Atom e :: body   -> bounceContinue _env cont (Operative{ prms = prms; envarg = e; body = body; closure = _env; compiledBody = None} ) 
             | _ -> fail (Default("invalid arguments"))
 
         let define env cont xs = 

--- a/IronKernel.Runtime/RuntimeDispatch.fs
+++ b/IronKernel.Runtime/RuntimeDispatch.fs
@@ -24,28 +24,28 @@ module RuntimeDispatch =
     [<Sealed; AllowNullLiteral>]
     type ResolvedCallSite
         (
-            env: LispVal,
-            path: SymbolTable.VisitedFrame[],
-            cell: BindingCell,
+            resolution: SymbolTable.ChainResolution,
             version: int64,
             combiner: LispVal,
             eagerUnderlying: LispVal voption
         ) =
-        member _.Env = env
-        member _.Path = path
-        member _.Cell = cell
+        member _.Resolution = resolution
         member _.Version = version
         member _.Combiner = combiner
         member _.EagerUnderlying = eagerUnderlying
 
     /// Monomorphic inline cache for a compiled `(name operand ...)` call site.
     ///
-    /// The cache is valid while the invoking environment is the same instance,
-    /// every frame scanned during the original resolution still holds the same
-    /// number of bindings (frames only gain bindings, so an unchanged count
-    /// proves no new definition shadows the resolved cell), and the resolved
-    /// cell's version is unchanged (redefinition bumps it). Any mismatch falls
-    /// back to full resolution and refills the cache.
+    /// The cache is valid while resolving the name from the invoking environment
+    /// would still reach the same frame -- every nearer frame still lacks the name
+    /// and the owning frame is the same object -- and the resolved cell's version is
+    /// unchanged (redefinition bumps it). Any mismatch falls back to full resolution
+    /// and refills the cache.
+    ///
+    /// Validating the chain rather than the environment's identity is what makes the
+    /// cache usable inside a procedure body, where application binds parameters in a
+    /// fresh frame and no two calls ever share an environment instance. Chains that
+    /// are not a simple single-parent walk are dispatched without caching.
     ///
     /// When the cached combiner is an applicative over an ordinary combiner and
     /// every operand is a variable or a self-evaluating value, arguments are
@@ -80,16 +80,8 @@ module RuntimeDispatch =
                 | _ -> ValueNone
 
         let cacheValid (resolved: ResolvedCallSite) env =
-            obj.ReferenceEquals(env, resolved.Env)
-            && resolved.Cell.state.version = resolved.Version
-            && (let path = resolved.Path
-                let mutable consistent = true
-                let mutable index = 0
-                while consistent && index < path.Length do
-                    let entry = path.[index]
-                    consistent <- entry.frame.bindings.Count = entry.bindingCount
-                    index <- index + 1
-                consistent)
+            resolved.Resolution.cell.state.version = resolved.Version
+            && SymbolTable.chainResolutionHolds env name resolved.Resolution
 
         let rec evaluateSimpleOperands env evaluated remaining =
             match remaining with
@@ -113,20 +105,23 @@ module RuntimeDispatch =
             if not (isNull cached) && cacheValid cached env then
                 dispatch cached env cont
             else
-                match SymbolTable.resolveBindingCellWithPath env name with
-                | ValueNone -> Done(throwError (UnboundVar("Getting an unbound variable", name)))
-                | ValueSome(cell, visitedPath) ->
-                    let state = cell.state
+                match SymbolTable.tryResolveAlongChain env name with
+                | ValueSome resolution ->
+                    let state = resolution.cell.state
                     let resolved =
                         ResolvedCallSite(
-                            env,
-                            visitedPath,
-                            cell,
+                            resolution,
                             state.version,
                             state.value,
                             classifyEager state.value)
                     Volatile.Write(&cache, resolved)
                     dispatch resolved env cont
+                // Not a simple chain: dispatch without caching rather than storing a
+                // snapshot that could never be revalidated.
+                | ValueNone ->
+                    match getVar env name with
+                    | Choice1Of2 error -> Done(throwError error)
+                    | Choice2Of2 combiner -> bounceOperate env cont combiner operands
 
     type GeneratedFunc = Func<LispVal, LispVal, Step>
 

--- a/IronKernel.Runtime/SymbolTable.fs
+++ b/IronKernel.Runtime/SymbolTable.fs
@@ -94,6 +94,69 @@ module SymbolTable =
         bindingCount : int
     }
 
+    /// A resolution along a simple single-parent chain: the cell, the frame holding
+    /// it, and how many frames were skipped to reach it.
+    ///
+    /// Call sites inside a procedure body see a *fresh* frame on every call, because
+    /// application binds parameters in a new environment. A cache keyed on
+    /// environment identity therefore never hits there. Revalidating a chain
+    /// resolution instead costs one dictionary miss per skipped frame and allocates
+    /// nothing, and stays valid as the frame changes.
+    type ChainResolution = {
+        cell : BindingCell
+        owner : EnvironmentRecord
+        depth : int
+    }
+
+    /// `ValueNone` when the walk meets a frame with anything other than exactly one
+    /// environment parent; such chains keep the general resolver.
+    let tryResolveAlongChain env var : ChainResolution voption =
+        let mutable current = env
+        let mutable depth = 0
+        let mutable result = ValueNone
+        let mutable running = true
+        while running do
+            match current with
+            | Environment record ->
+                match record.bindings.TryGetValue var with
+                | true, cell ->
+                    result <- ValueSome { cell = cell; owner = record; depth = depth }
+                    running <- false
+                | _ ->
+                    match record.parents with
+                    | [(Environment _ as parent)] ->
+                        depth <- depth + 1
+                        current <- parent
+                    | _ -> running <- false
+            | _ -> running <- false
+        result
+
+    /// True when resolving `var` from `env` would still reach `resolution.owner`:
+    /// every nearer frame must still lack the name, and the frame at that depth must
+    /// be the same object. Frames only gain bindings, so an absent name stays absent
+    /// unless something defines it, which this check sees.
+    let chainResolutionHolds env var (resolution: ChainResolution) =
+        let mutable current = env
+        let mutable remaining = resolution.depth
+        let mutable holds = false
+        let mutable running = true
+        while running do
+            match current with
+            | Environment record ->
+                if remaining = 0 then
+                    holds <- obj.ReferenceEquals(record, resolution.owner)
+                    running <- false
+                elif record.bindings.ContainsKey var then
+                    running <- false
+                else
+                    match record.parents with
+                    | [(Environment _ as parent)] ->
+                        remaining <- remaining - 1
+                        current <- parent
+                    | _ -> running <- false
+            | _ -> running <- false
+        holds
+
     /// Resolve a binding cell and record every frame scanned before the hit.
     /// Call-site inline caches revalidate against these snapshots instead of
     /// re-walking the environment chain.

--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -160,13 +160,15 @@ let ``partial evaluation handles deeply nested locations`` () =
 let ``environment-aware analysis guards primitive forms`` () =
     let env = freshEnv ()
 
+    // Guarded specialization lowers the sub-forms into Core so a compiled body does
+    // not hand them back to the interpreter.
     match analyzeGuarded env (parseOk "(if #t 1 2)") with
-    | CGuarded (guard, CIntrinsicOperate (PrimitiveIf, _), COperate (CVar "if", _)) ->
+    | CGuarded (guard, CIf (CLit (Bool true), CLit _, CLit _), COperate (CVar "if", _)) ->
         Assert.True(bindingGuardMatches env guard)
     | other -> failwith (showCore other)
 
     match analyzeGuarded env (parseOk "(define answer 42)") with
-    | CGuarded (guard, CIntrinsicOperate (PrimitiveDefine, _), COperate (CVar "define", _)) ->
+    | CGuarded (guard, CDefine (CVar "answer", CLit _), COperate (CVar "define", _)) ->
         Assert.True(bindingGuardMatches env guard)
     | other -> failwith (showCore other)
 

--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -720,3 +720,22 @@ let ``continuation captured inside a compiled body resumes the remaining forms``
         assertEval env "(record)" (Obj (1 :> obj))
         ignore (evalIn env "((vector-ref saved 0) 0)")
         assertEval env "(vector-ref store 0)" (Obj (2 :> obj)))
+
+[<Fact>]
+let ``operative bodies are compiled on first application`` () =
+    withKernel (fun env ->
+        ignore (evalIn env "(define twice (lambda (n) (+ n n)))")
+        let operativeOf name =
+            match getVar' env name with
+            | Some (Applicative (Operative record)) -> record
+            | other -> failwithf "expected an applicative operative, got %A" other
+
+        // Nothing is compiled until the combiner is actually applied.
+        Assert.True((operativeOf "twice").compiledBody.IsNone)
+        assertEval env "(twice 21)" (Obj (42 :> obj))
+        Assert.True((operativeOf "twice").compiledBody.IsSome)
+
+        // The memo is reused rather than recompiled per call.
+        let compiled = (operativeOf "twice").compiledBody
+        assertEval env "(twice 1)" (Obj (2 :> obj))
+        Assert.Same(Option.get compiled, Option.get (operativeOf "twice").compiledBody))

--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -622,3 +622,101 @@ let ``inline cache reports unbound operand variables`` () =
     | Choice1Of2 error -> failwith (showError error)
     | Choice2Of2 _ -> ()
     assertEqv (invokeSite compiled env) (Obj (42 :> obj))
+
+// ADR 0004 phase 2: compiled procedure bodies live in the continuation as a list
+// of compiled forms. Phase 3 fills `compiledBody` in automatically; these build it
+// by hand so the representation and its tail-call rule are exercised now.
+
+/// Compiles each source form and adapts it to the plain function `CompiledCode` holds.
+let private compiledBody env sources =
+    sources
+    |> List.map (fun source ->
+        let compiled = compileLispValGuarded env (parseOk source)
+        fun (e: LispVal) (c: LispVal) -> compiled.Invoke(e, c))
+
+/// Defines `name` as an applicative whose body is compiled rather than interpreted.
+let private defineCompiledProcedure env name formals sources =
+    let operative =
+        Operative
+            { prms = parseOk formals
+              envarg = "_"
+              body = List.map parseOk sources
+              closure = env
+              compiledBody = Some(compiledBody env sources) }
+    match defineVar env name (Applicative operative) with
+    | Choice1Of2 error -> failwith (showError error)
+    | Choice2Of2 _ -> ()
+
+[<Fact>]
+let ``compiled body runs its forms in order and yields the last value`` () =
+    let env = freshEnv ()
+    defineCompiledProcedure env "run" "()" [ "(define a 1)"; "(define b 2)"; "(+ a b)" ]
+    assertEval env "(run)" (Obj (3 :> obj))
+
+[<Fact>]
+let ``compiled body propagates errors from any form`` () =
+    let env = freshEnv ()
+    defineCompiledProcedure env "run" "()" [ "(define a 1)"; "missing"; "(define b 2)" ]
+    match evalRaw Compiled env "(run)" with
+    | Choice1Of2 (UnboundVar (_, "missing")) -> ()
+    | result -> failwithf "unexpected error result: %A" result
+
+[<Fact>]
+let ``compiled body sees its own frame and the caller's arguments`` () =
+    let env = freshEnv ()
+    defineCompiledProcedure env "twice" "(n)" [ "(+ n n)" ]
+    assertEval env "(twice 21)" (Obj (42 :> obj))
+
+/// Length of a continuation's `nextCont` chain. Proper tail calls keep this
+/// bounded; a missed tail call adds one frame per iteration.
+let rec private continuationDepth value =
+    match value with
+    | Continuation (record, _, _) ->
+        match record.nextCont with
+        | Some next -> 1 + continuationDepth next
+        | None -> 1
+    | _ -> 0
+
+[<Fact>]
+let ``self tail call through a compiled body does not grow the continuation`` () =
+    // The last form of a compiled body leaves `CompiledCode []` as the caller's
+    // continuation. If operative application does not treat that as a tail call, a
+    // frame is retained per iteration. The trampoline keeps the CLR stack flat
+    // either way and still returns the right answer, so the leak is only visible in
+    // the continuation captured at the deepest point.
+    withKernel (fun env ->
+        ignore (evalIn env "(define captured (vector 0))")
+        defineCompiledProcedure
+            env
+            "countdown"
+            "(n)"
+            [ "(if (eqv? n 0) (vector-set! captured 0 (call/cc (lambda (k) k))) (countdown (- n 1)))" ]
+
+        let depthAfter iterations =
+            ignore (evalIn env (sprintf "(countdown %d)" iterations))
+            match evalIn env "(vector-ref captured 0)" with
+            | Continuation _ as continuation -> continuationDepth continuation
+            | other -> failwithf "expected a captured continuation, got %A" other
+
+        let shallow = depthAfter 10
+        let deep = depthAfter 1000
+        Assert.Equal(shallow, deep))
+
+[<Fact>]
+let ``continuation captured inside a compiled body resumes the remaining forms`` () =
+    // Resuming re-enters the body part-way through, which is why a body stays a list
+    // of compiled forms rather than one opaque delegate.
+    withKernel (fun env ->
+        ignore (evalIn env "(define store (vector 0))")
+        ignore (evalIn env "(define saved (vector 0))")
+        defineCompiledProcedure
+            env
+            "record"
+            "()"
+            [ "(vector-set! saved 0 (call/cc (lambda (k) k)))"
+              "(vector-set! store 0 (+ (vector-ref store 0) 1))"
+              "(vector-ref store 0)" ]
+
+        assertEval env "(record)" (Obj (1 :> obj))
+        ignore (evalIn env "((vector-ref saved 0) 0)")
+        assertEval env "(vector-ref store 0)" (Obj (2 :> obj)))

--- a/IronKernel.Tests/TestHelpers.fs
+++ b/IronKernel.Tests/TestHelpers.fs
@@ -14,6 +14,7 @@ open IronKernel.Parser
 /// Isolated primitive environment (does not share REPL state).
 let freshEnv () =
     IronKernel.RuntimeSourceServices.configure ()
+    installBodyCompiler ()
     makePrimitiveBindings ()
 
 let evalIn env expr =

--- a/IronKernel/Analyze.fs
+++ b/IronKernel/Analyze.fs
@@ -76,7 +76,13 @@ module Analyze =
     let analyzeForms (forms: LispVal list) : CoreExpr list =
         List.map analyze forms
 
-    let analyzeGuarded env (value: LispVal) : CoreExpr =
+    /// Specialized `if` and `define` analyze their sub-forms into Core rather than
+    /// leaving them as operands for the runtime primitive. `CIntrinsicOperate` hands
+    /// the primitive raw syntax, which it then evaluates through the interpreter, so
+    /// leaving them there kept every conditional and every definition inside a
+    /// compiled body interpreted. The located analyzer below has always lowered them
+    /// this way; this makes the ordinary path agree.
+    let rec analyzeGuarded env (value: LispVal) : CoreExpr =
         let mutable current = value
         let mutable pendingOperands = []
         let mutable result = None
@@ -91,7 +97,10 @@ module Analyze =
                         Some(
                             CGuarded(
                                 guard,
-                                CIntrinsicOperate(PrimitiveIf, [condition; consequent; alternative]),
+                                CIf(
+                                    analyzeGuarded env condition,
+                                    analyzeGuarded env consequent,
+                                    analyzeGuarded env alternative),
                                 fallback))
                 | None -> result <- Some fallback
             | List (Atom "define" :: [Atom name; rhs] as form) ->
@@ -102,7 +111,7 @@ module Analyze =
                         Some(
                             CGuarded(
                                 guard,
-                                CIntrinsicOperate(PrimitiveDefine, [Atom name; rhs]),
+                                CDefine(CVar name, analyzeGuarded env rhs),
                                 fallback))
                 | None -> result <- Some fallback
             | List (Atom name :: operands) ->
@@ -168,7 +177,7 @@ module Analyze =
                     let expression = analyzeGuarded env (Source.toLispVal located)
                     match located.kind, expression with
                     | Source.LList [_; condition; consequent; alternative],
-                      CGuarded (guard, CIntrinsicOperate (PrimitiveIf, _), fallback) ->
+                      CGuarded (guard, CIf _, fallback) ->
                         pending <-
                             AnalyzeLocated condition
                             :: AnalyzeLocated consequent
@@ -176,7 +185,7 @@ module Analyze =
                             :: BuildLocatedIf(located.span, sourceLine, guard, fallback)
                             :: pending
                     | Source.LList [_; { kind = Source.LAtom name }; rhs],
-                      CGuarded (guard, CIntrinsicOperate (PrimitiveDefine, _), fallback) ->
+                      CGuarded (guard, CDefine _, fallback) ->
                         pending <-
                             AnalyzeLocated rhs
                             :: BuildLocatedDefine(located.span, sourceLine, guard, name, fallback)

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -167,7 +167,7 @@ module Compiler =
                     let bodyLv = List.map toLispVal body
                     completed <-
                         KernelFunc(fun env cont ->
-                            let op = Operative { prms = formals; envarg = envarg; body = bodyLv; closure = env }
+                            let op = Operative { prms = formals; envarg = envarg; body = bodyLv; closure = env; compiledBody = None }
                             bounceContinue env cont op)
                         :: completed
                 | CEval (environmentExpression, valueExpression) ->

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -6,7 +6,6 @@ namespace IronKernel
 module Compiler =
 
     open System
-    open System.Linq.Expressions
     open Ast
     open Errors
     open Ir
@@ -81,51 +80,14 @@ module Compiler =
         static member AppNamed(env: LispVal, cont: LispVal, name: string, operands: LispVal[]) : Step =
             RuntimeDispatch.appNamed env cont name operands
 
-    let private resolveHelper name parameterTypes =
-        let methodInfo =
-            typeof<Helpers>.GetMethod(
-                name,
-                Reflection.BindingFlags.Public ||| Reflection.BindingFlags.Static,
-                null,
-                parameterTypes,
-                null)
-        if isNull methodInfo || methodInfo.ReturnType <> typeof<Step> then
-            invalidOp (sprintf "Compiler helper '%s' has an incompatible signature" name)
-        methodInfo
+    // Plain closures rather than expression trees. `Expression.Lambda(...).Compile()`
+    // costs tens of microseconds per node, which was affordable when only top-level
+    // forms were compiled once. Procedure bodies are compiled per operative
+    // (ADR 0004 phase 3), and combiners built and applied once -- every `let`
+    // expands to one -- would pay that cost with nothing to amortise it against.
+    let private compileLiteral v = KernelFunc(fun env cont -> Helpers.Continue(env, cont, v))
 
-    let private continueMethod =
-        resolveHelper "Continue" [| typeof<LispVal>; typeof<LispVal>; typeof<LispVal> |]
-
-    let private lookupMethod =
-        resolveHelper "Lookup" [| typeof<LispVal>; typeof<LispVal>; typeof<string> |]
-
-    let private ifThenElseMethod =
-        resolveHelper
-            "IfThenElse"
-            [| typeof<LispVal>; typeof<LispVal>; typeof<KernelFunc>; typeof<KernelFunc>; typeof<KernelFunc> |]
-
-    let private appMethod =
-        resolveHelper
-            "App"
-            [| typeof<LispVal>; typeof<LispVal>; typeof<KernelFunc>; typeof<LispVal[]> |]
-
-    let private compileLiteral v =
-        let envP = Expression.Parameter(typeof<LispVal>, "env")
-        let contP = Expression.Parameter(typeof<LispVal>, "cont")
-        let call =
-            Expression.Call(
-                continueMethod,
-                envP, contP, Expression.Constant(v, typeof<LispVal>))
-        Expression.Lambda<KernelFunc>(call, envP, contP).Compile()
-
-    let private compileVariable name =
-        let envP = Expression.Parameter(typeof<LispVal>, "env")
-        let contP = Expression.Parameter(typeof<LispVal>, "cont")
-        let call =
-            Expression.Call(
-                lookupMethod,
-                envP, contP, Expression.Constant(name))
-        Expression.Lambda<KernelFunc>(call, envP, contP).Compile()
+    let private compileVariable name = KernelFunc(fun env cont -> Helpers.Lookup(env, cont, name))
 
     let compileToFunc (expr: CoreExpr) : KernelFunc =
         let mutable pending = [CompileExpression expr]
@@ -225,16 +187,10 @@ module Compiler =
             | BuildIf ->
                 match takeCompleted 3 with
                 | [condition; consequent; alternative] ->
-                    let envP = Expression.Parameter(typeof<LispVal>, "env")
-                    let contP = Expression.Parameter(typeof<LispVal>, "cont")
-                    let call =
-                        Expression.Call(
-                            ifThenElseMethod,
-                            envP, contP,
-                            Expression.Constant(condition),
-                            Expression.Constant(consequent),
-                            Expression.Constant(alternative))
-                    completed <- Expression.Lambda<KernelFunc>(call, envP, contP).Compile() :: completed
+                    completed <-
+                        KernelFunc(fun env cont ->
+                            Helpers.IfThenElse(env, cont, condition, consequent, alternative))
+                        :: completed
                 | _ -> invalidOp "Conditional compilation is incomplete"
             | BuildSequence count ->
                 let functions = takeCompleted count |> List.toArray
@@ -255,15 +211,9 @@ module Compiler =
             | BuildApp operands ->
                 match takeCompleted 1 with
                 | [operator] ->
-                    let envP = Expression.Parameter(typeof<LispVal>, "env")
-                    let contP = Expression.Parameter(typeof<LispVal>, "cont")
-                    let call =
-                        Expression.Call(
-                            appMethod,
-                            envP, contP,
-                            Expression.Constant(operator),
-                            Expression.Constant(operands))
-                    completed <- Expression.Lambda<KernelFunc>(call, envP, contP).Compile() :: completed
+                    completed <-
+                        KernelFunc(fun env cont -> Helpers.App(env, cont, operator, operands))
+                        :: completed
                 | _ -> invalidOp "Application compilation is incomplete"
             | BuildOperation operands ->
                 match takeCompleted 1 with

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -315,6 +315,18 @@ module Compiler =
     let evalCompiled env cont (v: LispVal) =
         compileLispValGuarded env v |> fun f -> run (f.Invoke(env, cont))
 
+    /// Installs body compilation for operative application (ADR 0004 phase 3).
+    /// The runtime cannot reference this assembly, so the tool injects it, exactly
+    /// as `RuntimeSourceServices` injects the parser. Bodies are compiled against
+    /// the operative's closure environment; guards and call-site caches revalidate
+    /// per call, so the child frame each application creates is handled already.
+    let installBodyCompiler () =
+        Eval.configureBodyCompiler (fun closure body ->
+            body
+            |> List.map (fun form ->
+                let compiled = compileLispValGuarded closure form
+                fun (env: LispVal) (cont: LispVal) -> compiled.Invoke(env, cont)))
+
     let analyzeAndCompile (source: string) : ThrowsError<KernelFunc list> =
         match Parser.readExprList source with
         | Choice1Of2 e -> throwError e

--- a/IronKernel/Emit.fs
+++ b/IronKernel/Emit.fs
@@ -85,6 +85,7 @@ module Emit =
 
     let bootstrapEnvForProfile profile =
         RuntimeSourceServices.configure ()
+        Compiler.installBodyCompiler ()
         let env = makePrimitiveBindingsForProfile profile
         let loadFile name =
             let legacyName = Path.ChangeExtension(name, ".scm")

--- a/docs/adr/0004-compiling-procedure-bodies.md
+++ b/docs/adr/0004-compiling-procedure-bodies.md
@@ -138,15 +138,50 @@ One further trap found here: operands must not be partially evaluated. Constant
 folding an operand raises errors from expressions that may never be evaluated, and
 `(and? #f (/ 1 0))` must short-circuit.
 
-**Phase 4 (revised) — make call-site caching work in fresh frames.** The blocker is
-the validation strategy, not how much of the body is compiled. Resolution from a
-call frame walks a short prefix of fresh frames into a stable closure chain, so a
-cache can validate by confirming the name is absent from that prefix and that the
-frame where resolution lands is the same object, instead of demanding the whole
-environment be identical. That reduces the common case to a dictionary miss and a
-reference comparison, and it makes compiled bodies, compiled operands, and binding
-guards all worth having. It is a change to a concurrency-sensitive component and
-should be measured against the same workload before anything else is compiled.
+**Phase 4 (revised) — implemented.** Three changes, each measured separately.
+
+*Call-site validation across fresh frames.* `NamedCallSite` now validates that
+resolving the name from the invoking environment still reaches the same frame --
+every nearer frame still lacks the name, and the owning frame is the same object --
+rather than requiring the environment to be the same instance. Hit rate inside a
+procedure body went from 0% to 67%. Chains that are not a simple single-parent walk
+are dispatched without caching rather than cached and never revalidated.
+
+*Lowering guarded `if` and `define` into Core.* `analyzeGuarded` produced
+`CIntrinsicOperate`, which hands the runtime primitive raw syntax that it then
+evaluates through the interpreter. Every conditional and every definition inside a
+compiled body was therefore interpreted. The located analyzer had always lowered
+them to `CIf` and `CDefine`; the ordinary path now agrees.
+
+*Plain closures instead of expression trees.* `Expression.Lambda(...).Compile()`
+costs tens of microseconds per node. That was affordable when only top-level forms
+were compiled once, but phase 3 compiles a body per operative, and a combiner built
+and applied once -- every `let` expands to one -- has nothing to amortise it
+against. Lowering `if` while still emitting expression trees made
+`LambdaLiteralCall` 4.5x slower; replacing them with closures removed that and left
+every benchmark at or better than master.
+
+Compiling operand trees stays rejected. Retried on top of the fixed cache it was
+still 2.4x slower, so the cost is in the dispatch path rather than in cache misses,
+and it needs profiling rather than another attempt.
+
+## Results
+
+Against master, with 237 tests passing and diagnostics byte-identical:
+
+| Measurement | master | now |
+|---|---|---|
+| Body-heavy workload | 23.0 s | 20.5 s (-11%) |
+| `NamedLambdaCall` | 905 ns | 695 ns (-23%) |
+| `NamedVauCall` | 902 ns | 680 ns (-25%) |
+| `DirectEffectHandler` | 1040 ns | 799 ns (-23%) |
+| `EffectHandlerAbort` | 2021 ns | 1774 ns (-12%) |
+| `LambdaLiteralCall` | 29.7 us | 28.9 us (-3%) |
+
+Allocation on a named call falls 22%. Continuation-heavy paths are within 1-2% of
+master. Phase 1's cost on `CompiledGeneric` and `CompiledFolded` remains: those
+measure a single top-level form, where the extra continuation threading is not
+offset by anything a body would gain.
 
 **Phase 5 — revisit analyzer specialization.** Re-measure with
 `GuardSpecializationBenchmarks`. Fresh-frame invocation becomes the common case

--- a/docs/adr/0004-compiling-procedure-bodies.md
+++ b/docs/adr/0004-compiling-procedure-bodies.md
@@ -115,12 +115,38 @@ with 17% less allocation, and continuation-heavy paths are 4-6% slower. That doe
 not repay phase 1's cost, so the premise that phase 3 pays for phase 1 does not
 hold as stated.
 
-**Phase 4 — compile operand trees.** The remaining lever is teaching the compiler
-to descend into operands while preserving Kernel's operative/applicative
-distinction: operands may only be pre-compiled once the combiner in operator
-position is known to be applicative, which the binding guards and call-site cache
-already establish. This is a larger change than phases 1-3 and should be measured
-against the same body-heavy workload before being adopted.
+**Phase 4 — compile operand trees. Attempted and rejected.** Operands were
+compiled and dispatched once the call site resolved to an applicative, preserving
+the operative distinction. It was correct but 2.4x *slower* on the body-heavy
+workload, 55s against 23s, and the cost scaled with iteration count rather than
+being one-time compilation.
+
+Instrumenting the call-site cache during that run explains why, and invalidates
+the premise of phases 3 and 4 together: **0 hits against 150,393 misses**.
+`NamedCallSite.cacheValid` requires `obj.ReferenceEquals(env, resolved.Env)`, and
+every procedure call binds its parameters in a fresh frame, so a call site
+evaluated inside a procedure body never sees the same environment twice. Each
+compiled operand therefore pays full `resolveBindingCellWithPath`, a
+`ResolvedCallSite` allocation, and a volatile publish, where the interpreter pays
+one `getVar'`. Compiling more of the body simply buys more cache misses.
+
+This is the same effect measured earlier by `GuardSpecializationBenchmarks`, where
+guards only paid off against a fresh frame per call, and it is why phase 3 returned
+1.3% rather than the projected multiple.
+
+One further trap found here: operands must not be partially evaluated. Constant
+folding an operand raises errors from expressions that may never be evaluated, and
+`(and? #f (/ 1 0))` must short-circuit.
+
+**Phase 4 (revised) — make call-site caching work in fresh frames.** The blocker is
+the validation strategy, not how much of the body is compiled. Resolution from a
+call frame walks a short prefix of fresh frames into a stable closure chain, so a
+cache can validate by confirming the name is absent from that prefix and that the
+frame where resolution lands is the same object, instead of demanding the whole
+environment be identical. That reduces the common case to a dictionary miss and a
+reference comparison, and it makes compiled bodies, compiled operands, and binding
+guards all worth having. It is a change to a concurrency-sensitive component and
+should be measured against the same workload before anything else is compiled.
 
 **Phase 5 — revisit analyzer specialization.** Re-measure with
 `GuardSpecializationBenchmarks`. Fresh-frame invocation becomes the common case

--- a/docs/adr/0004-compiling-procedure-bodies.md
+++ b/docs/adr/0004-compiling-procedure-bodies.md
@@ -98,7 +98,31 @@ managed artifacts to exclude the compiler and FParsec. The body compiler is
 therefore injected the way `RuntimeSourceServices` already injects the parser.
 Artifacts that do not install it fall back to interpretation.
 
-**Phase 4 — revisit analyzer specialization.** Re-measure with
+**Phase 3 outcome.** Bodies are compiled and memoised as designed, but the gain
+is about 1.3% on a body-heavy workload, not the 2.3x-4.0x projected above. The
+projection came from `CompilerBenchmarks` measuring a single flat form, which is
+not representative of a procedure body.
+
+The reason is structural: the compiler never descends into operand position. Every
+combination case in `compileToFunc` converts its operands back to raw `LispVal`
+and hands them to the runtime, because `COperate` deliberately retains operand
+syntax so combiner dispatch can tell operatives from applicatives. Compiling a
+body therefore compiles only the shell of each form; all nested evaluation stays
+interpreted, and nested evaluation is where the time goes.
+
+Across `ControlFlowBenchmarks`, repeated named procedure calls are 15-16% faster
+with 17% less allocation, and continuation-heavy paths are 4-6% slower. That does
+not repay phase 1's cost, so the premise that phase 3 pays for phase 1 does not
+hold as stated.
+
+**Phase 4 — compile operand trees.** The remaining lever is teaching the compiler
+to descend into operands while preserving Kernel's operative/applicative
+distinction: operands may only be pre-compiled once the combiner in operator
+position is known to be applicative, which the binding guards and call-site cache
+already establish. This is a larger change than phases 1-3 and should be measured
+against the same body-heavy workload before being adopted.
+
+**Phase 5 — revisit analyzer specialization.** Re-measure with
 `GuardSpecializationBenchmarks`. Fresh-frame invocation becomes the common case
 once bodies are compiled, and guards measured 12% faster there, so extending
 `PrimitiveIdentity` should be reconsidered then, with evidence.

--- a/docs/adr/0004-compiling-procedure-bodies.md
+++ b/docs/adr/0004-compiling-procedure-bodies.md
@@ -36,8 +36,11 @@ compiled form is therefore a nested trampoline. For one-shot top-level forms thi
 is harmless. For procedure bodies it breaks three guarantees:
 
 - **Proper tail calls.** A tail-recursive procedure one million calls deep runs in
-  constant stack today. Nested trampolines would turn each Kernel tail call into
-  CLR stack growth.
+  constant stack today. Each nested `run` is a loop entered from inside another
+  loop's thunk, so compiling bodies against collapsing functions would turn each
+  Kernel tail call into CLR stack growth. Note this is specific to *nested
+  trampolines*. Once compiled code returns `Step` there is a second, independent
+  tail-call obligation that costs heap rather than stack; see phase 2.
 - **First-class continuations.** `run` collapses `Step` into a value, so a
   continuation captured inside a compiled body cannot escape past that boundary
   or be resumed back into the middle of the body.
@@ -57,16 +60,31 @@ mechanical, and the type checker locates every site. It alters no observable
 behaviour and is validated by the existing suite plus deep tail recursion.
 
 **Phase 2 — represent compiled bodies in continuations.** Add
-`CompiledCode of KernelFunc list` beside `KernelCode` in `DeferredCode` and
-mirror the existing stepping in `continueEvalValidStep`: evaluate the head form,
-retain the remaining forms in `currentCont`, and let the final form inherit
-`nextCont`. Keeping the body a list rather than one opaque delegate is what
-preserves proper tail calls structurally, exactly as the interpreter does.
-`DeferredCode` appears in only ten places across `Ast.fs` and `Eval.fs`, two of
-them its own declaration. `appendContinuationRecord` and
-`findPrompt` manipulate only the `nextCont` chain and never inspect the payload
+`CompiledCode` beside `KernelCode` in `DeferredCode`, holding the body as a list
+of compiled forms. It is typed as a plain function rather than the compiler's
+`KernelFunc` so `IronKernel.Runtime` stays free of a compiler dependency. Mirror
+the existing stepping in `continueEvalValidStep`: evaluate the head form, retain
+the remaining forms in `currentCont`, and let the final form inherit `nextCont`.
+Keeping the body a list rather than one opaque delegate is what preserves proper
+tail calls structurally, exactly as the interpreter does. `appendContinuationRecord`
+and `findPrompt` manipulate only the `nextCont` chain and never inspect the payload
 of `currentCont`, so continuation splicing, `call/cc`, `shift`/`reset`, and
 `prompt`/`perform`/`resume` require no changes.
+
+Operative application detects a tail call by observing that the caller's body is
+exhausted, and matches `KernelCode []` to do it. A compiled caller reports an
+exhausted body as `CompiledCode []`, so that case must be added or a frame is
+retained on every tail call out of compiled code.
+
+This second tail-call obligation costs heap, not stack, and the distinction
+matters for how it is tested. Once compiled code returns `Step`, the trampoline
+keeps the CLR stack flat whether or not the tail call is recognised, and the
+program still computes the right answer; what grows is the retained continuation
+chain. A test that merely runs many iterations and checks the result therefore
+passes either way. The property is only visible structurally: capture a
+continuation at the deepest point of a self-recursive compiled body and measure
+its `nextCont` depth, which stays bounded when the tail call is recognised and
+grows with the iteration count when it is not.
 
 **Phase 3 — compile bodies lazily.** Give `OperativeRecord` a mutable memo and
 compile on first application with `analyzeFormsGuarded` against the closure
@@ -88,7 +106,19 @@ once bodies are compiled, and guards measured 12% faster there, so extending
 ## Consequences
 
 Phases 1 and 2 change no observable behaviour and land independently; the
-performance benefit arrives only with Phase 3. Until then, adding
+performance benefit arrives only with Phase 3. Phase 1 is a measured cost until
+then: threading continuations where nested trampolines previously ran tight inner
+loops costs about 7% on `CompiledGeneric` and 15% on `CompiledFolded`, at 10-27%
+more allocation. If phases 2 and 3 do not land, phase 1 should be reverted rather
+than left in place.
+
+Phase 1 also constrains how a located span may be applied. Errors short-circuit
+the trampoline as `Done` and bypass continuations, so `runLocated` has to inspect
+the step chain. Under CPS that chain also covers everything that runs after the
+form, so a span applied naively reaches past its own form and an operator's span
+swallows errors raised by the operands evaluated after it. Interpreting bounded
+each sub-evaluation with a fresh continuation; the compiled path has to restore
+that boundary explicitly by recording when control passes out of the form. Until then, adding
 `PrimitiveIdentity` cases is a measured pessimization rather than an
 optimization: guards re-resolve the binding by name on every invocation, whereas
 the `COperate` fallback's call-site cache validates by environment reference


### PR DESCRIPTION
Carries **ADR 0004 phases 2, 3 and 4** into `master`.

## Why this PR exists

PRs #27–#30 were a stack, and all four show as merged — but only #27 reached `master`. Each of the others merged into *its own base branch* instead:

| PR | merged into | outcome |
|---|---|---|
| #27 | `master` | phase 1 landed |
| #28 | `…phase-1…` | phase 2 stopped there |
| #29 | `…phase-2…` | phase 3 stopped there |
| #30 | `…phase-3…` | phase 4 stopped there |

With stacked PRs each base needs retargeting to `master` once the one below it lands; the bases stayed pointing at the branches, so the content cascaded down the stack rather than up.

Nothing was lost — the merges accumulated everything on the branch this PR is built from. No commits are rewritten or duplicated; #28–#30's merge commits are preserved as history.

## Why it matters

`master` currently has **phase 1 only**, which is the worst state to sit in: phase 1 costs ~7% on `CompiledGeneric` and ~15% on `CompiledFolded`, and every phase that repays it is missing. This PR restores the intended end state.

## What lands

| Measurement | master today (phase 1 only) | with this PR |
|---|---|---|
| Body-heavy workload | 23.0 s | **20.5 s (−11%)** |
| `NamedLambdaCall` | 905 ns | **695 ns (−23%)** |
| `NamedVauCall` | 902 ns | **680 ns (−25%)** |
| `DirectEffectHandler` | 1040 ns | **799 ns (−23%)** |
| `EffectHandlerAbort` | 2021 ns | **1774 ns (−12%)** |
| `LambdaLiteralCall` | 29.7 µs | 28.9 µs (−3%) |

Allocation on a named call falls 22%; continuation-heavy paths stay within 1–2%.

Contents, unchanged from the reviewed PRs:

- **Phase 2** (#28) — `CompiledCode` in `DeferredCode`, plus the tail-call fix in operative application, which recognised only `KernelCode []` and so retained a frame on every tail call out of compiled code.
- **Phase 3** (#29) — lazy, memoised body compilation via an injected compiler, keeping `IronKernel.Runtime` free of a compiler dependency. Worth ~1.3% alone; a prerequisite for phase 4.
- **Phase 4** (#30) — call-site validation across fresh frames (hit rate 0% → 67%), lowering guarded `if`/`define` into Core, and replacing expression trees with plain closures. Also records why compiling operand trees was rejected after two measured attempts.

## Verification

Test-merged into `master`: clean, no conflicts. Clean `--no-incremental` rebuild gives 0 warnings, 0 errors. **237 tests pass.** Diagnostics byte-identical to master across nine erroring programs; all examples green; 1M-deep tail recursion intact.

## After merging

The four stack branches can be deleted. `adr-0004-phase-4-compile-operand-trees` holds only the ADR record of the rejected attempt and is already included here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789308564&installation_model_id=427656&pr_number=31&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F31&signature=eff8f00959bb0cb62c34dd274499d6632042031ff6f8af6affb5dacbd4a2a88d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->