### PR TITLE
Make +, * and - variadic (R-1RK 12.5.4-12.5.6)

### DIFF
--- a/IronKernel.Runtime/Arithmetic.fs
+++ b/IronKernel.Runtime/Arithmetic.fs
@@ -80,28 +80,22 @@ namespace IronKernel
                     | 3 -> Singles(toSingle a, toSingle b)
                     | _ -> Doubles(toDouble a, toDouble b))
 
-        /// `validate` rejects operand combinations for which the operation is undefined,
-        /// before the CLR is asked to perform it. The `try` is a backstop for the rest:
-        /// integer division can still overflow (Int32.MinValue / -1), and an escaping
-        /// CLR exception would fault the process rather than raise a Kernel error.
-        let private numericBinaryOpWith validate apply (a': LispVal) (b': LispVal) =
+        /// No exception handler and no validation hook on this path. F# addition,
+        /// subtraction and multiplication are unchecked and wrap rather than raise, so
+        /// a handler would guard against nothing while sitting on the hottest operation
+        /// in the language; division is the only arithmetic that can raise, and it is
+        /// implemented separately below with its own checks.
+        let private numericBinaryOp apply (a': LispVal) (b': LispVal) =
             match a', b' with
             | Obj a, Obj b ->
                 match widen a b with
-                | Choice2Of2 widened ->
-                    match validate widened with
-                    | Some error -> throwError error
-                    | None ->
-                        try returnM (Obj(apply widened))
-                        with ex -> throwError (ClrException ex)
+                | Choice2Of2 widened -> returnM (Obj(apply widened))
                 | Choice1Of2 FirstOperand ->
                     throwError (ClrTypeMismatch("number", a.GetType().Name))
                 | Choice1Of2 SecondOperand ->
                     throwError (ClrTypeMismatch(rankName (rankOf a), b.GetType().Name))
             | Obj _, found -> throwError (TypeMismatch("object", found))
             | found, _ -> throwError (TypeMismatch("object", found))
-
-        let private numericBinaryOp apply = numericBinaryOpWith (fun _ -> None) apply
 
         let private comparisonBinaryOp apply (a': LispVal) (b': LispVal) =
             match a', b' with
@@ -187,13 +181,29 @@ namespace IronKernel
         /// division throws, and floating-point division quietly yields an infinity,
         /// which the report rejects because the limit depends on the direction zero
         /// is approached from.
+        /// Division is the one arithmetic operation the CLR can still raise from once a
+        /// zero divisor is excluded: Int32.MinValue / -1 has no representable result.
+        /// An escaping exception would fault the process, so this path keeps a handler.
+        let private guardedDivide widened =
+            try Choice2Of2(divideWidened widened)
+            with ex -> Choice1Of2 ex
+
         let opDivide a' b' =
-            numericBinaryOpWith
-                (fun widened ->
-                    if divisorIsZero widened then Some(Default "division by zero") else None)
-                divideWidened
-                a'
-                b'
+            match a', b' with
+            | Obj a, Obj b ->
+                match widen a b with
+                | Choice2Of2 widened when divisorIsZero widened ->
+                    throwError (Default "division by zero")
+                | Choice2Of2 widened ->
+                    match guardedDivide widened with
+                    | Choice2Of2 result -> returnM (Obj result)
+                    | Choice1Of2 ex -> throwError (ClrException ex)
+                | Choice1Of2 FirstOperand ->
+                    throwError (ClrTypeMismatch("number", a.GetType().Name))
+                | Choice1Of2 SecondOperand ->
+                    throwError (ClrTypeMismatch(rankName (rankOf a), b.GetType().Name))
+            | Obj _, found -> throwError (TypeMismatch("object", found))
+            | found, _ -> throwError (TypeMismatch("object", found))
 
         let opLessThan a' b' = comparisonBinaryOp lessThanWidened a' b'
         let opLessThanOrEqual a' b' = comparisonBinaryOp lessThanOrEqualWidened a' b'

