### PR TITLE
Implement module Narrow inexact (R-1RK 12.7.1)

### DIFF
--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -704,13 +704,25 @@
         /// guaranteed at the point a primitive first reads it.
         let private strictArithmeticKey () = Guid "9d2f5a10-7c3e-4b58-9a61-2f7c1d4e8b03"
 
+        /// R-1RK 12.7.1's narrow-arithmetic variable, the other of the pair.
+        let private narrowArithmeticKey () = Guid "4e81c6b2-05da-4f37-8c19-6b3a7f20d5ee"
+
+        let private booleanDynamicVariable key defaultValue cont =
+            match findDynamicBinding (key ()) cont with
+            | Some (Bool value) -> value
+            | _ -> defaultValue
+
         /// The report leaves the initial value open. True is what IronKernel has always
         /// done: a result with no primary value has been an error here rather than a
         /// NaN that propagates silently into later arithmetic.
         let private isStrictArithmetic cont =
-            match findDynamicBinding (strictArithmeticKey ()) cont with
-            | Some (Bool value) -> value
-            | _ -> true
+            booleanDynamicVariable strictArithmeticKey true cont
+
+        /// R-1RK 12.7.1 phrases narrowing as advice the client asks for, so it starts
+        /// off. Nothing here reads it beyond the accessor: see the divergence recorded
+        /// for 12.7 in the conformance matrix.
+        let private isNarrowArithmetic cont =
+            booleanDynamicVariable narrowArithmeticKey false cont
 
         /// R-1RK 12.2: a real with no primary value is NaN here. That is where the
         /// indeterminate infinity combinations land -- infinity minus infinity, zero
@@ -1356,27 +1368,46 @@
             | [_; _; _] -> fail (TypeMismatch("real", List args))
             | _ -> fail (NumArgs(3, args))
 
-        /// R-1RK 12.6.6: the binder and accessor of the strict-arithmetic keyed dynamic
-        /// variable. The binder is a keyed dynamic binder like any other (10.1.1), so
-        /// the setting follows the dynamic extent of the call including across captured
-        /// continuations; the accessor differs from a plain one only in answering with
-        /// the default when no binder encloses it.
-        let withStrictArithmetic env cont args =
+        /// R-1RK 12.6.6 and 12.7.1 are each "the binder and accessor of" a keyed
+        /// dynamic variable, so the binder is one from 10.1.1 -- the setting follows the
+        /// dynamic extent of its call, including across captured continuations -- and
+        /// the accessor differs from a plain one only in answering with a default when
+        /// no binder encloses it.
+        let private withBooleanVariable key env cont args =
             match args with
             | [Bool _ as flag; combiner] ->
                 let isolated = newEnvWithClr (ofEnvironment env) [] []
                 bounceOperate
                     isolated
-                    (makeDynamicBinding env cont (strictArithmeticKey ()) flag)
+                    (makeDynamicBinding env cont (key ()) flag)
                     combiner
                     []
             | [found; _] -> fail (TypeMismatch("boolean", found))
             | _ -> fail (NumArgs(2, args))
 
-        let getStrictArithmetic env cont args =
+        let private getBooleanVariable read env cont args =
             match args with
-            | [] -> bounceContinue env cont (Bool(isStrictArithmetic cont))
+            | [] -> bounceContinue env cont (Bool(read cont))
             | _ -> fail (NumArgs(0, args))
+
+        let withStrictArithmetic env cont args =
+            withBooleanVariable strictArithmeticKey env cont args
+
+        let getStrictArithmetic env cont args =
+            getBooleanVariable isStrictArithmetic env cont args
+
+        /// R-1RK 12.7.1. Setting this asks the implementation to maintain the most
+        /// restrictive bounding and robustness information it correctly can. It is
+        /// advice, and the report's only hard constraints are that whatever is
+        /// maintained be correct and be no less restrictive when the variable is true
+        /// than when it is false. IronKernel's bounds are the infinities either way, so
+        /// both hold and nothing observable changes; the matrix records that rather
+        /// than leaving a reader to discover it.
+        let withNarrowArithmetic env cont args =
+            withBooleanVariable narrowArithmeticKey env cont args
+
+        let getNarrowArithmetic env cont args =
+            getBooleanVariable isNarrowArithmetic env cont args
 
         let numeratorOf env cont args = ratioPart true env cont args
 
