### PR TITLE
Route operative capture through an immutable-acquisition seam (ADR 0005 phase 0)

### DIFF
--- a/IronKernel.Runtime/Ast.fs
+++ b/IronKernel.Runtime/Ast.fs
@@ -277,6 +277,25 @@ module Ast =
 
     and ThrowsError<'a> = Choice<LispError,'a>
 
+    /// R-1RK 4.7.2's operation at the value level: the object with an immutable
+    /// evaluation structure -- the set of pairs reachable from it without passing
+    /// through a non-pair. `$vau` (4.10.3) acquires immutable copies of the structures
+    /// it captures, which is what keeps an algorithm from changing under the combiner
+    /// that captured it.
+    ///
+    /// Every IronKernel pair is already immutable, so this returns its argument and
+    /// costs nothing. It exists as a named seam because that stops being true when
+    /// pairs become mutable cells (ADR 0005). `OperativeRecord.compiledBody` memoises
+    /// a compiled body and is sound only while the body cannot change after capture,
+    /// so the capture sites route through here *before* mutation exists rather than
+    /// being found again afterwards.
+    let acquireImmutable (value: LispVal) = value
+
+    /// The same, for a body held as a list of forms rather than as one structure.
+    /// Identity today, and deliberately not `List.map acquireImmutable`: that would
+    /// allocate a new list on every operative construction to no effect.
+    let acquireImmutableForms (forms: LispVal list) = forms
+
     let makeObj = (fun x -> x :> obj  |> Obj)
 
     let allHostCapabilities : CapabilitySet =

--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -401,15 +401,30 @@
                         // caller's `cont` ran the rest of the caller's computation once
                         // per loaded form, and then `bounceContinue` ran it again, so a
                         // nested (load f) evaluated its enclosing form twice.
+                        //
+                        // R-1RK 15.2.2 has load acquire immutable copies of what it
+                        // captures; it captures nothing here. Each form is evaluated and
+                        // discarded, and an operative created along the way acquires its
+                        // own structure through `vau` above (ADR 0005 phase 0).
                         let evaluateForm form = eval env (newContinuation env) form
                         match sequence (List.map evaluateForm lisp) [] with
                         | Choice1Of2 e -> fail e
                         | Choice2Of2 _ -> bounceContinue env cont Inert
             | badform -> fail (NumArgs(1, badform))
 
+        /// R-1RK 4.10.3. The parameter tree and the body are acquired immutably, per
+        /// 4.7.2: an operative must not change under whoever captured it. See ADR 0005
+        /// -- today `acquireImmutable` is the identity, and this is the seam that has to
+        /// start copying when pairs become mutable.
         let vau _env cont xs = 
             match xs with
-            | prms :: Atom e :: body   -> bounceContinue _env cont (Operative{ prms = prms; envarg = e; body = body; closure = _env; compiledBody = None} ) 
+            | prms :: Atom e :: body   ->
+                bounceContinue _env cont (
+                    Operative{ prms = acquireImmutable prms
+                               envarg = e
+                               body = acquireImmutableForms body
+                               closure = _env
+                               compiledBody = None } ) 
             | _ -> fail (Default("invalid arguments"))
 
         let define env cont xs = 
@@ -1302,7 +1317,7 @@
         /// (6.4.2), which the report requires to return a *fresh* pair.
         let copyEsImmutable env cont args =
             match args with
-            | [object'] -> bounceContinue env cont object'
+            | [object'] -> bounceContinue env cont (acquireImmutable object')
             | _ -> fail (NumArgs(1, args))
 
         /// R-1RK 7.2.1: the primitive type predicate for type continuation.

--- a/IronKernel.Tests/PairMutationTests.fs
+++ b/IronKernel.Tests/PairMutationTests.fs
@@ -73,3 +73,30 @@ let ``copy-es-immutable and copy-es take exactly one argument`` () =
             match evalIn env expression with
             | Status _ -> ()
             | value -> failwithf "%s should signal an error, got %s" expression (showVal value))
+
+[<Fact>]
+let ``a memoised body keeps answering as the body that was captured`` () =
+    // OperativeRecord.compiledBody memoises the compiled form of a body after first
+    // application, so the second call runs the memo rather than the captured forms.
+    // That is sound only while the body cannot change after $vau captured it, which
+    // is what immutable acquisition guarantees (R-1RK 4.10.3 / 4.7.2, ADR 0005
+    // phase 0). Applying an operative repeatedly, and through both the interpreted
+    // and the compiled construction paths, has to keep giving the captured answer.
+    [
+        "(define f (vau (x) _ (+ 1 2)))", Inert
+        "(=? (f 0) 3)", Bool true
+        "(=? (f 0) 3)", Bool true
+        "(=? (f 0) 3)", Bool true
+        // A wrapped one, whose body runs through the same memo.
+        "(define g (wrap (vau (x) _ (* x 2))))", Inert
+        "(=? (g 21) 42)", Bool true
+        "(=? (g 21) 42)", Bool true
+        // Rebinding a name the body mentions is lexical, not a change to the body:
+        // the operative keeps its closure and the memo stays correct.
+        "(define n 1)", Inert
+        "(define h (wrap (vau () _ n)))", Inert
+        "(=? (h) 1)", Bool true
+        "(set! (get-current-environment) n 2)", Inert
+        "(=? (h) 2)", Bool true
+        "(=? (h) 2)", Bool true
+    ] |> evalSessionKernel

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -129,7 +129,16 @@ module Compiler =
                     let bodyLv = List.map toLispVal body
                     completed <-
                         KernelFunc(fun env cont ->
-                            let op = Operative { prms = formals; envarg = envarg; body = bodyLv; closure = env; compiledBody = None }
+                            // The same immutable acquisition the `vau` primitive
+                            // performs (R-1RK 4.10.3 / 4.7.2, ADR 0005 phase 0): a
+                            // compiled $vau captures structure exactly as an
+                            // interpreted one does.
+                            let op =
+                                Operative { prms = acquireImmutable formals
+                                            envarg = envarg
+                                            body = acquireImmutableForms bodyLv
+                                            closure = env
+                                            compiledBody = None }
                             bounceContinue env cont op)
                         :: completed
                 | CEval (environmentExpression, valueExpression) ->

