### PR TITLE
Return the value an awaited task produced

### DIFF
--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -617,18 +617,36 @@
             | [found; _] -> fail (TypeMismatch("resumption", found))
             | bad -> fail (NumArgs(2, bad))
 
+        /// The result type has to be found by walking the base types, not by testing
+        /// the concrete one. An F# `task { ... return v }` is an
+        /// AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1, which *derives from*
+        /// Task<T> but whose own generic definition is not Task<>. Testing the
+        /// concrete type therefore always failed, and every awaited value was
+        /// discarded and reported as #inert.
+        let rec private taskResultType (candidate: Type) =
+            // `isNull` is shadowed in this module by the `null?` primitive.
+            if obj.ReferenceEquals(candidate, null) then None
+            elif candidate.IsGenericType
+                 && candidate.GetGenericTypeDefinition() = typedefof<Task<_>> then
+                Some candidate
+            else taskResultType candidate.BaseType
+
         let private taskOutcome (completed: Task) =
             try
                 completed.GetAwaiter().GetResult()
-                let taskType = completed.GetType()
-                if taskType.IsGenericType
-                   && taskType.GetGenericTypeDefinition() = typedefof<Task<_>> then
-                    match taskType.GetProperty("Result").GetValue(completed) with
-                    | null -> returnM Inert
-                    | :? LispVal as value -> returnM value
-                    | other -> returnM (Obj other)
-                else
-                    returnM Inert
+                match taskResultType (completed.GetType()) with
+                | Some taskType ->
+                    // `task { do! ... }` with no value is Task<VoidTaskResult>; that
+                    // carries no result and is inert.
+                    let resultType = taskType.GetGenericArguments().[0]
+                    if resultType.FullName = "System.Threading.Tasks.VoidTaskResult" then
+                        returnM Inert
+                    else
+                        match taskType.GetProperty("Result").GetValue(completed) with
+                        | null -> returnM Inert
+                        | :? LispVal as value -> returnM value
+                        | other -> returnM (Obj other)
+                | None -> returnM Inert
             with
             | :? OperationCanceledException as error -> throwError (ClrException error)
             | error -> throwError (ClrException error)

--- a/IronKernel.Tests/EffectTests.fs
+++ b/IronKernel.Tests/EffectTests.fs
@@ -129,3 +129,25 @@ let ``effects and async preserve interpreter compiler parity`` () =
           "(define effect (make-prompt-tag))"
           "(prompt effect (lambda (value k) (resume k value)) (+ 1 (perform effect 41)))"
           "(+ 1 (await-task (task-delay 5 41)))" ]
+
+[<Fact>]
+let ``await-task returns the awaited value`` () =
+    // The value used to be discarded and reported as #inert. An F# `task { ... }` is
+    // an AsyncStateMachineBox that *derives from* Task<T> without being it, so a check
+    // against the concrete type never matched. Nothing awaited a task and inspected
+    // the result, so only capability gating was covered and this went unnoticed.
+    withKernel (fun env ->
+        assertEval env "(await-task (task-delay 5 42))" (Obj 42)
+        assertEval env "(equal? (await-task (task-delay 5 'done)) 'done)" (Bool true)
+        // The value must survive being bound, not just being returned.
+        ignore (evalIn env "(define awaited (await-task (task-delay 5 7)))")
+        assertEval env "(=? awaited 7)" (Bool true)
+        // And it must compose with further computation rather than ending it.
+        assertEval env "(+ 1 (await-task (task-delay 5 41)))" (Obj 42))
+
+[<Fact>]
+let ``await-task rejects a non-task argument`` () =
+    let env = freshEnv ()
+    match evalIn env "(await-task 5)" with
+    | Status message -> Assert.Contains("Task", message)
+    | value -> failwithf "expected an error, got %s" (showVal value)

--- a/IronKernel.Tests/ExampleTests.fs
+++ b/IronKernel.Tests/ExampleTests.fs
@@ -81,3 +81,11 @@ let ``coroutines.ikr interleaves both computations and terminates`` () =
         [| "Hefty computation: 5"; "Hefty computation: 4"; "Hefty computation: 3"
            "Hefty computation: 2"; "Hefty computation: 1"; "Hefty computation: 0" |],
         hefty)
+
+[<Fact>]
+let ``effects-async.ikr resolves its handler and its awaited value`` () =
+    // Only packaged, never executed, so a broken awaited value went unnoticed here
+    // too -- the same coverage gap that hid the coroutines example.
+    let output = runExampleCapturingOutput "effects-async.ikr"
+    Assert.Contains("handled=42", output)
+    Assert.Contains("async complete", output)


### PR DESCRIPTION
`await-task` discarded the value of every task it awaited and returned `#inert`:

```
(define d (await-task (task-delay 25 "x")))
d   ⇒  #inert
```

`Examples/effects-async.ikr` had been failing because of this since before any of this work.

## Cause

`taskOutcome` tested the **concrete** runtime type against `Task<_>`:

```fsharp
if taskType.IsGenericType && taskType.GetGenericTypeDefinition() = typedefof<Task<_>> then
```

An F# `task { ... return v }` produces an `AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1`, which *derives from* `Task<T>` without being it. `GetGenericTypeDefinition()` returns the state-machine type, so the test never matched and every result fell through to `Inert`.

The result type is now found by walking the base types. `Task<VoidTaskResult>` — a `task { }` with no value — still yields inert, which is correct.

## Why it survived

Nothing had ever awaited a task and inspected the result. The async tests covered **capability gating only**, and `effects-async.ikr` was packaged but never executed — the same coverage gap that hid the broken coroutines example earlier in this work.

Both are closed:

- `await-task` returns the value, survives being bound, and composes with further computation.
- `effects-async.ikr` is executed in CI and its output asserted.

Both new tests were confirmed to **fail against the old behaviour** before being kept.

## Result

**All twelve examples now run.** 279 tests pass on two consecutive runs; the CLR fault scan still reports zero.

Worth noting what this was not: I had suspected it might be another casualty of the single-trampoline change in ADR 0004 phase 1, since that had already broken `IOFunc`'s continuation. It wasn't — `await-task` threads its continuation correctly and the bug predates that work entirely. The suspicion was reasonable but wrong, and checking was cheap.

## Verification

Clean `--no-incremental` rebuild: 0 warnings, 0 errors. **279 tests pass on two consecutive runs.** All twelve examples exit 0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789326870&installation_model_id=427656&pr_number=43&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F43&signature=caffc39951fcaf842fc85844106f8dcb815aa29438bae1a829b52c5c47345097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->