--- a/IronKernel.Runtime/Ast.fs
+++ b/IronKernel.Runtime/Ast.fs
@@ -64,6 +64,11 @@ module Ast =
         effect : ContractEffect
         inlineable : bool
         trust : ContractTrust
+        /// `None` fixes the arity at `operands.Length`. `Some n` accepts n or more
+        /// arguments, matching argument i against `operands[i]` and every argument
+        /// past the end against the last declared shape. R-1RK's arithmetic is
+        /// variadic ((+ . numbers)), so a fixed arity cannot describe it.
+        minimumOperands : int option
     }
 
     type ContinuationType = Full | Delimited

--- a/IronKernel.Runtime/Contracts.fs
+++ b/IronKernel.Runtime/Contracts.fs
@@ -57,17 +57,35 @@ module Contracts =
     let validateArguments contract args =
         let expectedCount = List.length contract.operands
         let actualCount = List.length args
-        if expectedCount <> actualCount then
-            Some(
-                ContractViolation(
-                    sprintf
-                        "%s expected %d operands, found %d"
-                        contract.name
-                        expectedCount
-                        actualCount))
-        else
+        let arityError =
+            match contract.minimumOperands with
+            | Some minimum when actualCount < minimum ->
+                Some(
+                    ContractViolation(
+                        sprintf
+                            "%s expected at least %d operands, found %d"
+                            contract.name
+                            minimum
+                            actualCount))
+            | Some _ -> None
+            | None when expectedCount <> actualCount ->
+                Some(
+                    ContractViolation(
+                        sprintf
+                            "%s expected %d operands, found %d"
+                            contract.name
+                            expectedCount
+                            actualCount))
+            | None -> None
+        match arityError with
+        | Some error -> Some error
+        | None ->
             let rec validate index shapes values =
                 match shapes, values with
+                // A variadic contract runs out of declared shapes before it runs out
+                // of arguments; the last shape describes the rest.
+                | [lastShape], (_ :: _ :: _ as values) when contract.minimumOperands.IsSome ->
+                    validate index (List.replicate (List.length values) lastShape) values
                 | shape :: remainingShapes, value :: remainingValues ->
                     if shapeMatches shape value then
                         validate (index + 1) remainingShapes remainingValues
@@ -136,7 +154,12 @@ module Contracts =
             cell.id = guard.cellId
             && state.version = guard.version
             && (tryGetContract state.value
-                |> Option.exists (fun contract -> contract = guard.contractSnapshot))
+                |> Option.exists (fun contract ->
+                    // Reference equality first: a contract is almost always the same
+                    // instance the guard captured, and structural equality walks every
+                    // field of the record on each invocation of a folded constant.
+                    obj.ReferenceEquals(contract, guard.contractSnapshot)
+                    || contract = guard.contractSnapshot))
         | ValueNone -> false
 
     let certifiedApplicative name operands result =
@@ -146,4 +169,10 @@ module Contracts =
           result = result
           effect = Pure
           inlineable = true
-          trust = Certified }
+          trust = Certified
+          minimumOperands = None }
+
+    /// A certified applicative accepting `minimum` or more arguments. Arguments past
+    /// the declared shapes are matched against the last one.
+    let certifiedVariadicApplicative name operands minimum result =
+        { certifiedApplicative name operands result with minimumOperands = Some minimum }

--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -427,7 +427,8 @@
                           result = result
                           effect = effect
                           inlineable = inlineable
-                          trust = Asserted }
+                          trust = Asserted
+                          minimumOperands = None }
                     match Contracts.attach contract value with
                     | Some contracted ->
                         match defineVar env name contracted with
@@ -634,9 +635,44 @@
             | [found; _] -> fail (TypeMismatch("non-negative int", found))
             | bad -> fail (NumArgs(2, bad))
 
