### PR TITLE
Fix stack overflow: analyze guarded forms on an explicit stack

### DIFF
--- a/IronKernel/Analyze.fs
+++ b/IronKernel/Analyze.fs
@@ -19,6 +19,16 @@ module Analyze =
         | BuildEval
         | BuildReset
 
+    /// Guarded analysis runs on an explicit stack. Recursing into the sub-forms of
+    /// `if` and `define` instead would grow the CLR stack with the nesting depth of
+    /// the program being analyzed, and a few thousand nested conditionals is enough
+    /// to overflow it.
+    type private GuardedAnalysisWork =
+        | AnalyzeGuardedForm of LispVal
+        | BuildGuardedIf of BindingGuard * CoreExpr
+        | BuildGuardedDefine of BindingGuard * string * CoreExpr
+        | BuildGuardedOperate of LispVal list
+
     type private LocatedAnalysisWork =
         | AnalyzeLocated of Source.LocatedValue
         | BuildLocatedIf of SourceSpan * string option * BindingGuard * CoreExpr
@@ -76,61 +86,82 @@ module Analyze =
     let analyzeForms (forms: LispVal list) : CoreExpr list =
         List.map analyze forms
 
-    /// Specialized `if` and `define` analyze their sub-forms into Core rather than
+    /// Specialized `if` and `define` lower their sub-forms into Core rather than
     /// leaving them as operands for the runtime primitive. `CIntrinsicOperate` hands
     /// the primitive raw syntax, which it then evaluates through the interpreter, so
     /// leaving them there kept every conditional and every definition inside a
-    /// compiled body interpreted. The located analyzer below has always lowered them
-    /// this way; this makes the ordinary path agree.
-    let rec analyzeGuarded env (value: LispVal) : CoreExpr =
-        let mutable current = value
-        let mutable pendingOperands = []
-        let mutable result = None
+    /// compiled body interpreted. The located analyzer below lowers them the same way.
+    let analyzeGuarded env (value: LispVal) : CoreExpr =
+        let mutable pending = [AnalyzeGuardedForm value]
+        let mutable completed : CoreExpr list = []
 
-        while result.IsNone do
-            match current with
-            | List (Atom "if" :: [condition; consequent; alternative] as form) ->
-                let fallback = COperate(CVar "if", List.tail form)
-                match tryCreateBindingGuard env "if" PrimitiveIf with
-                | Some guard ->
-                    result <-
-                        Some(
-                            CGuarded(
-                                guard,
-                                CIf(
-                                    analyzeGuarded env condition,
-                                    analyzeGuarded env consequent,
-                                    analyzeGuarded env alternative),
-                                fallback))
-                | None -> result <- Some fallback
-            | List (Atom "define" :: [Atom name; rhs] as form) ->
-                let fallback = COperate(CVar "define", List.tail form)
-                match tryCreateBindingGuard env "define" PrimitiveDefine with
-                | Some guard ->
-                    result <-
-                        Some(
-                            CGuarded(
-                                guard,
-                                CDefine(CVar name, analyzeGuarded env rhs),
-                                fallback))
-                | None -> result <- Some fallback
-            | List (Atom name :: operands) ->
-                // Prefer a real binding over CLR call sugar (same rule as Eval).
-                match getVar' env name with
-                | Some _ -> result <- Some(COperate(CVar name, operands))
-                | None ->
-                    match tryRewrite name operands with
-                    | Some rewritten -> current <- rewritten
-                    | None -> result <- Some(COperate(CVar name, operands))
-            | List (op :: operands) ->
-                pendingOperands <- operands :: pendingOperands
-                current <- op
-            | other -> result <- Some(analyze other)
+        let takeCompleted count =
+            let mutable expressions = []
+            for _ in 1..count do
+                match completed with
+                | expression :: rest ->
+                    expressions <- expression :: expressions
+                    completed <- rest
+                | [] -> invalidOp "Guarded analysis stack is incomplete"
+            expressions
 
