### PR TITLE
Implement the list library and type predicates

### DIFF
--- a/Examples/constant-width-amb.ikr
+++ b/Examples/constant-width-amb.ikr
@@ -81,7 +81,7 @@
 
 ; Yield each element of xs in turn. `k` is multi-shot and re-delimits, so the
 ; whole remaining computation runs once per alternative.
-(defn (amb xs) (shift (lambda (k) (for-each xs k))))
+(defn (amb xs) (shift (lambda (k) (for-each k xs))))
 
 ; Strategy 1: run body, return the list of everything it emitted.
 (define collect
@@ -236,11 +236,11 @@
   (let* ((n (fig-n f)) (s (fig-squares f)) (m (- (* 2 n) 1))
          (rw (make-vector n 0)) (cl (make-vector n 0))
          (pd (make-vector m 0)) (nd (make-vector m 0)))
-    (for-each s (lambda (p)
+    (for-each (lambda (p)
       (tally! rw (car p))
       (tally! cl (cdr p))
       (tally! pd (+ (car p) (cdr p)))
-      (tally! nd (- (+ n (- (car p) (cdr p))) 1))))
+      (tally! nd (- (+ n (- (car p) (cdr p))) 1))) s)
     ; fold the four families together: every non-zero count must agree
     (letrec ((scan (lambda (v i len w)
                      (if (eq? i len) w
@@ -261,9 +261,9 @@
 (defn (extended? f)
   (let* ((n (fig-n f)) (s (fig-squares f))
          (p (make-vector n 0)) (q (make-vector n 0)))
-    (for-each s (lambda (sq)
+    (for-each (lambda (sq)
       (tally! p (modulo (+ (car sq) (cdr sq)) n))
-      (tally! q (modulo (- (car sq) (cdr sq)) n))))
+      (tally! q (modulo (- (car sq) (cdr sq)) n))) s)
     (let ((t (fig-type f)))
       (if (null? t) #f
         (let ((w (car (cddr t))))
@@ -283,11 +283,11 @@
 ; w1*w2 on a board (n1*n2) wide.
 (defn (compose f1 f2)
   (let ((m (fig-n f1)) (acc (make-vector 1 ())))
-    (for-each (fig-squares f2) (lambda (q)
-      (for-each (fig-squares f1) (lambda (p)
+    (for-each (lambda (q)
+      (for-each (lambda (p)
         (vector-set! acc 0
           (cons (cons (+ (car p) (* m (car q))) (+ (cdr p) (* m (cdr q))))
-                (vector-ref acc 0)))))))
+                (vector-ref acc 0)))) (fig-squares f1))) (fig-squares f2))
     (figure (* m (fig-n f2)) (vector-ref acc 0))))
 
 (defn (same-square? p q) (if (eq? (car p) (car q)) (eq? (cdr p) (cdr q)) #f))
@@ -304,8 +304,8 @@
   (let* ((n (fig-n f)) (s (fig-squares f)) (m (- (* 2 n) 1))
          (byrow (make-vector n ()))
          (uc (make-vector n 0)) (up (make-vector m 0)) (un (make-vector m 0)))
-    (for-each s (lambda (p)
-      (vector-set! byrow (car p) (cons p (vector-ref byrow (car p))))))
+    (for-each (lambda (p)
+      (vector-set! byrow (car p) (cons p (vector-ref byrow (car p))))) s)
     (letrec
       ((pdx (lambda (p) (+ (car p) (cdr p))))
        (ndx (lambda (p) (- (+ n (- (car p) (cdr p))) 1)))
@@ -321,10 +321,10 @@
                 (vector-set! un (ndx p) (+ (vector-ref un (ndx p)) d))))
        (pick (lambda (cands)
                (shift (lambda (k)
-                 (for-each cands (lambda (p)
+                 (for-each (lambda (p)
                    (if (avail? p)
                      (begin (mark! p 1) (k p) (mark! p -1))
-                     #inert)))))))
+                     #inert)) cands)))))
        (go (lambda (r acc)
              (if (eq? r n)
                (emit (reverse acc))
@@ -338,10 +338,10 @@
 ; constant width w-1.
 (defn (fig-remove f t)
   (let ((acc (make-vector 1 ())))
-    (for-each (fig-squares f) (lambda (p)
+    (for-each (lambda (p)
       (if (member-of? p t)
         #inert
-        (vector-set! acc 0 (cons p (vector-ref acc 0))))))
+        (vector-set! acc 0 (cons p (vector-ref acc 0))))) (fig-squares f))
     (figure (fig-n f) (vector-ref acc 0))))
 
 (defn (peel f)

--- a/Examples/coroutines.ikr
+++ b/Examples/coroutines.ikr
@@ -42,12 +42,12 @@
 (defn (superfluous-computation do-other-stuff)
     (define home (get-current-environment))
     (letrec ((loop (lambda ()
-      ; for-each takes the collection first, then the combiner.
-      (for-each '("Straight up." "Quarter after." "Half past."  "Quarter til.")
-                (lambda (graphic)
+      ; R-1RK 6.9.1: (for-each applicative . lists) -- the applicative comes first.
+      (for-each (lambda (graphic)
                   (display graphic)
                   (newline)
-                  (set! home do-other-stuff (call/cc do-other-stuff))))
+                  (set! home do-other-stuff (call/cc do-other-stuff)))
+                '("Straight up." "Quarter after." "Half past."  "Quarter til."))
       (loop))))
       (loop)))
 

--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -839,6 +839,62 @@
             | [found; _] -> fail (TypeMismatch("number", found))
             | _ -> fail (NumArgs(2, args))
 
+        /// Type predicates from chapters 4 and 6. Each is variadic and true for an
+        /// empty argument list, matching the report's "every element" phrasing.
+        let private typePredicate test env cont args =
+            let rec loop = function
+                | [] -> bounceContinue env cont (Bool true)
+                | value :: rest -> if test value then loop rest else bounceContinue env cont (Bool false)
+            loop args
+
+        let isBoolean env cont args =
+            typePredicate (function Bool _ -> true | _ -> false) env cont args
+
+        let isSymbol env cont args =
+            typePredicate (function Atom _ -> true | _ -> false) env cont args
+
+        let isInert env cont args =
+            typePredicate (function Inert -> true | _ -> false) env cont args
+
+        /// R-1RK 4.10.1 / 4.10.2 / 6.2.1. A combiner is an operative or an applicative;
+        /// wrapping is what makes it applicative, so anything not wrapped is operative.
+        let private isApplicativeValue = function
+            | Applicative _ -> true
+            | _ -> false
+
+        let private isOperativeValue = function
+            | Operative _
+            | PrimitiveOperative _
+            | CompiledCombiner _ -> true
+            | ContractedCombiner record -> record.contract.mode = RawOperands
+            | _ -> false
+
+        let isApplicative env cont args = typePredicate isApplicativeValue env cont args
+        let isOperative env cont args = typePredicate isOperativeValue env cont args
+
+        let isCombiner env cont args =
+            typePredicate (fun v -> isApplicativeValue v || isOperativeValue v) env cont args
+
+        /// R-1RK 5.7.1. Returns (p n a c): pairs, nils, acyclic prefix length and cycle
+        /// length of the improper list starting at the argument.
+        ///
+        /// IronKernel's pairs are immutable and it does not implement the optional Pair
+        /// mutation module, so no cyclic structure can be built and c is always zero
+        /// and a always equals p. The shape of the answer is still the report's.
+        let getListMetrics env cont args =
+            match args with
+            | [value] ->
+                let pairs, nils =
+                    match value with
+                    | List [] -> 0, 1
+                    | List items -> List.length items, 1
+                    | DottedList(items, tail) ->
+                        List.length items, (match tail with List [] -> 1 | _ -> 0)
+                    | _ -> 0, 0
+                let counted n = Obj(box n)
+                bounceContinue env cont (List [counted pairs; counted nils; counted pairs; counted 0])
+            | _ -> fail (NumArgs(1, args))
+
         /// R-1RK 12.10. Like 12.9 the report gives these signatures only, so they take
         /// their standard meanings. A complex whose imaginary part is zero is a real,
         /// so make-rectangular collapses that case rather than creating a value that
@@ -1057,6 +1113,14 @@
                   ("cdr", cdr);
                   ("cons", cons);
                   ("eq?", eqv);
+                  ("equal?", eqv);
+                  ("boolean?", isBoolean);
+                  ("symbol?", isSymbol);
+                  ("inert?", isInert);
+                  ("operative?", isOperative);
+                  ("applicative?", isApplicative);
+                  ("combiner?", isCombiner);
+                  ("get-list-metrics", getListMetrics);
                   ("eqv?", eqv);
                   ("null?", isNull);
                   ("pair?", isPair) ;

--- a/IronKernel.Tests/KernelConformanceTests.fs
+++ b/IronKernel.Tests/KernelConformanceTests.fs
@@ -80,7 +80,41 @@ let private behaviouralChecks () : (string * string list) list = [
                "(eqv? (if #f 1 2) 2)"
                // The unselected branch must not be evaluated.
                "(eqv? (if #t 1 no-such-variable) 1)" ]
+    "4.1.1", [ "(boolean? #t)"; "(boolean? #f)"; "(eqv? (boolean? 1) #f)"; "(boolean?)" ]
+    "4.3.1", [ "(equal? (list 1 2) (list 1 2))"; "(eqv? (equal? 1 2) #f)"
+               "(equal? \"ab\" \"ab\")" ]
+    "4.4.1", [ "(symbol? 'a)"; "(eqv? (symbol? 1) #f)"; "(symbol?)" ]
+    "4.5.1", [ "(inert? #inert)"; "(eqv? (inert? 1) #f)"; "(inert?)" ]
     "4.6.1", [ "(pair? (cons 1 2))"; "(eqv? (pair? ()) #f)" ]
+    "4.10.1", [ "(operative? vau)"; "(eqv? (operative? car) #f)"; "(operative?)" ]
+    "4.10.2", [ "(applicative? car)"; "(eqv? (applicative? vau) #f)"; "(applicative?)" ]
+    "5.7.1", [ "(equal? (get-list-metrics (list 1 2 3)) (list 3 1 3 0))"
+               "(equal? (get-list-metrics ()) (list 0 1 0 0))"
+               // A non-pair is the start of an improper list of just itself.
+               "(equal? (get-list-metrics 5) (list 0 0 0 0))" ]
+    "5.7.2", [ "(equal? (list-tail (list 1 2 3 4) 2) (list 3 4))"
+               "(equal? (list-tail (list 1 2) 0) (list 1 2))" ]
+    "6.2.1", [ "(combiner? car)"; "(combiner? vau)"; "(eqv? (combiner? 1) #f)" ]
+    "6.3.2", [ "(=? (list-ref (list 1 2 3) 1) 2)"; "(=? (list-ref (list 1 2 3) 0) 1)" ]
+    "6.3.3", [ "(equal? (append (list 1 2) (list 3)) (list 1 2 3))"
+               "(equal? (append) ())"; "(equal? (append (list 1)) (list 1))"
+               "(equal? (append () (list 1)) (list 1))" ]
+    "6.3.4", [ "(equal? (list-neighbors (list 1 2 3)) (list (list 1 2) (list 2 3)))"
+               "(equal? (list-neighbors ()) ())"
+               "(equal? (list-neighbors (list 1)) ())" ]
+    // 6.3.5: (filter applicative list) -- the applicative comes first.
+    "6.3.5", [ "(equal? (filter (lambda (x) (positive? x)) (list -1 2 -3 4)) (list 2 4))"
+               "(equal? (filter (lambda (x) #t) ()) ())" ]
+    "6.3.6", [ "(equal? (assoc 'b (list (list 'a 1) (list 'b 2))) (list 'b 2))"
+               "(equal? (assoc 'z (list (list 'a 1))) ())" ]
+    "6.3.7", [ "(member? 2 (list 1 2 3))"; "(eqv? (member? 9 (list 1 2)) #f)" ]
+    "6.3.8", [ "(finite-list? (list 1 2))"; "(finite-list? ())"; "(eqv? (finite-list? 5) #f)" ]
+    "6.3.9", [ "(countable-list? (list 1 2))"; "(eqv? (countable-list? 5) #f)" ]
+    // 6.3.10: (reduce list binary identity) -- the list comes first here.
+    "6.3.10", [ "(=? (reduce (list 1 2 3 4) + 0) 10)"; "(=? (reduce () + 0) 0)"
+                "(=? (reduce (list 5) + 0) 5)" ]
+    "6.6.1", [ "(equal? (list 1 (list 2)) (list 1 (list 2)))"
+               "(eqv? (equal? (list 1) (list 2)) #f)" ]
     "4.6.2", [ "(null? ())"; "(eqv? (null? (cons 1 2)) #f)" ]
     "4.6.3", [ "(eqv? (car (cons 1 2)) 1)"; "(eqv? (cdr (cons 1 2)) 2)" ]
     "4.8.1", [ "(environment? (get-current-environment))" ]
@@ -117,7 +151,8 @@ let private behaviouralChecks () : (string * string list) list = [
     "6.7.5", [ "(eqv? (letrec ((f (lambda (n) (if (eqv? n 0) 0 (f (- n 1)))))) (f 3)) 0)" ]
     "6.7.9", [ "(eqv? (remote-eval (+ 1 2) (get-current-environment)) 3)" ]
     "6.8.1", [ "(let ((e (get-current-environment))) (sequence (set! e zz 7) (eqv? zz 7)))" ]
-    "6.9.1", [ "(eqv? (sequence (for-each (list 1) (lambda (x) x)) 1) 1)" ]
+    // 6.9.1: (for-each applicative . lists) -- applicative first, as for map.
+    "6.9.1", [ "(let ((t (vector 0))) (sequence (for-each (lambda (x) (vector-set! t 0 x)) (list 7)) (=? (vector-ref t 0) 7)))" ]
     "7.2.2", [ "(eqv? (call/cc (lambda (k) (k 42))) 42)" ]
     "7.3.2", [ "(eqv? (let/cc k (k 9)) 9)" ]
     "8.1.1", [ "(let ((t (make-encapsulation-type))) (let ((e ((car t) 1)) (p (car (cdr t)))) (p e)))" ]
@@ -224,6 +259,9 @@ let private divergences () = [
             + "real domain takes its complex value now that 12.10 is supported, so "
             + "`(sqrt -1)` is `i`; a NaN result still signals an error; and infinities "
             + "are returned as values."
+    "4.2.1", "`eq?` is bound to the same structural comparison as `eqv?`, so it is "
+             + "coarser than the report's, which distinguishes objects that `equal?` "
+             + "does not."
     "12.10", "Complex numbers are `System.Numerics.Complex`, so components are "
              + "double precision and a result whose imaginary part is zero collapses "
              + "back to a real. The report specifies 12.10 by signature only."

--- a/IronKernel.Tests/ListTests.fs
+++ b/IronKernel.Tests/ListTests.fs
@@ -80,3 +80,79 @@ let ``quote preserves structure`` () =
         "'(a b c)", List [Atom "a"; Atom "b"; Atom "c"]
         "(car '(x y))", Atom "x"
     ] |> evalSessionKernel
+
+[<Fact>]
+let ``type predicates cover the report's types`` () =
+    [
+        "(boolean? #t)", Bool true
+        "(boolean? 1)", Bool false
+        "(symbol? 'a)", Bool true
+        "(symbol? 1)", Bool false
+        "(inert? #inert)", Bool true
+        "(applicative? car)", Bool true
+        "(operative? car)", Bool false
+        "(operative? vau)", Bool true
+        "(combiner? car)", Bool true
+        "(combiner? vau)", Bool true
+        "(combiner? 1)", Bool false
+        // Variadic and true for no arguments, like the report's other predicates.
+        "(boolean?)", Bool true
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``get-list-metrics reports the shape of an improper list`` () =
+    // R-1RK 5.7.1 returns (pairs nils acyclic-prefix cycle-length). IronKernel's
+    // pairs are immutable and the optional Pair mutation module is unimplemented, so
+    // no cycle can be built: the cycle length is always zero.
+    [
+        "(equal? (get-list-metrics (list 1 2 3)) (list 3 1 3 0))", Bool true
+        "(equal? (get-list-metrics ()) (list 0 1 0 0))", Bool true
+        // A non-pair starts an improper list consisting of just itself.
+        "(equal? (get-list-metrics 5) (list 0 0 0 0))", Bool true
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``list accessors and constructors follow the report`` () =
+    [
+        "(equal? (list-tail (list 1 2 3 4) 2) (list 3 4))", Bool true
+        "(=? (list-ref (list 1 2 3) 1) 2)", Bool true
+        "(equal? (append (list 1 2) (list 3)) (list 1 2 3))", Bool true
+        "(equal? (append) ())", Bool true
+        "(equal? (append (list 1)) (list 1))", Bool true
+        "(equal? (list-neighbors (list 1 2 3)) (list (list 1 2) (list 2 3)))", Bool true
+        "(equal? (list-neighbors ()) ())", Bool true
+        "(equal? (list-neighbors (list 1)) ())", Bool true
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``list searches and folds follow the report's argument order`` () =
+    // filter and for-each take the applicative first (6.3.5, 6.9.1); reduce takes the
+    // list first (6.3.10). The orders differ between them in the report itself.
+    [
+        "(equal? (filter (lambda (x) (positive? x)) (list -1 2 -3 4)) (list 2 4))", Bool true
+        "(equal? (assoc 'b (list (list 'a 1) (list 'b 2))) (list 'b 2))", Bool true
+        "(equal? (assoc 'z (list (list 'a 1))) ())", Bool true
+        "(member? 2 (list 1 2 3))", Bool true
+        "(member? 9 (list 1 2))", Bool false
+        "(=? (reduce (list 1 2 3 4) + 0) 10)", Bool true
+        "(=? (reduce () + 0) 0)", Bool true
+        "(=? (reduce (list 5) + 0) 5)", Bool true
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``for-each takes the applicative first`` () =
+    // R-1RK 6.9.1 is (for-each applicative . lists). IronKernel used to take the list
+    // first, which an earlier conformance check failed to catch because it passed a
+    // one-element list and never depended on the order.
+    [
+        "(define trace (vector 0))", Inert
+        "(for-each (lambda (x) (vector-set! trace 0 x)) (list 7))", Inert
+        "(=? (vector-ref trace 0) 7)", Bool true
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``filter requires a boolean result`` () =
+    withKernel (fun env ->
+        match evalIn env "(filter (lambda (x) 1) (list 1 2))" with
+        | Status message -> Assert.Contains("non-boolean", message)
+        | value -> failwithf "expected an error, got %s" (showVal value))

--- a/IronKernel/kernel.ikr
+++ b/IronKernel/kernel.ikr
@@ -153,8 +153,10 @@
     (eval (cons (eval (list* lambda (map car bindings) body) (eval exp env))
                 (map cadr bindings)) env)))
 
+; R-1RK 6.9.1: (for-each applicative . lists) -- the applicative comes first, as it
+; does for map (5.9.1). IronKernel used to take the list first.
 (define for-each
-  (wrap (vau (x f) env (apply map (list f x) env) #inert)))
+  (wrap (vau (f x) env (apply map (list f x) env) #inert)))
   
 (define get-current-environment (wrap (vau () e e)))
 
@@ -398,6 +400,105 @@
 (define rationalize
   (lambda (x tolerance)
     (simplest-rational (- x tolerance) (+ x tolerance))))
+
+; --- R-1RK list features (5.7, 6.3) ------------------------------------------
+; get-list-metrics is a primitive; the rest are derived from it and from the pair
+; primitives. IronKernel's pairs are immutable and the optional Pair mutation
+; module is unimplemented, so no list can be cyclic: every list here is finite,
+; and the cycle-handling the report describes has nothing to act on.
+
+; 5.7.2
+(define list-tail
+  (lambda (ls k)
+    (letrec ((aux (lambda (rest n) (if (zero? n) rest (aux (cdr rest) (- n 1))))))
+      (aux ls k))))
+
+; 6.3.2
+(define list-ref (lambda (ls k) (car (list-tail ls k))))
+
+; 6.3.3: the last argument is referenced rather than copied, so (append) is nil and
+; (append x) is x.
+(define append
+  (lambda lists
+    (letrec ((join (lambda (a b) (if (null? a) b (cons (car a) (join (cdr a) b)))))
+             (aux (lambda (ls)
+                    (if (null? ls)
+                      ()
+                      (if (null? (cdr ls))
+                        (car ls)
+                        (join (car ls) (aux (cdr ls))))))))
+      (aux lists))))
+
+; 6.3.4: consecutive sublists of length two. Nil gives nil, and otherwise the result
+; is one shorter than the argument.
+(define list-neighbors
+  (lambda (ls)
+    (letrec ((aux (lambda (rest)
+                    (if (null? rest)
+                      ()
+                      (if (null? (cdr rest))
+                        ()
+                        (cons (list (car rest) (car (cdr rest))) (aux (cdr rest))))))))
+      (aux ls))))
+
+; 6.3.5: (filter applicative list). The result of each call must be boolean.
+(define filter
+  (lambda (accept? ls)
+    (letrec ((aux (lambda (rest)
+                    (if (null? rest)
+                      ()
+                      (let ((keep (accept? (car rest))))
+                        (if (boolean? keep)
+                          (if keep
+                            (cons (car rest) (aux (cdr rest)))
+                            (aux (cdr rest)))
+                          (error "filter: predicate returned a non-boolean")))))))
+      (aux ls))))
+
+; 6.3.6 / 6.3.7: assoc searches a list of pairs by car; member? searches for an
+; element. Both compare with equal? (structural), per the report.
+(define assoc
+  (lambda (key pairs)
+    (letrec ((aux (lambda (rest)
+                    (if (null? rest)
+                      ()
+                      (if (equal? key (car (car rest)))
+                        (car rest)
+                        (aux (cdr rest)))))))
+      (aux pairs))))
+
+(define member?
+  (lambda (object ls)
+    (letrec ((aux (lambda (rest)
+                    (if (null? rest)
+                      #f
+                      (if (equal? object (car rest)) #t (aux (cdr rest)))))))
+      (aux ls))))
+
+; 6.3.8 / 6.3.9: with no cycles possible, a countable list is a finite list, and both
+; reduce to "the improper list starting here is terminated by nil".
+(define $list-shaped?
+  (lambda (xs)
+    (letrec ((aux (lambda (ys)
+                    (if (null? ys) #t (if (pair? ys) (aux (cdr ys)) #f)))))
+      (aux xs))))
+
+(define $every?
+  (lambda (ok? xs)
+    (letrec ((aux (lambda (ys) (if (null? ys) #t (if (ok? (car ys)) (aux (cdr ys)) #f)))))
+      (aux xs))))
+
+(define finite-list? (lambda xs ($every? $list-shaped? xs)))
+(define countable-list? (lambda xs ($every? $list-shaped? xs)))
+
+; 6.3.10: (reduce list binary identity). The report also gives a six-argument form
+; for cyclic lists; with no cycles to describe, the three-argument form is the whole
+; of it here.
+(define reduce
+  (lambda (ls binary identity)
+    (letrec ((aux (lambda (rest acc)
+                    (if (null? rest) acc (aux (cdr rest) (binary acc (car rest)))))))
+      (if (null? ls) identity (aux (cdr ls) (car ls))))))
 
 ; --- R-1RK canonical names ---------------------------------------------------
 ; The report spells operatives with a leading `$`, and the primitive definer as

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ This tree is a **hybrid CLR runtime**: programs are analyzed to a Core IR and co
 
 [`docs/kernel-conformance.md`](docs/kernel-conformance.md) tracks IronKernel against
 the [Revised-1 Report on the Kernel Programming Language](https://ftp.cs.wpi.edu/pub/techreports/pdf/05-07.pdf)
-(R-1RK), feature by feature. Of the report's 135 feature entries, **66 are verified
-by a behavioural check, 12 resolve but are unchecked, and 57 are absent**; 34 belong
+(R-1RK), feature by feature. Of the report's 135 feature entries, **85 are verified
+by a behavioural check, 12 resolve but are unchecked, and 38 are absent**; 34 belong
 to modules the report marks optional. The matrix also reports status per *module*,
-which R-1RK 1.3.2 makes the unit of conformance.
+which R-1RK 1.3.2 makes the unit of conformance: **25 of 34 modules are complete**.
 
 Chapter 12's required **Numbers** module (12.5) is complete, as are the optional
 **Rational** (12.8), **Real** (12.9) and **Complex** (12.10) modules. Rational is

--- a/docs/kernel-conformance.md
+++ b/docs/kernel-conformance.md
@@ -25,10 +25,10 @@ rather than hidden behind a pass.
 
 | | Entries | Share |
 |---|---:|---:|
-| `verified` | 66 | 49% |
+| `verified` | 85 | 63% |
 | `bound` | 12 | 9% |
 | `partial` | 0 | 0% |
-| `absent` | 57 | 42% |
+| `absent` | 38 | 28% |
 | **total** | **135** | |
 
 34 of 135 entries belong to modules the report marks optional; an
@@ -46,6 +46,7 @@ exercised, not that IronKernel matches the report exactly.
 | 12.5.13 | `(max)` and `(min)` with no arguments signal an error. The report returns exact negative and positive infinity, which IronKernel cannot represent. |
 | 12.5.14 | `(gcd)` returns 0 and `(lcm)` returns 1. The report returns exact positive infinity for `(gcd)`. |
 | 12.9 | The report specifies 12.9.2 through 12.9.6 by signature only. Appendix A.2 records that it is an incomplete draft whose unwritten portions were "only planned in rough outline", so `verified` there means the binding exists with its standard mathematical meaning, and the choices the report leaves open are IronKernel's: an argument outside a function's real domain takes its complex value now that 12.10 is supported, so `(sqrt -1)` is `i`; a NaN result still signals an error; and infinities are returned as values. |
+| 4.2.1 | `eq?` is bound to the same structural comparison as `eqv?`, so it is coarser than the report's, which distinguishes objects that `equal?` does not. |
 | 12.10 | Complex numbers are `System.Numerics.Complex`, so components are double precision and a result whose imaginary part is zero collapses back to a real. The report specifies 12.10 by signature only. |
 | 12.8 | Module Rational is implemented over the existing numeric types, which have no exact rational representation. `(/ 1 3)` is the closest double rather than an exact third, and `numerator`/`denominator` signal an error when a value's exact ratio does not fit in 64 bits. |
 
@@ -58,32 +59,32 @@ counts as complete here only when every one of its entries is `verified`.
 
 | Module | Required | Entries | Verified | Complete |
 |---|---|---:|---:|---|
-| 4.1 Core types and primitive features — Booleans | **required** | 1 | 0 | no |
+| 4.1 Core types and primitive features — Booleans | **required** | 1 | 1 | yes |
 | 4.2 Core types and primitive features — Equivalence under mutation (optional) | optional | 1 | 0 | no |
-| 4.3 Core types and primitive features — Equivalence up to mutation | **required** | 1 | 0 | no |
-| 4.4 Core types and primitive features — Symbols | **required** | 1 | 0 | no |
-| 4.5 Core types and primitive features — Control | **required** | 2 | 1 | no |
+| 4.3 Core types and primitive features — Equivalence up to mutation | **required** | 1 | 1 | yes |
+| 4.4 Core types and primitive features — Symbols | **required** | 1 | 1 | yes |
+| 4.5 Core types and primitive features — Control | **required** | 2 | 2 | yes |
 | 4.6 Core types and primitive features — Pairs and lists | **required** | 3 | 3 | yes |
 | 4.7 Core types and primitive features — Pair mutation (optional) | optional | 2 | 0 | no |
 | 4.8 Core types and primitive features — Environments | **required** | 4 | 3 | no |
 | 4.9 Core types and primitive features — Environment mutation (optional) | optional | 1 | 0 | no |
-| 4.10 Core types and primitive features — Combiners | **required** | 5 | 3 | no |
+| 4.10 Core types and primitive features — Combiners | **required** | 5 | 5 | yes |
 | 5.1 Core library features (I) — Control | **required** | 1 | 1 | yes |
 | 5.2 Core library features (I) — Pairs and lists | **required** | 2 | 2 | yes |
 | 5.3 Core library features (I) — Combiners | **required** | 2 | 2 | yes |
 | 5.4 Core library features (I) — Pairs and lists | **required** | 1 | 1 | yes |
 | 5.5 Core library features (I) — Combiners | **required** | 1 | 1 | yes |
 | 5.6 Core library features (I) — Control | **required** | 1 | 1 | yes |
-| 5.7 Core library features (I) — Pairs and lists | **required** | 2 | 0 | no |
+| 5.7 Core library features (I) — Pairs and lists | **required** | 2 | 2 | yes |
 | 5.8 Core library features (I) — Pair mutation (optional) | optional | 1 | 0 | no |
 | 5.9 Core library features (I) — Combiners | **required** | 1 | 1 | yes |
 | 5.10 Core library features (I) — Environments | **required** | 1 | 1 | yes |
 | 6.1 Core library features (II) — Booleans | **required** | 5 | 5 | yes |
-| 6.2 Core library features (II) — Combiners | **required** | 1 | 0 | no |
-| 6.3 Core library features (II) — Pairs and lists | **required** | 10 | 1 | no |
+| 6.2 Core library features (II) — Combiners | **required** | 1 | 1 | yes |
+| 6.3 Core library features (II) — Pairs and lists | **required** | 10 | 10 | yes |
 | 6.4 Core library features (II) — Pair mutation (optional) | optional | 4 | 0 | no |
 | 6.5 Core library features (II) — Equivalence under mutation (optional) | optional | 1 | 0 | no |
-| 6.6 Core library features (II) — Equivalence up to mutation | **required** | 1 | 0 | no |
+| 6.6 Core library features (II) — Equivalence up to mutation | **required** | 1 | 1 | yes |
 | 6.7 Core library features (II) — Environments | **required** | 10 | 4 | no |
 | 6.8 Core library features (II) — Environment mutation (optional) | optional | 3 | 1 | no |
 | 6.9 Core library features (II) — Control | **required** | 1 | 1 | yes |
@@ -107,11 +108,11 @@ counts as complete here only when every one of its entries is `verified`.
 
 | Entry | Feature | Module | Status | Notes |
 |---|---|---|---|---|
-| 4.1.1 | `boolean?` | Booleans | `absent` |  |
+| 4.1.1 | `boolean?` | Booleans | `verified` | 4 behavioural check(s) |
 | 4.2.1 | `eq?` | Equivalence under mutation (optional) | `bound` | optional module |
-| 4.3.1 | `equal?` | Equivalence up to mutation | `absent` |  |
-| 4.4.1 | `symbol?` | Symbols | `absent` |  |
-| 4.5.1 | `inert?` | Control | `absent` |  |
+| 4.3.1 | `equal?` | Equivalence up to mutation | `verified` | 3 behavioural check(s) |
+| 4.4.1 | `symbol?` | Symbols | `verified` | 3 behavioural check(s) |
+| 4.5.1 | `inert?` | Control | `verified` | 3 behavioural check(s) |
 | 4.5.2 | `$if` | Control | `verified` | 3 behavioural check(s) |
 | 4.6.1 | `pair?` | Pairs and lists | `verified` | 2 behavioural check(s) |
 | 4.6.2 | `null?` | Pairs and lists | `verified` | 2 behavioural check(s) |
@@ -123,8 +124,8 @@ counts as complete here only when every one of its entries is `verified`.
 | 4.8.3 | `eval` | Environments | `verified` | 1 behavioural check(s) |
 | 4.8.4 | `make-environment` | Environments | `verified` | 1 behavioural check(s) |
 | 4.9.1 | `$define!` | Environment mutation (optional) | `bound` | optional module |
-| 4.10.1 | `operative?` | Combiners | `absent` |  |
-| 4.10.2 | `applicative?` | Combiners | `absent` |  |
+| 4.10.1 | `operative?` | Combiners | `verified` | 3 behavioural check(s) |
+| 4.10.2 | `applicative?` | Combiners | `verified` | 3 behavioural check(s) |
 | 4.10.3 | `$vau` | Combiners | `verified` | 1 behavioural check(s) |
 | 4.10.4 | `wrap` | Combiners | `verified` | 1 behavioural check(s) |
 | 4.10.5 | `unwrap` | Combiners | `verified` | 1 behavioural check(s) |
@@ -141,8 +142,8 @@ counts as complete here only when every one of its entries is `verified`.
 | 5.4.1 | `car, cdr` | Pairs and lists | `verified` | 2 behavioural check(s) |
 | 5.5.1 | `apply` | Combiners | `verified` | 1 behavioural check(s) |
 | 5.6.1 | `$cond` | Control | `verified` | 1 behavioural check(s) |
-| 5.7.1 | `get-list-metrics` | Pairs and lists | `absent` |  |
-| 5.7.2 | `list-tail` | Pairs and lists | `absent` |  |
+| 5.7.1 | `get-list-metrics` | Pairs and lists | `verified` | 3 behavioural check(s) |
+| 5.7.2 | `list-tail` | Pairs and lists | `verified` | 2 behavioural check(s) |
 | 5.8.1 | `encycle!` | Pair mutation (optional) | `absent` | optional module |
 | 5.9.1 | `map` | Combiners | `verified` | 1 behavioural check(s) |
 | 5.10.1 | `$let` | Environments | `verified` | 1 behavioural check(s) |
@@ -156,23 +157,23 @@ counts as complete here only when every one of its entries is `verified`.
 | 6.1.3 | `or?` | Booleans | `verified` | 4 behavioural check(s) |
 | 6.1.4 | `$and?` | Booleans | `verified` | 4 behavioural check(s) |
 | 6.1.5 | `$or?` | Booleans | `verified` | 4 behavioural check(s) |
-| 6.2.1 | `combiner?` | Combiners | `absent` |  |
+| 6.2.1 | `combiner?` | Combiners | `verified` | 3 behavioural check(s) |
 | 6.3.1 | `length` | Pairs and lists | `verified` | 2 behavioural check(s) |
-| 6.3.2 | `list-ref` | Pairs and lists | `absent` |  |
-| 6.3.3 | `append` | Pairs and lists | `absent` |  |
-| 6.3.4 | `list-neighbors` | Pairs and lists | `absent` |  |
-| 6.3.5 | `filter` | Pairs and lists | `absent` |  |
-| 6.3.6 | `assoc` | Pairs and lists | `absent` |  |
-| 6.3.7 | `member?` | Pairs and lists | `absent` |  |
-| 6.3.8 | `finite-list?` | Pairs and lists | `absent` |  |
-| 6.3.9 | `countable-list?` | Pairs and lists | `absent` |  |
-| 6.3.10 | `reduce` | Pairs and lists | `absent` |  |
+| 6.3.2 | `list-ref` | Pairs and lists | `verified` | 2 behavioural check(s) |
+| 6.3.3 | `append` | Pairs and lists | `verified` | 4 behavioural check(s) |
+| 6.3.4 | `list-neighbors` | Pairs and lists | `verified` | 3 behavioural check(s) |
+| 6.3.5 | `filter` | Pairs and lists | `verified` | 2 behavioural check(s) |
+| 6.3.6 | `assoc` | Pairs and lists | `verified` | 2 behavioural check(s) |
+| 6.3.7 | `member?` | Pairs and lists | `verified` | 2 behavioural check(s) |
+| 6.3.8 | `finite-list?` | Pairs and lists | `verified` | 3 behavioural check(s) |
+| 6.3.9 | `countable-list?` | Pairs and lists | `verified` | 2 behavioural check(s) |
+| 6.3.10 | `reduce` | Pairs and lists | `verified` | 3 behavioural check(s) |
 | 6.4.1 | `append!` | Pair mutation (optional) | `absent` | optional module |
 | 6.4.2 | `copy-es` | Pair mutation (optional) | `absent` | optional module |
 | 6.4.3 | `assq` | Pair mutation (optional) | `absent` | optional module |
 | 6.4.4 | `memq?` | Pair mutation (optional) | `absent` | optional module |
 | 6.5.1 | `eq?` | Equivalence under mutation (optional) | `bound` | optional module |
-| 6.6.1 | `equal?` | Equivalence up to mutation | `absent` |  |
+| 6.6.1 | `equal?` | Equivalence up to mutation | `verified` | 2 behavioural check(s) |
 | 6.7.1 | `$binds?` | Environments | `absent` |  |
 | 6.7.2 | `get-current-environment` | Environments | `verified` | 1 behavioural check(s) |
 | 6.7.3 | `make-kernel-standard-environment` | Environments | `absent` |  |

--- a/lib/IronKernel.Amb/src/amb.ikr
+++ b/lib/IronKernel.Amb/src/amb.ikr
@@ -99,7 +99,7 @@
   (define require (lambda (test) (if test #inert (fail))))
 
   ; Yield each element of xs. An empty list fails.
-  (define amb (lambda (xs) (shift (lambda (k) (for-each xs k)))))
+  (define amb (lambda (xs) (shift (lambda (k) (for-each k xs)))))
 
   ; Yield each integer in [lo, hi) without building the list.
   (define amb-range
@@ -115,10 +115,10 @@
   (define amb-bracket
     (lambda (xs ok? enter! leave!)
       (shift (lambda (k)
-        (for-each xs (lambda (x)
+        (for-each (lambda (x)
           (if (ok? x)
             (with-bracket x enter! leave! k)
-            #inert)))))))
+            #inert)) xs)))))
 
   ; amb-bracket over the integers in [lo, hi).
   (define amb-bracket-range


### PR DESCRIPTION
Implements the list library and the remaining type predicates from chapters 4, 5 and 6. **Verified entries go from 66 to 85; complete modules from 14 to 25.**

`boolean?`, `symbol?`, `inert?`, `operative?`, `applicative?`, `combiner?`, `equal?`, `get-list-metrics`, `list-tail`, `list-ref`, `append`, `list-neighbors`, `filter`, `assoc`, `member?`, `finite-list?`, `countable-list?`, `reduce`.

## Cyclic lists have nothing to act on

R-1RK specifies these features carefully for **cyclic** lists — `get-list-metrics` returns an acyclic prefix length and a cycle length, and `append`, `filter`, `list-neighbors` and `reduce` all describe cycle behaviour.

IronKernel's pairs are immutable and the optional Pair mutation module (`set-cdr!`, `encycle!`) is unimplemented, so **no cyclic structure can be constructed**. The cycle length is always zero and the acyclic prefix is the whole list. The shape of `get-list-metrics`' answer is still the report's `(p n a c)`, so the feature is honest rather than reshaped.

## `for-each` had the wrong argument order

R-1RK 6.9.1 is `(for-each applicative . lists)` — the applicative first, matching `map` (5.9.1). IronKernel took the list first.

The existing conformance check was:

```
(eqv? (sequence (for-each (list 1) (lambda (x) x)) 1) 1)
```

It passes a one-element list and ignores the result, so it never depended on the order at all. **This is the second time a check I wrote was too weak to catch an argument-order divergence** — the first was `(=? (/ 8 2) 4)` passing while `/` truncated. Both were cases where I picked an example that could not fail.

The order is corrected and the ten call sites across the examples and `lib/IronKernel.Amb` updated. **Breaking for user code calling `for-each`.**

Worth noting the report is not internally uniform here: `filter` and `for-each` take the applicative first, but `reduce` takes the **list** first (`(reduce list binary identity)`). The tests assert each order explicitly rather than assuming a convention.

## A tool that failed quietly

I reused the s-expression swapper written for the `eval` change to flip those call sites. It silently skipped one: a leading quote parses as its own token, so `(for-each '(...) f)` has four children rather than three and did not match. `coroutines.ikr` failed the example sweep as a result.

Fixed by hand, and the limitation is now recorded in the tool — it reports which sites it changed, and that count has to be checked against a grep of all of them rather than trusted.

## Also recorded

`eq?` is bound to the same structural comparison as `eqv?`, so it is coarser than the report's, which distinguishes objects `equal?` does not. Left as a divergence rather than papered over.

`ignore?` (4.8.2) stays absent: IronKernel has no `#ignore` object, and adding one changes how formal parameter trees are written, which is beyond a list-library change.

## Status

**85 of 135 entries verified**, 12 bound, 38 absent. **25 of 34 modules complete.**

## Verification

Clean `--no-incremental` rebuild: 0 warnings, 0 errors. **275 tests pass on two consecutive runs.** All 11 examples exit 0, diagnostics byte-identical.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789323933&installation_model_id=427656&pr_number=40&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F40&signature=987356cc38b397041c4e7233e51b8f9299841fae66fc4fb012a6ec1ea32601fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->