-        let plus env cont args = numericBinOp env cont opAdd args
-        let minus env cont args = numericBinOp env cont opMinus args
-        let times env cont args = numericBinOp env cont opMultiply args
+        /// R-1RK 12.5.4 / 12.5.5: (+ . numbers) and (* . numbers) are variadic, with
+        /// the empty sum zero and the empty product one. Folding left keeps the CLR
+        /// extensions working -- (+ date timespan) is still a DateTime -- because each
+        /// step is the same binary operation as before.
+        let private foldNumeric op identity env cont args =
+            match args with
+            | [] -> bounceContinue env cont (Obj identity)
+            | first :: rest ->
+                let rec loop acc = function
+                    | [] -> bounceContinue env cont acc
+                    | next :: remaining ->
+                        match op acc next with
+                        | Choice2Of2 result -> loop result remaining
+                        | Choice1Of2 error -> fail error
+                loop first rest
+
+        /// The binary case is matched directly. Two arguments is overwhelmingly the
+        /// common shape, and routing it through the fold costs a closure and a list
+        /// traversal on the hottest path in the language.
+        let inline private binaryOrFold op identity env cont args =
+            match args with
+            | [a; b] ->
+                match op a b with
+                | Choice2Of2 result -> bounceContinue env cont result
+                | Choice1Of2 error -> fail error
+            | _ -> foldNumeric op identity env cont args
+
+        let plus env cont args = binaryOrFold opAdd (box 0) env cont args
+        let times env cont args = binaryOrFold opMultiply (box 1) env cont args
+
+        /// R-1RK 12.5.6: (- number . numbers) needs at least two arguments. The report
+        /// declines to give `-` a unary meaning, so that negation is not silently
+        /// spelled the same way as subtraction.
+        let minus env cont args =
+            match args with
+            | [_; _] -> binaryOrFold opMinus (box 0) env cont args
+            | _ :: _ :: _ -> foldNumeric opMinus (box 0) env cont args
+            | _ -> fail (NumArgs(2, args))
         let divide env cont args = numericBinOp env cont opDivide args
         let lessThan env cont args = numBoolBinop env cont opLessThan args
         let lessThanOrEqual env cont args = numBoolBinop env cont opLessThanOrEqual args
@@ -768,19 +804,23 @@
                     // in a validation continuation, which these hot paths avoid.
                     | "+" ->
                         Some(
-                            certifiedApplicative
+                            certifiedVariadicApplicative
                                 name
                                 [ OneOfShape [NumberShape; DateTimeShape]
                                   OneOfShape [NumberShape; TimeSpanShape] ]
+                                0
                                 AnyShape)
                     | "-" ->
                         Some(
-                            certifiedApplicative
+                            certifiedVariadicApplicative
                                 name
                                 [ OneOfShape [NumberShape; DateTimeShape]
                                   OneOfShape [NumberShape; DateTimeShape] ]
+                                2
                                 AnyShape)
-                    | "*" | "/" ->
+                    | "*" ->
+                        Some(certifiedVariadicApplicative name [NumberShape; NumberShape] 0 NumberShape)
+                    | "/" ->
                         Some(certifiedApplicative name [NumberShape; NumberShape] NumberShape)
                     | "<" | "<=" | ">" ->
                         Some(certifiedApplicative name [NumberShape; NumberShape] BooleanShape)

--- a/IronKernel.Tests/ArithmeticTests.fs
+++ b/IronKernel.Tests/ArithmeticTests.fs
@@ -192,3 +192,38 @@ let ``numeric comparison is not structural equality`` () =
         assertEval env "(=? 1 1.0)" (Bool true)
         // eqv? compares representations, so it disagrees -- that is expected.
         assertEval env "(eqv? 1 1.0)" (Bool false))
