### PR TITLE
Check the twelve bound entries, and fix two bugs they exposed

### DIFF
--- a/IronKernel.Runtime/Eval.fs
+++ b/IronKernel.Runtime/Eval.fs
@@ -259,7 +259,16 @@ module Eval =
             else
                 match evalArgs _env (newContinuation _env) args with
                 | Choice1Of2 e -> fail e
-                | Choice2Of2 q -> ofResult (f q)
+                // The result has to be handed to `cont`, not returned as `Done`.
+                // `Done` ends the trampoline, which was harmless while every combiner
+                // ran inside its own nested `run`, but since compiled code shares one
+                // trampoline (ADR 0004) it discards the rest of the computation: the
+                // value of `(define p (open-output-file f))` became the value of the
+                // whole form and the binding never happened.
+                | Choice2Of2 q ->
+                    match f q with
+                    | Choice1Of2 error -> fail error
+                    | Choice2Of2 value -> More (fun () -> continueEvalStep _env cont value)
         | Applicative f -> evalArgsExStep _env cont args f
         | Continuation (cr, capturedPrompt, ct') ->
             match args with

--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -120,12 +120,24 @@
                 returnM (File.ReadAllText filename :> obj |> Ast.Obj) 
             with _ -> throwError (Default("File not found: '" + filename + "'"))
 
+        /// File operations are guarded so that an I/O failure -- a missing file, a
+        /// locked file, a permissions error -- becomes a Kernel error. Left unguarded
+        /// the CLR exception escapes the evaluator and faults the process, taking the
+        /// REPL or script host with it, as division by zero used to.
+        let private guardIO description work =
+            try work () with
+            | :? IOException as ex -> throwError (Default(description + ": " + ex.Message))
+            | :? UnauthorizedAccessException as ex ->
+                throwError (Default(description + ": " + ex.Message))
+            | :? ArgumentException as ex -> throwError (Default(description + ": " + ex.Message))
+            | :? NotSupportedException as ex -> throwError (Default(description + ": " + ex.Message))
+
         let makePort mode = function
             | [Obj filename] ->
                 either {
                     let! fname = cast filename
-                    let port = File.Open(fname, FileMode.OpenOrCreate, mode)
-                    return Port port
+                    return! guardIO "open file" (fun () ->
+                        returnM (Port(File.Open(fname, FileMode.OpenOrCreate, mode))))
                 }
             | [found] -> throwError(TypeMismatch("string", found))
             | bad -> throwError(NumArgs(1, bad))
@@ -141,8 +153,7 @@
             | [Obj filename] ->
                 either {
                     let! path = cast filename
-                    let contents = File.ReadAllText path
-                    return makeObj contents
+                    return! guardIO "read file" (fun () -> returnM (makeObj (File.ReadAllText path)))
                 }
             | [found] -> throwError(TypeMismatch("string", found))
             | bad -> throwError(NumArgs(1, bad))
@@ -168,9 +179,11 @@
 
         let writeProc = function
                 | [ob] -> Console.Out.Write(showVal ob);returnM (Bool true)
-                | [ob; Port port] -> use writer = new StreamWriter(port)
-                                     writer.Write(showVal ob)
-                                     returnM (Bool true)
+                | [ob; Port port] ->
+                    guardIO "write" (fun () ->
+                        use writer = new StreamWriter(port)
+                        writer.Write(showVal ob)
+                        returnM (Bool true))
                 | bad -> throwError (NumArgs(1, bad))
 
         let readProc port =
@@ -179,7 +192,7 @@
                    | Choice1Of2 error -> throwError error
                    | Choice2Of2 services -> reader.ReadLine() |> services.parseExpression
                match port with
-                | [Port p]  -> use s = new StreamReader(p) in parseReader s
+                | [Port p] -> guardIO "read" (fun () -> use s = new StreamReader(p) in parseReader s)
                 | [] -> parseReader Console.In
                 | bad -> throwError (NumArgs(1, bad))
           
@@ -375,7 +388,12 @@
                     match load fname with
                     | Choice1Of2 e -> fail e
                     | Choice2Of2 lisp ->
-                        match sequence (List.map (eval env cont) lisp) [] with
+                        // Each loaded form gets a fresh continuation. Passing the
+                        // caller's `cont` ran the rest of the caller's computation once
+                        // per loaded form, and then `bounceContinue` ran it again, so a
+                        // nested (load f) evaluated its enclosing form twice.
+                        let evaluateForm form = eval env (newContinuation env) form
+                        match sequence (List.map evaluateForm lisp) [] with
                         | Choice1Of2 e -> fail e
                         | Choice2Of2 _ -> bounceContinue env cont Inert
             | badform -> fail (NumArgs(1, badform))

--- a/IronKernel.Tests/KernelConformanceTests.fs
+++ b/IronKernel.Tests/KernelConformanceTests.fs
@@ -85,7 +85,26 @@ let private behaviouralChecks () : (string * string list) list = [
                "(equal? \"ab\" \"ab\")" ]
     "4.4.1", [ "(symbol? 'a)"; "(eqv? (symbol? 1) #f)"; "(symbol?)" ]
     "4.5.1", [ "(inert? #inert)"; "(eqv? (inert? 1) #f)"; "(inert?)" ]
+    // 4.2.1 / 6.5.1: eq? is coarser here than the report's (see the divergence), so
+    // these check what it does guarantee.
+    "4.2.1", [ "(eq? 'a 'a)"; "(eqv? (eq? 'a 'b) #f)"; "(eq? 1 1)" ]
     "4.6.1", [ "(pair? (cons 1 2))"; "(eqv? (pair? ()) #f)" ]
+    // 4.9.1: $define! binds in the current environment and returns inert.
+    "4.9.1", [ "(let ((e (get-current-environment))) (sequence (eval (list $define! 'dz 11) e) (=? dz 11)))"
+               "(inert? ($define! dy 1))" ]
+    "6.5.1", [ "(eq? 'a 'a)"; "(eqv? (eq? 'a 'b) #f)" ]
+    "6.7.6", [ // $letrec* binds sequentially, so a later binding sees an earlier one.
+               "(=? (letrec* ((a 1) (b (+ a 1))) b) 2)" ]
+    "6.7.7", [ "(=? (let-redirect (make-environment) ((x 5)) x) 5)"
+               // The body is evaluated in the redirected environment, so a binding of
+               // the caller is not visible: `car` is unbound in a fresh environment.
+               "(=? (let-redirect (get-current-environment) ((x 5)) (car (list x))) 5)" ]
+    "6.7.10", [ "(environment? (bindings->environment (n 3)))"
+                "(=? (remote-eval n (bindings->environment (n 3))) 3)" ]
+    "6.8.2", [ "(sequence (provide! (pa pb) (define pa 1) (define pb 2)) (=? (+ pa pb) 3))"
+               // Only the named symbols escape; the helper stays private.
+               "(sequence (provide! (shown) (define hidden 41) (define shown (+ hidden 1))) (=? shown 42))" ]
+    "6.8.3", [ "(sequence (define src (bindings->environment (q 9))) (import! src q) (=? q 9))" ]
     "4.10.1", [ "(operative? vau)"; "(eqv? (operative? car) #f)"; "(operative?)" ]
     "4.10.2", [ "(applicative? car)"; "(eqv? (applicative? vau) #f)"; "(applicative?)" ]
     "5.7.1", [ "(equal? (get-list-metrics (list 1 2 3)) (list 3 1 3 0))"
@@ -215,6 +234,15 @@ let private behaviouralChecks () : (string * string list) list = [
     "12.10.2", [ "(=? (real-part (make-rectangular 3 4)) 3)"
                  "(=? (imag-part (make-rectangular 3 4)) 4)"
                  "(=? (* (make-rectangular 0 1) (make-rectangular 0 1)) -1)" ]
+    // 15.1.5 / 15.1.7 / 15.1.8: a value written to a file and read back must come
+    // back equal. Numbers do not survive this, because `write` prints them as
+    // `<obj 42 : Int32>`, which `read` cannot parse -- the 3.6 divergence. Symbols,
+    // lists and booleans do.
+    "15.1.5", [ "(let ((f (. System.IO.Path GetTempFileName))) (sequence (let ((p (open-output-file f))) (sequence (write 'alpha p) (close-output-port p))) (. System.IO.File Delete f) #t))" ]
+    "15.1.7", [ "(let ((f (. System.IO.Path GetTempFileName))) (sequence (let ((p (open-output-file f))) (sequence (write 'alpha p) (close-output-port p))) (let ((p (open-input-file f))) (let ((v (read p))) (sequence (close-input-port p) (. System.IO.File Delete f) (equal? v 'alpha))))))" ]
+    "15.1.8", [ "(let ((f (. System.IO.Path GetTempFileName))) (sequence (let ((p (open-output-file f))) (sequence (write '(a b c) p) (close-output-port p))) (let ((p (open-input-file f))) (let ((v (read p))) (sequence (close-input-port p) (. System.IO.File Delete f) (equal? v '(a b c)))))))" ]
+    // 15.2.2: load evaluates the file's forms in the calling environment.
+    "15.2.2", [ "(let ((f (. System.IO.Path GetTempFileName))) (sequence (. System.IO.File WriteAllText f \"(define loaded-marker 7)\") (load f) (. System.IO.File Delete f) (=? loaded-marker 7)))" ]
     "12.10.3", [ "(<? (abs (- (magnitude (make-rectangular 3 4)) 5)) 0.000001)"
                  "(<? (abs (- (angle (make-rectangular 0 1)) 1.5707963267948966)) 0.000001)"
                  "(=? (make-polar 1 0) 1)" ]
@@ -242,7 +270,9 @@ let private behaviouralChecks () : (string * string list) list = [
 /// row is not read as "identical to the report".
 let private divergences () = [
     "3.6", "External representations differ: IronKernel prints a number as "
-           + "`<obj 3 : Int32>` rather than `3`."
+           + "`<obj 3 : Int32>` rather than `3`. `write` uses that spelling, so a "
+           + "number written to a port cannot be read back by `read`; symbols, lists "
+           + "and booleans round-trip."
     "12.2", "There is no exact/inexact distinction. Numbers are CLR primitives, so "
             + "exactness, bounds and robustness (module Inexact, 12.6) are absent and "
             + "no number can be an exact infinity."

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ This tree is a **hybrid CLR runtime**: programs are analyzed to a Core IR and co
 
 [`docs/kernel-conformance.md`](docs/kernel-conformance.md) tracks IronKernel against
 the [Revised-1 Report on the Kernel Programming Language](https://ftp.cs.wpi.edu/pub/techreports/pdf/05-07.pdf)
-(R-1RK), feature by feature. Of the report's 135 feature entries, **85 are verified
-by a behavioural check, 12 resolve but are unchecked, and 38 are absent**; 34 belong
-to modules the report marks optional. The matrix also reports status per *module*,
-which R-1RK 1.3.2 makes the unit of conformance: **25 of 34 modules are complete**.
+(R-1RK), feature by feature. Of the report's 135 feature entries, **97 are verified
+by a behavioural check and 38 are absent**; nothing is merely bound-but-unchecked.
+34 entries belong to modules the report marks optional. The matrix also reports
+status per *module*, which R-1RK 1.3.2 makes the unit of conformance: **25 of 34
+modules are complete**.
 
 Chapter 12's required **Numbers** module (12.5) is complete, as are the optional
 **Rational** (12.8), **Real** (12.9) and **Complex** (12.10) modules. Rational is

--- a/docs/kernel-conformance.md
+++ b/docs/kernel-conformance.md
@@ -25,8 +25,8 @@ rather than hidden behind a pass.
 
 | | Entries | Share |
 |---|---:|---:|
-| `verified` | 85 | 63% |
-| `bound` | 12 | 9% |
+| `verified` | 97 | 72% |
+| `bound` | 0 | 0% |
 | `partial` | 0 | 0% |
 | `absent` | 38 | 28% |
 | **total** | **135** | |
@@ -41,7 +41,7 @@ exercised, not that IronKernel matches the report exactly.
 
 | Report | Divergence |
 |---|---|
-| 3.6 | External representations differ: IronKernel prints a number as `<obj 3 : Int32>` rather than `3`. |
+| 3.6 | External representations differ: IronKernel prints a number as `<obj 3 : Int32>` rather than `3`. `write` uses that spelling, so a number written to a port cannot be read back by `read`; symbols, lists and booleans round-trip. |
 | 12.2 | There is no exact/inexact distinction. Numbers are CLR primitives, so exactness, bounds and robustness (module Inexact, 12.6) are absent and no number can be an exact infinity. |
 | 12.5.13 | `(max)` and `(min)` with no arguments signal an error. The report returns exact negative and positive infinity, which IronKernel cannot represent. |
 | 12.5.14 | `(gcd)` returns 0 and `(lcm)` returns 1. The report returns exact positive infinity for `(gcd)`. |
@@ -60,14 +60,14 @@ counts as complete here only when every one of its entries is `verified`.
 | Module | Required | Entries | Verified | Complete |
 |---|---|---:|---:|---|
 | 4.1 Core types and primitive features — Booleans | **required** | 1 | 1 | yes |
-| 4.2 Core types and primitive features — Equivalence under mutation (optional) | optional | 1 | 0 | no |
+| 4.2 Core types and primitive features — Equivalence under mutation (optional) | optional | 1 | 1 | yes |
 | 4.3 Core types and primitive features — Equivalence up to mutation | **required** | 1 | 1 | yes |
 | 4.4 Core types and primitive features — Symbols | **required** | 1 | 1 | yes |
 | 4.5 Core types and primitive features — Control | **required** | 2 | 2 | yes |
 | 4.6 Core types and primitive features — Pairs and lists | **required** | 3 | 3 | yes |
 | 4.7 Core types and primitive features — Pair mutation (optional) | optional | 2 | 0 | no |
 | 4.8 Core types and primitive features — Environments | **required** | 4 | 3 | no |
-| 4.9 Core types and primitive features — Environment mutation (optional) | optional | 1 | 0 | no |
+| 4.9 Core types and primitive features — Environment mutation (optional) | optional | 1 | 1 | yes |
 | 4.10 Core types and primitive features — Combiners | **required** | 5 | 5 | yes |
 | 5.1 Core library features (I) — Control | **required** | 1 | 1 | yes |
 | 5.2 Core library features (I) — Pairs and lists | **required** | 2 | 2 | yes |
@@ -83,10 +83,10 @@ counts as complete here only when every one of its entries is `verified`.
 | 6.2 Core library features (II) — Combiners | **required** | 1 | 1 | yes |
 | 6.3 Core library features (II) — Pairs and lists | **required** | 10 | 10 | yes |
 | 6.4 Core library features (II) — Pair mutation (optional) | optional | 4 | 0 | no |
-| 6.5 Core library features (II) — Equivalence under mutation (optional) | optional | 1 | 0 | no |
+| 6.5 Core library features (II) — Equivalence under mutation (optional) | optional | 1 | 1 | yes |
 | 6.6 Core library features (II) — Equivalence up to mutation | **required** | 1 | 1 | yes |
-| 6.7 Core library features (II) — Environments | **required** | 10 | 4 | no |
-| 6.8 Core library features (II) — Environment mutation (optional) | optional | 3 | 1 | no |
+| 6.7 Core library features (II) — Environments | **required** | 10 | 7 | no |
+| 6.8 Core library features (II) — Environment mutation (optional) | optional | 3 | 3 | yes |
 | 6.9 Core library features (II) — Control | **required** | 1 | 1 | yes |
 | 7.2 Continuations — Primitive features | **required** | 7 | 1 | no |
 | 7.3 Continuations — Library features | **required** | 4 | 1 | no |
@@ -101,15 +101,15 @@ counts as complete here only when every one of its entries is `verified`.
 | 12.9 Numbers — Real features | optional | 6 | 6 | yes |
 | 12.10 Numbers — Complex features | optional | 3 | 3 | yes |
 | 13.1 Strings — Primitive features | **required** | 1 | 0 | no |
-| 15.1 Ports — Primitive features | **required** | 8 | 0 | no |
-| 15.2 Ports — Library features | **required** | 3 | 0 | no |
+| 15.1 Ports — Primitive features | **required** | 8 | 3 | no |
+| 15.2 Ports — Library features | **required** | 3 | 1 | no |
 
 ## 4 Core types and primitive features
 
 | Entry | Feature | Module | Status | Notes |
 |---|---|---|---|---|
 | 4.1.1 | `boolean?` | Booleans | `verified` | 4 behavioural check(s) |
-| 4.2.1 | `eq?` | Equivalence under mutation (optional) | `bound` | optional module |
+| 4.2.1 | `eq?` | Equivalence under mutation (optional) | `verified` | optional module; 3 behavioural check(s) |
 | 4.3.1 | `equal?` | Equivalence up to mutation | `verified` | 3 behavioural check(s) |
 | 4.4.1 | `symbol?` | Symbols | `verified` | 3 behavioural check(s) |
 | 4.5.1 | `inert?` | Control | `verified` | 3 behavioural check(s) |
@@ -123,7 +123,7 @@ counts as complete here only when every one of its entries is `verified`.
 | 4.8.2 | `ignore?` | Environments | `absent` |  |
 | 4.8.3 | `eval` | Environments | `verified` | 1 behavioural check(s) |
 | 4.8.4 | `make-environment` | Environments | `verified` | 1 behavioural check(s) |
-| 4.9.1 | `$define!` | Environment mutation (optional) | `bound` | optional module |
+| 4.9.1 | `$define!` | Environment mutation (optional) | `verified` | optional module; 2 behavioural check(s) |
 | 4.10.1 | `operative?` | Combiners | `verified` | 3 behavioural check(s) |
 | 4.10.2 | `applicative?` | Combiners | `verified` | 3 behavioural check(s) |
 | 4.10.3 | `$vau` | Combiners | `verified` | 1 behavioural check(s) |
@@ -172,21 +172,21 @@ counts as complete here only when every one of its entries is `verified`.
 | 6.4.2 | `copy-es` | Pair mutation (optional) | `absent` | optional module |
 | 6.4.3 | `assq` | Pair mutation (optional) | `absent` | optional module |
 | 6.4.4 | `memq?` | Pair mutation (optional) | `absent` | optional module |
-| 6.5.1 | `eq?` | Equivalence under mutation (optional) | `bound` | optional module |
+| 6.5.1 | `eq?` | Equivalence under mutation (optional) | `verified` | optional module; 2 behavioural check(s) |
 | 6.6.1 | `equal?` | Equivalence up to mutation | `verified` | 2 behavioural check(s) |
 | 6.7.1 | `$binds?` | Environments | `absent` |  |
 | 6.7.2 | `get-current-environment` | Environments | `verified` | 1 behavioural check(s) |
 | 6.7.3 | `make-kernel-standard-environment` | Environments | `absent` |  |
 | 6.7.4 | `$let*` | Environments | `verified` | 1 behavioural check(s) |
 | 6.7.5 | `$letrec` | Environments | `verified` | 1 behavioural check(s) |
-| 6.7.6 | `$letrec*` | Environments | `bound` |  |
-| 6.7.7 | `$let-redirect` | Environments | `bound` |  |
+| 6.7.6 | `$letrec*` | Environments | `verified` | 1 behavioural check(s) |
+| 6.7.7 | `$let-redirect` | Environments | `verified` | 2 behavioural check(s) |
 | 6.7.8 | `$let-safe` | Environments | `absent` |  |
 | 6.7.9 | `$remote-eval` | Environments | `verified` | 1 behavioural check(s) |
-| 6.7.10 | `$bindings->environment` | Environments | `bound` |  |
+| 6.7.10 | `$bindings->environment` | Environments | `verified` | 2 behavioural check(s) |
 | 6.8.1 | `$set!` | Environment mutation (optional) | `verified` | optional module; 1 behavioural check(s) |
-| 6.8.2 | `$provide!` | Environment mutation (optional) | `bound` | optional module |
-| 6.8.3 | `$import!` | Environment mutation (optional) | `bound` | optional module |
+| 6.8.2 | `$provide!` | Environment mutation (optional) | `verified` | optional module; 2 behavioural check(s) |
+| 6.8.3 | `$import!` | Environment mutation (optional) | `verified` | optional module; 1 behavioural check(s) |
 | 6.9.1 | `for-each` | Control | `verified` | 1 behavioural check(s) |
 
 ## 7 Continuations
@@ -286,11 +286,11 @@ counts as complete here only when every one of its entries is `verified`.
 | 15.1.2 | `input-port?, output-port?` | Primitive features | `absent` | `input-port?` absent; `output-port?` absent |
 | 15.1.3 | `with-input-from-file, with-output-to-file` | Primitive features | `absent` | `with-input-from-file` absent; `with-output-to-file` absent |
 | 15.1.4 | `get-current-input-port, get-current-output-port` | Primitive features | `absent` | `get-current-input-port` absent; `get-current-output-port` absent |
-| 15.1.5 | `open-input-file, open-output-file` | Primitive features | `bound` |  |
+| 15.1.5 | `open-input-file, open-output-file` | Primitive features | `verified` | 1 behavioural check(s) |
 | 15.1.6 | `close-input-file, close-output-file` | Primitive features | `absent` | `close-input-file` absent; `close-output-file` absent |
-| 15.1.7 | `read` | Primitive features | `bound` |  |
-| 15.1.8 | `write` | Primitive features | `bound` |  |
+| 15.1.7 | `read` | Primitive features | `verified` | 1 behavioural check(s) |
+| 15.1.8 | `write` | Primitive features | `verified` | 1 behavioural check(s) |
 | 15.2.1 | `call-with-input-file, call-with-output-file` | Library features | `absent` | `call-with-input-file` absent; `call-with-output-file` absent |
-| 15.2.2 | `load` | Library features | `bound` |  |
+| 15.2.2 | `load` | Library features | `verified` | 1 behavioural check(s) |
 | 15.2.3 | `get-module` | Library features | `absent` |  |
 


### PR DESCRIPTION
Every entry whose bindings resolve now has a behavioural check. **Verified goes from 85 to 97; `bound` drops to zero** — that status was the one claiming more than it had earned.

`eq?`, `$define!`, `$letrec*`, `$let-redirect`, `$bindings->environment`, `$provide!`, `$import!`, `open-input-file`/`open-output-file`, `read`, `write`, `load`.

## Writing the checks exposed two bugs

**`IOFunc` discarded the rest of the computation — my regression.** It returned its result as `Done` rather than handing it to the continuation. `Done` ends the trampoline, which was harmless while every combiner ran inside its own nested `run`, but ADR 0004 phase 1 gave compiled code a *single* trampoline. Since then:

```
(define p (open-output-file f))
p   ⇒  error: unbound variable 'p'
```

The port became the value of the whole form and the binding never happened. I bisected against the commit before that work to confirm attribution: it is mine, and it has been on master since phase 1 merged. Every file primitive in nested position was affected.

**`load` evaluated its enclosing form twice — pre-existing.** It evaluated each form of the loaded file with the *caller's* continuation and then continued again, so a nested `(load f)` ran the rest of the caller once per loaded form, plus once more. Confirmed present before any of the ADR 0004 work. Each form now gets a fresh continuation.

## File I/O also faulted the process

Opening a missing or locked file raised a CLR exception that escaped the evaluator, exactly as division by zero used to:

```
(open-input-file "/nonexistent/x")   ⇒  unhandled IOException, process aborts
```

Now a Kernel error. This is the third instance of the same shape — arithmetic, then arithmetic overflow, now I/O — so it is worth treating as a pattern rather than three incidents: any CLR call reachable from a primitive needs its exceptions converted.

## What the port checks actually assert

A value written to a file and read back must come back `equal?`. **Numbers do not survive this**: `write` prints `42` as `<obj 42 : Int32>`, which `read` cannot parse. Symbols, lists and booleans do.

That is the 3.6 external-representation divergence, and the note now says what it costs rather than only what it looks like. The checks use the values that do round-trip, so they test `write`/`read` composing rather than asserting a bug.

Each port check deletes its temp file, so a repeated suite run leaves nothing behind.

## Status

**97 of 135 entries verified (72%), 0 bound, 38 absent.** 25 of 34 modules complete.

## Verification

Clean `--no-incremental` rebuild: 0 warnings, 0 errors. **275 tests pass on two consecutive runs.** Examples all exit 0 except `effects-async`, which fails identically on master — `await-task` returns `#inert` at top level, a pre-existing bug untouched here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789325112&installation_model_id=427656&pr_number=41&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F41&signature=166ce560d72b40d66f808ccf032baad7b2a5f0e8c3eca17c91bba282aa6c3911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->