--- a/docs/adr/0005-mutable-pairs.md
+++ b/docs/adr/0005-mutable-pairs.md
@@ -1,6 +1,6 @@
 # ADR 0005: Mutable pairs
 
-Status: Proposed
+Status: Accepted — phase 0 done, phases 1-6 outstanding
 
 ## Decision
 
@@ -146,11 +146,19 @@ Two further caveats, both real:
 
 ## Plan
 
-**Phase 0 — `$vau` and `load` copy their captured structure.** Add
-`copy-es-immutable` behaviour to operative construction and to `load`. Today this
-is a no-op, because every pair is already immutable, so it lands with no
-observable change and no risk. It is what makes the `compiledBody` memo sound
-later, and doing it first means the later phases cannot silently invalidate it.
+**Phase 0 — capture goes through an immutable-acquisition seam.** *Done.* Both
+operative construction sites — the `vau` primitive and the compiler's `CVau` —
+route the parameter tree and body through `acquireImmutable` /
+`acquireImmutableForms`, which are the identity today because every pair is
+already immutable. It lands with no observable change and no risk, and it is what
+makes the `compiledBody` memo sound later; doing it first means the later phases
+cannot silently invalidate it.
+
+`load` needed no seam, contrary to the first draft of this plan. R-1RK 15.2.2 has
+it acquire immutable copies of what it captures, and IronKernel's `load` captures
+nothing: each parsed form is evaluated and discarded, and an operative created
+along the way acquires its own structure through `vau`. That is recorded as a
+comment there rather than as a call that would do nothing.
 
 **Phase 1 — introduce the cell.** Replace the two union cases with `Pair of
 PairCell` plus `Nil`, keep `List`/`DottedList` as the active patterns described


### PR DESCRIPTION
Phase 0 of [ADR 0005](docs/adr/0005-mutable-pairs.md). **No behaviour change** — this is a seam, deliberately landed while it costs nothing.

## What and why

§4.10.3 has `$vau` acquire immutable copies of the parameter tree and body it captures, so an algorithm cannot change under the combiner that captured it. IronKernel gets that for free today because every pair is immutable — and it *quietly depends* on it: `OperativeRecord.compiledBody` memoises the compiled form of a body after first application, which is sound only while the body cannot change afterwards.

Both capture sites — the `vau` primitive and the compiler's `CVau` — now route through `acquireImmutable` / `acquireImmutableForms`. Both are the identity, so nothing changes and nothing costs. `acquireImmutableForms` is deliberately *not* `List.map acquireImmutable`, which would allocate a new list per operative to no effect.

The point is that when pairs become cells, the copying starts in one named place that already exists, rather than in capture sites someone has to find again while the memo goes silently stale.

## A correction to the ADR

`load` needed no seam. §15.2.2 has it acquire immutable copies of what it captures, and this `load` captures nothing: each parsed form is evaluated and discarded, and an operative created along the way acquires its own structure through `vau`. The ADR said to add one there; it's corrected, and a comment records the reasoning at `load` itself.

## On the test

The test added is a regression test for **the memo**, not for the seam — with everything immutable, no test can distinguish the seam from its absence, and I'd rather say that than add a check that cannot fail. It applies operatives repeatedly through both construction paths, and pins that rebinding a name the body mentions is lexical rather than a change to the body. That last property is what phase 3 must not break.

## Verification

- 341 tests pass (was 340); clean `--no-incremental` rebuild, 0 warnings
- every example runs (`yingyang.ikr` is the non-terminating puzzle by design)
- CLR fault sweep: zero process aborts across 169 cases
- `CompilerBenchmarks` unchanged, allocation byte-identical (592 / 1872 / 808 / 304 B)

ADR 0005 moves to **Accepted — phase 0 done, phases 1-6 outstanding**.

Next is phase 1: introduce `Pair of PairCell`, keep `List`/`DottedList` as active patterns, rename the constructors. That one is large but still behaviour-neutral, and it's the phase where the benchmark numbers above are the thing to watch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789343180&installation_model_id=427656&pr_number=54&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F54&signature=9a3ea90b5eef9c34e622e27cc668d357204736916d86fdce581adf66b635d697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->