### PR TITLE
Give the empty list one observable spelling (ADR 0005, phase 1 prerequisite)

### DIFF
--- a/IronKernel.Runtime/Eval.fs
+++ b/IronKernel.Runtime/Eval.fs
@@ -410,7 +410,12 @@ module Eval =
                 match defineVar newEnv envarg _env with
                 | Choice1Of2 error -> fail error
                 | Choice2Of2 _ -> evalBody newEnv
-        | Inert -> More (fun () -> continueEvalStep _env cont Nil)
+        // The empty list is spelled `List []` everywhere a Kernel program can observe
+        // it. Returning the bare `Nil` case here made a value that was neither `null?`
+        // nor `eqv?` to itself, because the predicates and the equivalence walk only
+        // know the `List` spelling. ADR 0005 phase 1 removes the duplicate case; until
+        // then the producers normalise.
+        | Inert -> More (fun () -> continueEvalStep _env cont (List []))
         | _ -> fail (BadSpecialForm ("Expecting a combiner, got ", func))
 
     and bindStep env cont lf rf : Step =

--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -100,6 +100,10 @@
                     pending.Push(x, y)
                     pushLists xs ys
                 | List xs, List ys -> pushLists xs ys
+                // Both spellings of the empty list, and either against the other. Left
+                // out, `Nil` was not even equal to itself, which breaks the reflexivity
+                // R-1RK 4.3.1 requires of an equivalence predicate.
+                | Nil, Nil | Nil, List [] | List [], Nil -> ()
                 | _ -> equal <- false
 
             equal
@@ -209,6 +213,10 @@
 
         let isNull env cont = function 
             | [List[]]   -> bounceContinue env cont <| Bool(true) 
+            // The producers normalise to `List []`, but the predicate accepts the bare
+            // case too, so that a future one cannot quietly reintroduce a value that is
+            // not `null?`.
+            | [Nil]      -> bounceContinue env cont <| Bool(true) 
             | _          -> bounceContinue env cont <| Bool(false)
 
         let isEnvironment env cont = function 

--- a/IronKernel.Tests/PairMutationTests.fs
+++ b/IronKernel.Tests/PairMutationTests.fs
@@ -100,3 +100,23 @@ let ``a memoised body keeps answering as the body that was captured`` () =
         "(=? (h) 2)", Bool true
         "(=? (h) 2)", Bool true
     ] |> evalSessionKernel
+
+[<Fact>]
+let ``the empty list has one spelling that a program can observe`` () =
+    // The type carries both `Nil` and `List []`, and only the second was recognised.
+    // Applying #inert produced the bare case, which was neither `null?` nor `eqv?` to
+    // itself -- a value not equal to itself breaks the reflexivity R-1RK 4.3.1
+    // requires of an equivalence predicate. ADR 0005 phase 1 removes the duplicate
+    // case; until then the producers normalise and the predicates accept both.
+    [
+        "(null? (#inert))", Bool true
+        "(eqv? (#inert) (#inert))", Bool true
+        "(equal? (#inert) (#inert))", Bool true
+        // and it is the same empty list as one built at runtime
+        "(eqv? (#inert) (list))", Bool true
+        "(eqv? (#inert) (cdr (list 1)))", Bool true
+        "(eqv? (list) (list))", Bool true
+        // still not a pair, and still counts as a list
+        "(eqv? (pair? (#inert)) #f)", Bool true
+        "(=? (length (#inert)) 0)", Bool true
+    ] |> evalSessionKernel

--- a/IronKernel/CorePackage.fs
+++ b/IronKernel/CorePackage.fs
@@ -82,7 +82,9 @@ module CorePackage =
         | 2uy -> DottedList(readValues (), readValue (depth + 1) reader)
         | 3uy -> Bool(reader.ReadBoolean())
         | 4uy -> Inert