@@ -1643,6 +1674,8 @@
                   ("real->exact", realToExact);
                   ("with-strict-arithmetic", withStrictArithmetic);
                   ("get-strict-arithmetic?", getStrictArithmetic);
+                  ("with-narrow-arithmetic", withNarrowArithmetic);
+                  ("get-narrow-arithmetic?", getNarrowArithmetic);
                   ("clr-opens", clr_opens);
                   ]
 

--- a/IronKernel.Tests/InexactTests.fs
+++ b/IronKernel.Tests/InexactTests.fs
@@ -221,3 +221,48 @@ let ``with-strict-arithmetic requires a boolean and a combiner`` () =
             match evalIn env expression with
             | Status _ -> ()
             | value -> failwithf "%s should signal an error, got %s" expression (showVal value))
+
+[<Fact>]
+let ``narrow arithmetic is a keyed dynamic variable that starts cleared`` () =
+    // R-1RK 12.7.1. Narrowing is advice the client asks for, so it starts off.
+    [
+        "(eqv? (get-narrow-arithmetic?) #f)", Bool true
+        "(with-narrow-arithmetic #t (lambda () (get-narrow-arithmetic?)))", Bool true
+        "(with-narrow-arithmetic #t (lambda () (with-narrow-arithmetic #f (lambda () (get-narrow-arithmetic?)))))",
+            Bool false
+        "(with-narrow-arithmetic #t (lambda () (with-narrow-arithmetic #f (lambda () 0)) (get-narrow-arithmetic?)))",
+            Bool true
+        "(eqv? (get-narrow-arithmetic?) #f)", Bool true
+        // The two arithmetic variables of 12.6.6 and 12.7.1 are separate.
+        "(with-narrow-arithmetic #t (lambda () (get-strict-arithmetic?)))", Bool true
+        "(with-strict-arithmetic #f (lambda () (get-narrow-arithmetic?)))", Bool false
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``the bounds are no less restrictive when narrow arithmetic is set`` () =
+    // This is the report's only hard constraint on the information maintained, besides
+    // correctness: it "cannot be less restrictive when the variable is true than when
+    // the variable is false". IronKernel narrows nothing, so the two intervals are
+    // equal, which satisfies containment -- and the check would catch a later change
+    // that made the narrow bounds *wider* rather than tighter.
+    [
+        "(define wide (with-narrow-arithmetic #f (lambda () (get-real-exact-bounds 0.5))))", Inert
+        "(define narrow (with-narrow-arithmetic #t (lambda () (get-real-exact-bounds 0.5))))", Inert
+        "(<=? (car wide) (car narrow))", Bool true
+        "(<=? (car (cdr narrow)) (car (cdr wide)))", Bool true
+        // And robustness cannot go backwards either.
+        "(define robust-wide (with-narrow-arithmetic #f (lambda () (robust? 0.5))))", Inert
+        "(define robust-narrow (with-narrow-arithmetic #t (lambda () (robust? 0.5))))", Inert
+        "(if robust-wide robust-narrow #t)", Bool true
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``with-narrow-arithmetic requires a boolean and a combiner`` () =
+    withKernel (fun env ->
+        for expression in
+            [ "(with-narrow-arithmetic 1 (lambda () 0))"
+              "(with-narrow-arithmetic #t)"
+              "(get-narrow-arithmetic? 1)" ] do
+            match evalIn env expression with
+            | Status _ -> ()
+            | value -> failwithf "%s should signal an error, got %s" expression (showVal value))

--- a/IronKernel.Tests/KernelConformanceTests.fs
+++ b/IronKernel.Tests/KernelConformanceTests.fs
@@ -330,6 +330,24 @@ let private behaviouralChecks () : (string * string list) list = [
                 + " (number? (- #e+infinity #e+infinity))))"
                 "(with-strict-arithmetic #f (lambda ()"
                 + " (eqv? (robust? (- #e+infinity #e+infinity)) #f)))" ]
+    // R-1RK 12.7.1. Narrowing is advice, so the checks assert what the report
+    // actually requires: the binder and accessor behave as a keyed dynamic variable,
+    // and the bounding information is no less restrictive when the variable is set
+    // than when it is cleared.
+    "12.7.1", [ "(eqv? (with-narrow-arithmetic #t (lambda () (get-narrow-arithmetic?))) #t)"
+                "(eqv? (with-narrow-arithmetic #f (lambda () (get-narrow-arithmetic?))) #f)"
+                "(eqv? (get-narrow-arithmetic?) #f)"
+                "(eqv? (with-narrow-arithmetic #t (lambda ()"
+                + " (with-narrow-arithmetic #f (lambda () (get-narrow-arithmetic?))))) #f)"
+                // The two arithmetic variables are separate.
+                "(with-narrow-arithmetic #t (lambda () (get-strict-arithmetic?)))"
+                // The report's only hard constraint on what is maintained, besides
+                // correctness: the interval when set is contained in the one when
+                // cleared.
+                "(<=? (car (with-narrow-arithmetic #f (lambda () (get-real-exact-bounds 0.5))))"
+                + " (car (with-narrow-arithmetic #t (lambda () (get-real-exact-bounds 0.5)))))"
+                "(<=? (car (cdr (with-narrow-arithmetic #t (lambda () (get-real-exact-bounds 0.5)))))"
+                + " (car (cdr (with-narrow-arithmetic #f (lambda () (get-real-exact-bounds 0.5))))))" ]
     "12.8.1", [ "(rational? 1)"; "(rational? 1.5)"; "(rational? 1/3)"
                 "(eqv? (rational? 'a) #f)"; "(rational?)"
                 // A ratio is not an integer, and reduces to one when it can.
@@ -435,6 +453,13 @@ let private divergences () = [
             + "above its upper bound, so the report's `undefined` number never arises "
             + "and `undefined?` is always false. Narrowing the bounds is what module "
             + "Narrow inexact (12.7) asks for, and that module is absent."
+    "12.7", "Module Narrow inexact is supported in the sense the report requires -- "
+            + "the variable binds and reads, and the bounding information is no less "
+            + "restrictive when it is set than when it is cleared -- but setting it "
+            + "changes nothing observable. Narrowing is advice (\"the implementation is "
+            + "advised to maintain the most restrictive bounding and robustness "
+            + "information it (correctly) can\"), and IronKernel maintains the "
+            + "infinite bounds of 12.2 either way."
     "12.3.3", "Under strict arithmetic the report signals on numeric overflow and "
               + "underflow as well as on a result with no primary value. IronKernel "
               + "signals only the latter: an overflow still yields an infinity and an "

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ This tree is a **hybrid CLR runtime**: programs are analyzed to a Core IR and co
 
 [`docs/kernel-conformance.md`](docs/kernel-conformance.md) tracks IronKernel against
 the [Revised-1 Report on the Kernel Programming Language](https://ftp.cs.wpi.edu/pub/techreports/pdf/05-07.pdf)
-(R-1RK), feature by feature. Of the report's 135 feature entries, **105 are verified
-by a behavioural check and 30 are absent**; nothing is merely bound-but-unchecked.
+(R-1RK), feature by feature. Of the report's 135 feature entries, **106 are verified
+by a behavioural check and 29 are absent**; nothing is merely bound-but-unchecked.
 34 entries belong to modules the report marks optional. The matrix also reports
-status per *module*, which R-1RK 1.3.2 makes the unit of conformance: **32 of 44
+status per *module*, which R-1RK 1.3.2 makes the unit of conformance: **33 of 44
 modules are complete**.
 
-Every entry of chapter 12's **Numbers** (12.5), **Inexact** (12.6), **Rational**
-(12.8), **Real** (12.9) and **Complex** (12.10) modules has a passing check, and
-exact arithmetic meets what R-1RK 12.3.2 requires: exact integers are of arbitrary
+**Every entry of chapter 12 now has a passing check** — Numbers (12.5), Inexact
+(12.6), Narrow inexact (12.7), Rational (12.8), Real (12.9) and Complex (12.10).
+Exact arithmetic meets what R-1RK 12.3.2 requires: exact integers are of arbitrary
 size and promote rather than wrapping, dividing them gives an exact ratio, so
 `(/ 1 3)` is a third and three of them are exactly one, and both exact real
 infinities exist. Ratios are kept in least terms and read back as `1/3`; `(max)`

--- a/docs/kernel-conformance.md
+++ b/docs/kernel-conformance.md
@@ -25,10 +25,10 @@ rather than hidden behind a pass.
 
 | | Entries | Share |
 |---|---:|---:|
-| `verified` | 105 | 78% |
+| `verified` | 106 | 79% |
 | `bound` | 0 | 0% |
 | `partial` | 0 | 0% |
-| `absent` | 30 | 22% |
+| `absent` | 29 | 21% |
 | **total** | **135** | |
 
 34 of 135 entries belong to modules the report marks optional; an
@@ -44,6 +44,7 @@ exercised, not that IronKernel matches the report exactly.
 | 3.6 | External representations differ: IronKernel prints a number as `<obj 3 : Int32>` rather than `3`. `write` uses that spelling, so a number written to a port cannot be read back by `read`; symbols, lists and booleans round-trip. |
 | 12.9 | The report specifies 12.9.2 through 12.9.6 by signature only. Appendix A.2 records that it is an incomplete draft whose unwritten portions were "only planned in rough outline", so `verified` there means the binding exists with its standard mathematical meaning, and the choices the report leaves open are IronKernel's: an argument outside a function's real domain takes its complex value now that 12.10 is supported, so `(sqrt -1)` is `i`; a result with no primary value follows 12.2's rule and so signals under strict arithmetic and is returned without it; and infinities are returned as values. |
 | 12.2 | Inexact reals are non-robust with bounds of exact negative and positive infinity, which 12.2 sanctions explicitly ("an implementation can fully support module Inexact without making any effort to maintain finite bounds or robustness"). Two things follow. `robust?` is exactly "every argument is exact". And no number is ever created with its lower bound above its upper bound, so the report's `undefined` number never arises and `undefined?` is always false. Narrowing the bounds is what module Narrow inexact (12.7) asks for, and that module is absent. |
+| 12.7 | Module Narrow inexact is supported in the sense the report requires -- the variable binds and reads, and the bounding information is no less restrictive when it is set than when it is cleared -- but setting it changes nothing observable. Narrowing is advice ("the implementation is advised to maintain the most restrictive bounding and robustness information it (correctly) can"), and IronKernel maintains the infinite bounds of 12.2 either way. |
 | 12.3.3 | Under strict arithmetic the report signals on numeric overflow and underflow as well as on a result with no primary value. IronKernel signals only the latter: an overflow still yields an infinity and an underflow a zero, which is the report's behaviour for *cleared* strict-arithmetic. Its initial value here is true, which the report leaves open. |
 | 4.2.1 | `eq?` is bound to the same structural comparison as `eqv?`, so it is coarser than the report's, which distinguishes objects that `equal?` does not. |
 | 12.10 | Complex numbers are `System.Numerics.Complex`, so components are double precision and a result whose imaginary part is zero collapses back to a real. The report specifies 12.10 by signature only. |
@@ -100,7 +101,7 @@ divergences before taking any row as a claim of conformance.
 | 11.1 Keyed static variables — Primitive features | **required** | 1 | 1 | yes |
 | 12.5 Numbers — Number features | **required** | 14 | 14 | yes |
 | 12.6 Numbers — Inexact features | optional | 6 | 6 | yes |
-| 12.7 Numbers — Narrow inexact features | optional | 1 | 0 | no |
+| 12.7 Numbers — Narrow inexact features | optional | 1 | 1 | yes |
 | 12.8 Numbers — Rational features | optional | 5 | 5 | yes |
 | 12.9 Numbers — Real features | optional | 6 | 6 | yes |
 | 12.10 Numbers — Complex features | optional | 3 | 3 | yes |
@@ -260,7 +261,7 @@ divergences before taking any row as a claim of conformance.
 | 12.6.4 | `make-inexact` | Inexact features | `verified` | optional module; 4 behavioural check(s) |
 | 12.6.5 | `real->inexact, real->exact` | Inexact features | `verified` | optional module; 6 behavioural check(s) |
 | 12.6.6 | `with-strict-arithmetic, get-strict-arithmetic?` | Inexact features | `verified` | optional module; 6 behavioural check(s) |
-| 12.7.1 | `with-narrow-arithmetic, get-narrow-arithmetic?` | Narrow inexact features | `absent` | optional module; `with-narrow-arithmetic` absent; `get-narrow-arithmetic?` absent |
+| 12.7.1 | `with-narrow-arithmetic, get-narrow-arithmetic?` | Narrow inexact features | `verified` | optional module; 7 behavioural check(s) |
 | 12.8.1 | `rational?` | Rational features | `verified` | optional module; 7 behavioural check(s) |
 | 12.8.2 | `/` | Rational features | `verified` | optional module; 7 behavioural check(s) |
 | 12.8.3 | `numerator, denominator` | Rational features | `verified` | optional module; 12 behavioural check(s) |

--- a/tools/clr-fault-cases.txt
+++ b/tools/clr-fault-cases.txt
@@ -142,3 +142,6 @@
 (gcd 0)
 (lcm 0 5)
 (max)
+(with-narrow-arithmetic 1 (lambda () 0))
+(get-narrow-arithmetic? 1)
+(with-narrow-arithmetic #t (lambda () (car ())))


### PR DESCRIPTION
`with-narrow-arithmetic` and `get-narrow-arithmetic?` are "the binder and accessor of the narrow-arithmetic keyed dynamic variable", so they are a keyed dynamic binder and accessor from 10.1.1 (#46), exactly like the strict-arithmetic pair beside them. That machinery is now shared between the two instead of written twice — only the key and the default differ. Narrowing is something the client asks for, so this one starts cleared.

The module assumes module Inexact, which §1.3.2 requires for support and which landed in #48.

## Setting it changes nothing observable, and the matrix says so

This is the part worth being explicit about. Narrowing is **advice**:

> the implementation is advised to maintain the most restrictive bounding and robustness information it (correctly) can. The only constraint on such information, besides correctness, is that it cannot be less restrictive when the variable is true than when the variable is false.

IronKernel keeps the infinite bounds of §12.2 either way, so both hard constraints hold and the module is genuinely supported — but a reader deserves to know that setting the flag does not tighten anything. That is recorded as a divergence rather than left for someone to discover.

## The checks assert the constraint, not the round-trip

It would have been easy to check only that the flag reads back what was set. The checks also assert the report's actual requirement — that the bounding interval when set is *contained in* the interval when cleared, and that robustness cannot go backwards:

```
(define wide   (with-narrow-arithmetic #f (lambda () (get-real-exact-bounds 0.5))))
(define narrow (with-narrow-arithmetic #t (lambda () (get-real-exact-bounds 0.5))))
(<=? (car wide) (car narrow))              => #t
(<=? (car (cdr narrow)) (car (cdr wide)))  => #t
```

Today the two intervals are equal, so containment holds trivially — but these would catch a later change that widened the narrow bounds instead of tightening them, which is the way this can actually go wrong.

## Verification

- 320 tests pass (was 317); clean `--no-incremental` rebuild, 0 warnings
- every example runs (`yingyang.ikr` is the non-terminating puzzle by design)
- CLR fault sweep: zero process aborts across 147 cases
- `CompilerBenchmarks` unchanged

**Every entry of chapter 12 now has a passing behavioural check** — Numbers, Inexact, Narrow inexact, Rational, Real and Complex. **106 of 135** entries verified, **33 of 44** modules.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789336703&installation_model_id=427656&pr_number=49&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F49&signature=e1fcef2ffdfbf53529f1f71f16c917a206ef14994702fafa5319fd7a8765a318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->