+
+[<Fact>]
+let ``arithmetic is variadic with the report's identities`` () =
+    // R-1RK 12.5.4/12.5.5: (+ . numbers) and (* . numbers), empty sum zero and
+    // empty product one.
+    [
+        "(+)", Obj 0
+        "(*)", Obj 1
+        "(+ 7)", Obj 7
+        "(* 7)", Obj 7
+        "(+ 1 2 3 4 5)", Obj 15
+        "(* 1 2 3 4)", Obj 24
+        "(- 10 3 2)", Obj 5
+    ] |> evalSession
+
+[<Fact>]
+let ``minus keeps a minimum arity of two`` () =
+    // R-1RK 12.5.6 gives `-` no unary meaning, so that negation is not spelled the
+    // same way as subtraction.
+    let env = freshEnv ()
+    match evalIn env "(- 5)" with
+    | Status message -> Assert.Contains("at least 2 operands", message)
+    | value -> failwithf "(- 5) should signal an error, got %s" (showVal value)
+
+[<Fact>]
+let ``variadic addition preserves the datetime extension`` () =
+    // Folding left keeps (+ date timespan) working, and repeating the timespan
+    // stays well typed because each step is the same binary operation.
+    withKernel (fun env ->
+        ignore (evalIn env "(define d (new System.DateTime 2020 1 1))")
+        ignore (evalIn env "(define ts (new System.TimeSpan 24 0 0))")
+        // Compared as elapsed hours rather than by object equality, which keeps the
+        // assertion about arithmetic instead of about CLR equality semantics.
+        assertEval env "(=? (.get (- (+ d ts) d) TotalHours) 24.0)" (Bool true)
+        assertEval env "(=? (.get (- (+ d ts ts) d) TotalHours) 48.0)" (Bool true))

--- a/IronKernel.Tests/ConformanceTests.fs
+++ b/IronKernel.Tests/ConformanceTests.fs
@@ -62,7 +62,9 @@ let ``generated malformed expressions preserve interpreter compiler errors`` () 
             let number = generateNumber random 2 []
             let operator = choose random ["+"; "-"; "*"]
             match index % 6 with
-            | 0 -> $"({operator} {number})"
+            // `-` keeps a minimum arity of two (R-1RK 12.5.6); `+` and `*` are
+            // variadic, so a single argument is well formed for them.
+            | 0 -> $"(- {number})"
             | 1 -> $"({operator} #t {number})"
             | 2 -> $"(if {number} 1 2)"
             | 3 -> $"(car {number})"
@@ -104,7 +106,7 @@ let ``interpreter and compiler agree on core evaluation`` () =
 [<Fact>]
 let ``interpreter and compiler report structured errors without corrupting state`` () =
     let cases =