-        | 5uy -> Nil
+        // Normalised to the `List` spelling of the empty list: a decoded `Nil` was not
+        // `eqv?` to an empty list built at runtime. See Eval's note.
+        | 5uy -> List []
         | 6uy -> Keyword(readString reader)
         | 7uy -> Obj null
         | 8uy -> Obj(box (readString reader))

--- a/docs/adr/0005-mutable-pairs.md
+++ b/docs/adr/0005-mutable-pairs.md
@@ -160,6 +160,17 @@ nothing: each parsed form is evaluated and discarded, and an operative created
 along the way acquires its own structure through `vau`. That is recorded as a
 comment there rather than as a call that would do nothing.
 
+**Phase 1 prerequisite — one spelling of the empty list.** *Done.* `LispVal`
+carries both `Nil` and `List []`, and only the second was recognised: applying
+`#inert` produced the bare case, which was neither `null?` nor `eqv?` to itself.
+A value that is not equal to itself breaks the reflexivity 4.3.1 requires of an
+equivalence predicate, and the package decoder produced the same case for tag 5,
+so a value read back from a `.ikc` was not `eqv?` to the equal value built at
+runtime. The producers now normalise and the predicates accept both spellings.
+Collapsing the two cases on top of that inconsistency would have buried the bug
+rather than fixed it, so it is fixed first and phase 1 removes the duplicate case
+outright.
+
 **Phase 1 — introduce the cell.** Replace the two union cases with `Pair of
 PairCell` plus `Nil`, keep `List`/`DottedList` as the active patterns described
 above, and edit the construction sites to the renamed helpers. The type checker

--- a/tools/clr-fault-cases.txt
+++ b/tools/clr-fault-cases.txt
@@ -167,3 +167,6 @@
 (assq 1 5)
 (memq? 1 5)
 (assq 1 (list 5))
+(#inert)
+(null? (#inert))
+(eqv? (#inert) (list))


### PR DESCRIPTION
**This is not phase 1.** Starting phase 1 turned up a bug that phase 1 would have buried, so this fixes that first. See the note at the bottom on the rest.

## The bug

`LispVal` carries two empty lists — the `Nil` case and `List []` — and only the second was recognised anywhere. `null?` matched `List []` only, `pair?` likewise, and the equivalence walk in `eqvValue` had **no `Nil` case at all**, so it fell through to "not equal".

`Nil` is reachable: applying `#inert` returns it, and the package decoder produces it for tag 5.

```
(null? (#inert))            was #f
(eqv? (#inert) (#inert))    was #f
(equal? (#inert) (#inert))  was #f
```

A value that is not equal to itself breaks the reflexivity §4.3.1 requires of an equivalence predicate — and `eq?`, `eqv?` and `equal?` are all **required** entries. The package path is worse in kind than in effect: a value read back from a `.ikc` was not `eqv?` to the equal value built at runtime.

## The fix

Both producers now yield `List []`, and `null?` and the equivalence walk accept the bare case as well, so a future producer cannot quietly reintroduce a value that is neither `null?` nor equal to itself. Phase 1 removes the duplicate case outright — this is what it has to be removed *onto*, since collapsing the two representations on top of the inconsistency would have hidden it rather than fixed it.

## Verification

- 342 tests pass (was 341); clean `--no-incremental` rebuild, 0 warnings
- every example runs (`yingyang.ikr` is the non-terminating puzzle by design)
- CLR fault sweep: zero process aborts across 172 cases
- conformance matrix unchanged

## On phase 1 proper

I stopped here rather than pressing on. Phase 1 is the 121-site representation change plus custom equality on the cell (structural equality on a mutable record would hang on a cycle), plus rewriting `showVal`, the parser and the analyzer traversals onto cells — and it is the change where a subtle mistake sits in the core data type of the language rather than in a feature. I would rather start it with a full budget than land two thirds of it at the end of a long session.

The ADR now records this prerequisite as done, so phase 1 begins from a consistent baseline.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789343580&installation_model_id=427656&pr_number=55&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F55&signature=8cec7e0522f25524e83788261c54dd62deffcf2f4e71db00f41291b0a2ed8f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->