-        let mutable analyzed = result.Value
-        for operands in pendingOperands do
-            analyzed <- COperate(analyzed, operands)
-        analyzed
+        while not pending.IsEmpty do
+            let work = pending.Head
+            pending <- pending.Tail
+            match work with
+            | AnalyzeGuardedForm form ->
+                match form with
+                | List (Atom "if" :: [condition; consequent; alternative] as whole) ->
+                    let fallback = COperate(CVar "if", List.tail whole)
+                    match tryCreateBindingGuard env "if" PrimitiveIf with
+                    | Some guard ->
+                        pending <-
+                            AnalyzeGuardedForm condition
+                            :: AnalyzeGuardedForm consequent
+                            :: AnalyzeGuardedForm alternative
+                            :: BuildGuardedIf(guard, fallback)
+                            :: pending
+                    | None -> completed <- fallback :: completed
+                | List (Atom "define" :: [Atom name; rhs] as whole) ->
+                    let fallback = COperate(CVar "define", List.tail whole)
+                    match tryCreateBindingGuard env "define" PrimitiveDefine with
+                    | Some guard ->
+                        pending <-
+                            AnalyzeGuardedForm rhs
+                            :: BuildGuardedDefine(guard, name, fallback)
+                            :: pending
+                    | None -> completed <- fallback :: completed
+                | List (Atom name :: operands) ->
+                    // Prefer a real binding over CLR call sugar (same rule as Eval).
+                    match getVar' env name with
+                    | Some _ -> completed <- COperate(CVar name, operands) :: completed
+                    | None ->
+                        match tryRewrite name operands with
+                        | Some rewritten -> pending <- AnalyzeGuardedForm rewritten :: pending
+                        | None -> completed <- COperate(CVar name, operands) :: completed
+                | List (op :: operands) ->
+                    pending <- AnalyzeGuardedForm op :: BuildGuardedOperate operands :: pending
+                | other -> completed <- analyze other :: completed
+            | BuildGuardedIf (guard, fallback) ->
+                match takeCompleted 3 with
+                | [condition; consequent; alternative] ->
+                    completed <-
+                        CGuarded(guard, CIf(condition, consequent, alternative), fallback)
+                        :: completed
+                | _ -> invalidOp "Guarded conditional analysis is incomplete"
+            | BuildGuardedDefine (guard, name, fallback) ->
+                match takeCompleted 1 with
+                | [rhs] ->
+                    completed <- CGuarded(guard, CDefine(CVar name, rhs), fallback) :: completed
+                | _ -> invalidOp "Guarded definition analysis is incomplete"
+            | BuildGuardedOperate operands ->
+                match takeCompleted 1 with
+                | [operator] -> completed <- COperate(operator, operands) :: completed
+                | _ -> invalidOp "Guarded operation analysis is incomplete"
+
+        match completed with
+        | [result] -> result
+        | _ -> invalidOp "Guarded analysis did not produce one expression"
 
     let analyzeFormsGuarded env forms =
         List.map (analyzeGuarded env) forms


### PR DESCRIPTION
Fixes a stack overflow on `master` that I introduced in ADR 0004 phase 4 (#30).

## The bug

Phase 4 lowered specialized `if` and `define` into Core by having `analyzeGuarded` **recurse** into their sub-forms. That grows the CLR stack with the nesting depth of the program being analyzed.

`CompilerTests.located analysis handles deeply nested guarded conditionals` builds 5,000 nested conditionals for exactly this reason, and it now crashes the test host:

```
The active test run was aborted. Reason: Test host process crashed : Stack overflow.
```

Every other traversal in the compiler and analyzer — `CompilationWork`, `ReificationWork`, `LocatedAnalysisWork`, `CoreRenderWork` — is written as an explicit work stack precisely to avoid this. Phase 4 broke that invariant.

## Why it got through review

The failure is marginal, not deterministic. Whether 5,000 frames overflow depends on how much stack the preceding tests have already consumed, so full-suite runs passed repeatedly (237/237, several times) before beginning to abort. It also surfaces at different points each run — after 46, 63, or 100 tests — which reads like flakiness rather than a real defect. I saw one truncated run earlier and wrote it off as a reporting artifact; it was this.

## The fix

`analyzeGuarded` now walks an explicit work stack, matching the rest of the codebase. `AnalyzeGuardedForm` / `BuildGuardedIf` / `BuildGuardedDefine` / `BuildGuardedOperate` replace the recursion; the lowering it produces is unchanged.

## Verification

- The deep-nesting test passes.
- **237 tests pass on three consecutive full runs** (the failure mode required repetition to trust).
- Diagnostics byte-identical to pre-ADR-0004 master across nine erroring programs.
- Body-heavy workload holds at ~21 s against 23 s before ADR 0004, so phase 4's gain is intact.
- Examples green, including the continuation-heavy ones.

## Worth adopting

Deep-nesting stack-safety tests exist for the analyzer and compiler, but the marginal-overflow mode means a single green run does not prove much. Repeating the suite is the cheap guard, and I should have done that before phase 4 merged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789309633&installation_model_id=427656&pr_number=32&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F32&signature=1fca4f7b4dbd2934aaca6295a41a6032632e0a7c8391d8a2e51edf6bb91bbe98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->