-        [ "(+ 1)", (function ContractViolation "+ expected 2 operands, found 1" -> true | _ -> false)
+        [ "(- 1)", (function ContractViolation "- expected at least 2 operands, found 1" -> true | _ -> false)
           "(car 42)", (function TypeMismatch ("pair", Obj _) -> true | _ -> false)
           "(if 1 2 3)", (function TypeMismatch ("bool", Obj _) -> true | _ -> false)
           "missing", (function UnboundVar (_, "missing") -> true | _ -> false)
@@ -202,3 +204,13 @@ let ``guarded if preserves continuation context`` () =
           "(define saved #f)"
           "(+ 10 (if (call/cc (lambda (k) (begin (define saved k) #t))) 1 2))"
           "(saved #f)" ]
+
+[<Fact>]
+let ``interpreter and compiler agree on variadic arithmetic`` () =
+    // R-1RK 12.5.4/12.5.5 make + and * variadic, with the empty sum zero and the
+    // empty product one. These arities used to be contract violations.
+    assertParitySession
+        [ "(load \"kernel.ikr\")"
+          "(+)"; "(*)"; "(+ 7)"; "(* 7)"
+          "(+ 1 2 3 4 5)"; "(* 1 2 3 4)"; "(- 10 3 2)"
+          "(+ 1 2.5 3)" ]

--- a/IronKernel.Tests/KernelConformanceTests.fs
+++ b/IronKernel.Tests/KernelConformanceTests.fs
@@ -132,9 +132,11 @@ let private behaviouralChecks () : (string * string list) list = [
                 "(=? 1 1.0)"; "(eqv? (=? 1 2) #f)" ]
     "12.5.3", [ "(<=?)"; "(<=? 1)"; "(<=? 1 3 7 15)"; "(eqv? (<=? 1 7 3 15) #f)"
                 "(<? 1 2 3)"; "(eqv? (<? 1 1) #f)"; "(>? 3 2 1)"; "(>=? 3 3 1)" ]
-    "12.5.4", [ "(eqv? (+ 1 2) 3)" ]
-    "12.5.5", [ "(eqv? (* 3 4) 12)" ]
-    "12.5.6", [ "(eqv? (- 5 2) 3)" ]
+    "12.5.4", [ "(=? (+ 1 2) 3)"; "(=? (+) 0)"; "(=? (+ 7) 7)"; "(=? (+ 1 2 3 4 5) 15)" ]
+    "12.5.5", [ "(=? (* 3 4) 12)"; "(=? (*) 1)"; "(=? (* 7) 7)"; "(=? (* 1 2 3 4) 24)" ]
+    // 12.5.6: (- number . numbers) needs at least two arguments; the report
+    // deliberately gives `-` no unary meaning.
+    "12.5.6", [ "(=? (- 5 2) 3)"; "(=? (- 10 3 2) 5)" ]
     "12.5.7", [ "(zero? 0)"; "(zero? 0 0)"; "(eqv? (zero? 1) #f)"; "(zero?)" ]
     "12.5.8", [ "(=? (div 7 3) 2)"; "(=? (mod 7 3) 1)"
                 // Negative operands: the defining property is 0 <= mod < |divisor|.
@@ -164,8 +166,6 @@ let private divergences () = [
     "12.2", "There is no exact/inexact distinction. Numbers are CLR primitives, so "
             + "exactness, bounds and robustness (module Inexact, 12.6) are absent and "
             + "no number can be an exact infinity."
-    "12.5.4", "`+`, `*` and `-` are binary. The report makes them variadic, with "
-              + "`(+)` exact zero and `(*)` exact one."
     "12.5.13", "`(max)` and `(min)` with no arguments signal an error. The report "
                + "returns exact negative and positive infinity, which IronKernel "
                + "cannot represent."

--- a/docs/kernel-conformance.md
+++ b/docs/kernel-conformance.md
@@ -43,7 +43,6 @@ exercised, not that IronKernel matches the report exactly.
 |---|---|
 | 3.6 | External representations differ: IronKernel prints a number as `<obj 3 : Int32>` rather than `3`. |
 | 12.2 | There is no exact/inexact distinction. Numbers are CLR primitives, so exactness, bounds and robustness (module Inexact, 12.6) are absent and no number can be an exact infinity. |
-| 12.5.4 | `+`, `*` and `-` are binary. The report makes them variadic, with `(+)` exact zero and `(*)` exact one. |
 | 12.5.13 | `(max)` and `(min)` with no arguments signal an error. The report returns exact negative and positive infinity, which IronKernel cannot represent. |
 | 12.5.14 | `(gcd)` returns 0 and `(lcm)` returns 1. The report returns exact positive infinity for `(gcd)`. |
 
@@ -182,9 +181,9 @@ exercised, not that IronKernel matches the report exactly.
 | 12.5.1 | `number?, finite?, integer?` | Number features | `verified` | 10 behavioural check(s) |
 | 12.5.2 | `=?` | Number features | `verified` | 5 behavioural check(s) |
 | 12.5.3 | `<?, <=?, >=?, >?` | Number features | `verified` | 8 behavioural check(s) |
-| 12.5.4 | `+` | Number features | `verified` | 1 behavioural check(s) |
-| 12.5.5 | `*` | Number features | `verified` | 1 behavioural check(s) |
-| 12.5.6 | `-` | Number features | `verified` | 1 behavioural check(s) |
+| 12.5.4 | `+` | Number features | `verified` | 4 behavioural check(s) |
+| 12.5.5 | `*` | Number features | `verified` | 4 behavioural check(s) |
+| 12.5.6 | `-` | Number features | `verified` | 2 behavioural check(s) |
 | 12.5.7 | `zero?` | Number features | `verified` | 4 behavioural check(s) |
 | 12.5.8 | `div, mod, div-and-mod` | Number features | `verified` | 8 behavioural check(s) |
 | 12.5.9 | `div0, mod0, div0-and-mod0` | Number features | `verified` | 7 behavioural check(s) |


### PR DESCRIPTION
Closes the last gap in R-1RK's required Numbers module: `+`, `*` and `-` are now variadic. **Stacked on #35.**

## The report

- **12.5.4 / 12.5.5** — `(+ . numbers)` and `(* . numbers)`, with the empty sum exact zero and the empty product exact one.
- **12.5.6** — `(- number . numbers)`, minimum two. The report deliberately gives `-` no unary meaning, so that negation is not spelled the same way as subtraction.

## Why this needed a contract change

`validateArguments` required `expectedCount = actualCount`, so a fixed-arity contract could not describe a variadic combiner. Dropping the contracts would have been simpler, but they drive constant folding on the arithmetic path.

`OperativeContract` gains `minimumOperands`: `None` keeps today's fixed arity, `Some n` accepts n or more arguments and matches anything past the declared shapes against the last one. `+` is `Some 0`, `*` is `Some 0`, `-` is `Some 2`.

The primitives fold left, which keeps the CLR extensions intact — `(+ date timespan)` is still a `DateTime`, and repeating the timespan stays well typed because each step is the same binary operation as before.

## Performance: at or better than master

| | master | this branch |
|---|---:|---:|
| `ColdCompile` | 106.8 ns | 108.0 ns |
| `Interpreted` | 372.3 ns | 371.0 ns |
| `CompiledGeneric` | 174.8 ns | 173.7 ns |
| `CompiledFolded` | 108.8 ns | **52.9 ns** |

Two findings from measuring, both worth stating plainly:

**A regression I chased did not exist.** `ColdCompile` looked 25% worse, and I twice guessed at causes in this change (the fold, then the exception handler) and was wrong both times — neither edit moved the number. Measuring master directly showed the figure I had been comparing against predated the stack-safety fix already merged in #32. The lesson was to measure the baseline before attributing.

**Contract guards were re-comparing the whole record structurally** on every invocation of a folded constant. Adding a field only made an existing cost visible. Comparing by reference first — a contract is almost always the same instance the guard captured — takes `CompiledFolded` from 108.8 to 52.9 ns, a little over **twice as fast as master**. That is a real speedup this change happened to uncover, not a recovery from its own cost.

The exception handler introduced with the division fix also moved to the division path alone, since F# `+`, `-` and `*` are unchecked and wrap rather than raise, so a handler there guarded nothing.

## Test fallout, deliberately not papered over

Two interpreter/compiler parity tests treated `(+ 1)` and `(* 8)` as malformed — they encoded the old binary arity. Those expressions are now well formed per the report. They use `(- 1)` instead, which remains an arity error, and a new case covers parity across the newly legal arities.

## Status

Module 12.5 is complete: **all 14 entries verified**, with no arity divergence remaining. Still recorded for chapter 12: no exact/inexact distinction, and `(max)`/`(min)`/`(gcd)` needing exact infinities.

## Verification

Clean `--no-incremental` rebuild: 0 warnings, 0 errors. **256 tests pass on two consecutive runs.** All 11 examples exit 0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789316899&installation_model_id=427656&pr_number=36&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F36&signature=bba6fa4ea272c8ea368d37da62b4e3bbc0208a9ff651fd76f4bd6420959ed4ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->