### PR TITLE
Convert pairs to cons cells (ADR 0005 phase 1)

### DIFF
--- a/IronKernel.Benchmarks/Program.fs
+++ b/IronKernel.Benchmarks/Program.fs
@@ -76,13 +76,13 @@ type ClrResolutionBenchmarks() =
 type EqualityBenchmarks() =
     let values () = [1..16] |> List.map (fun value -> Obj (value :> obj))
     let scalarArgs = [Obj (42 :> obj); Obj (42 :> obj)]
-    let flatListArgs = [List (values ()); List (values ())]
+    let flatListArgs = [ofList (values ()); ofList (values ())]
     let nestedListArgs =
-        [ List [List (values ()); List (values ())]
-          List [List (values ()); List (values ())] ]
+        [ ofList [ofList (values ()); ofList (values ())]
+          ofList [ofList (values ()); ofList (values ())] ]
     let dottedListArgs =
-        [ DottedList (values (), Atom "tail")
-          DottedList (values (), Atom "tail") ]
+        [ (ofDotted (values ()) (Atom "tail"))
+          (ofDotted (values ()) (Atom "tail")) ]
 
     [<Benchmark(Baseline = true)>]
     member _.ScalarEqual() =

--- a/IronKernel.Runtime/Ast.fs
+++ b/IronKernel.Runtime/Ast.fs
@@ -233,8 +233,10 @@ module Ast =
     }
     and LispVal = 
         | Atom of string 
-        | List of LispVal list
-        | DottedList of (LispVal list * LispVal)
+        /// R-1RK's pair. A list is a chain of these ending at Nil; an improper list
+        /// ends at anything else. ADR 0005: the cell is mutable so that set-car! and
+        /// set-cdr! have somewhere to write, though nothing mutates one yet.
+        | Pair of PairCell
         | Bool of bool
         | Environment of EnvironmentRecord
         | PrimitiveOperative of PrimitiveOperativeRecord
@@ -255,6 +257,18 @@ module Ast =
         | Encapsulation of EncapsulationRecord
         /// CLR-compiled combiner (Expression / IL).
         | CompiledCombiner of (LispVal -> LispVal -> LispVal list -> Step)
+
+    /// Reference equality, not structural: two cells are the same pair only if they
+    /// are the same object, which is what `eq?` will come to mean (ADR 0005 phase 2).
+    /// It also keeps the compiler-generated equality on LispVal from walking a cycle
+    /// once one can exist.
+    and [<ReferenceEquality>] PairCell = {
+        mutable car : LispVal
+        mutable cdr : LispVal
+        /// R-1RK distinguishes mutable from immutable pairs (4.7.2). Everything is
+        /// built immutable until phase 3 gives set-car! something to refuse.
+        mutable immutable : bool
+    }
 
     and LispError = 
        | NumArgs of int * LispVal list
@@ -295,6 +309,65 @@ module Ast =
     /// Identity today, and deliberately not `List.map acquireImmutable`: that would
     /// allocate a new list on every operative construction to no effect.
     let acquireImmutableForms (forms: LispVal list) = forms
+
+    /// The pair constructors. Kernel structure is built immutable throughout phase 1,
+    /// so nothing observable changes; phase 3 adds the mutable constructors that
+    /// `cons` and `list` will use.
+    let consImmutable car cdr = Pair { car = car; cdr = cdr; immutable = true }
+
+    let ofList (values: LispVal list) = List.foldBack consImmutable values Nil
+
+    let ofDotted (values: LispVal list) (tail: LispVal) =
+        List.foldBack consImmutable values tail
+
+    /// A bound on how far the list patterns walk. Nothing builds a cycle yet, but the
+    /// patterns answer "is this a proper list of the shape I expect", and once
+    /// `encycle!` exists (phase 5) the honest answer for a cyclic argument is no
+    /// rather than a hang.
+    let private chainLimit = 10_000_000
+
+    /// Matches a proper list -- a chain of pairs ending at Nil -- and yields its
+    /// elements. `Nil` matches as the empty list, so `| List [] ->` still reads the
+    /// empty list and `| List (x :: rest) ->` still destructures a non-empty one.
+    let (|List|_|) (value: LispVal) : LispVal list option =
+        let mutable current = value
+        let mutable acc = []
+        let mutable steps = 0
+        let mutable result = None
+        let mutable walking = true
+        while walking do
+            match current with
+            | Nil ->
+                result <- Some(List.rev acc)
+                walking <- false
+            | Pair cell when steps < chainLimit ->
+                acc <- cell.car :: acc
+                current <- cell.cdr
+                steps <- steps + 1
+            | _ -> walking <- false
+        result
+
+    /// Matches an improper list: at least one pair, ending at something other than
+    /// Nil. Yields the elements before the tail, and the tail.
+    let (|DottedList|_|) (value: LispVal) : (LispVal list * LispVal) option =
+        let mutable current = value
+        let mutable acc = []
+        let mutable steps = 0
+        let mutable result = None
+        let mutable walking = true
+        while walking do
+            match current with
+            | Pair cell when steps < chainLimit ->
+                acc <- cell.car :: acc
+                current <- cell.cdr
+                steps <- steps + 1
+            | Nil -> walking <- false
+            | tail ->
+                if List.isEmpty acc then walking <- false
+                else
+                    result <- Some(List.rev acc, tail)
+                    walking <- false
+        result
 
     let makeObj = (fun x -> x :> obj  |> Obj)
 
@@ -417,6 +490,10 @@ module Ast =
                     pending <- Append " & " :: pending
                     prependValues head
                     pending <- Append "(" :: pending
+                // A pair that is neither proper nor improper has come back on itself.
+                // Nothing builds one yet; ADR 0005 phase 4 gives cyclic structure its
+                // external representation, and until then saying so beats looping.
+                | Pair _ -> output.Append("<circular list>") |> ignore
                 | Applicative applicative ->
                     pending <- Render applicative :: Append " >" :: pending
                     pending <- Append "<applicative " :: pending

--- a/IronKernel.Runtime/ClrSugar.fs
+++ b/IronKernel.Runtime/ClrSugar.fs
@@ -13,19 +13,19 @@ module ClrSugar =
         elif name.StartsWith(".-") && name.Length > 2 then
             match args with
             | instance :: rest ->
-                Some (List (Atom ".get" :: instance :: Atom (name.Substring(2)) :: rest))
+                Some (ofList (Atom ".get" :: instance :: Atom (name.Substring(2)) :: rest))
             | [] -> None
         elif name.StartsWith(".") && name.Length > 1 then
             match args with
             | instance :: rest ->
-                Some (List (Atom "." :: instance :: Atom (name.Substring(1)) :: rest))
+                Some (ofList (Atom "." :: instance :: Atom (name.Substring(1)) :: rest))
             | [] -> None
         elif name.EndsWith(".") && name.Length > 1 then
-            Some (List (Atom "new" :: Atom (name.Substring(0, name.Length - 1)) :: args))
+            Some (ofList (Atom "new" :: Atom (name.Substring(0, name.Length - 1)) :: args))
         elif name.Contains("/") then
             match name.Split([| '/' |], 2) with
             | [| typ; method |] when typ.Length > 0 && method.Length > 0 ->
-                Some (List (Atom "." :: Atom typ :: Atom method :: args))
+                Some (ofList (Atom "." :: Atom typ :: Atom method :: args))
             | _ -> None
         else
             None

--- a/IronKernel.Runtime/Contracts.fs
+++ b/IronKernel.Runtime/Contracts.fs
@@ -56,8 +56,10 @@ module Contracts =
         | StringShape, Obj (:? string) -> true
         | BooleanShape, Bool _ -> true
         | AtomShape, Atom _ -> true
-        | ListShape, List _
-        | ListShape, DottedList _ -> true
+        // One cell test. Through the list patterns this walked the whole chain to
+        // fail DottedList and again to match List, on every contracted call.
+        | ListShape, Pair _
+        | ListShape, Nil -> true
         | PromptTagShape, PromptTag _ -> true
         | ResumptionShape, Resumption _ -> true
         | DateTimeShape, Obj (:? System.DateTime) -> true

--- a/IronKernel.Runtime/Contracts.fs
+++ b/IronKernel.Runtime/Contracts.fs
@@ -28,7 +28,7 @@ module Contracts =
 
     /// Homoiconic shape rendering for `contract-of`: composite shapes become lists.
     let rec shapeValue = function
-        | OneOfShape shapes -> List(shapes |> List.map shapeValue)
+        | OneOfShape shapes -> ofList(shapes |> List.map shapeValue)
         | shape -> Atom(shapeName shape)
 
     let rec shapeMatches shape value =

--- a/IronKernel.Runtime/Eval.fs
+++ b/IronKernel.Runtime/Eval.fs
@@ -414,7 +414,7 @@ module Eval =
                         Nil)
 
             let newEnv = newEnv [closure]
-            match bind newEnv (newContinuation _env) prms (ofList args) with
+            match run (bindArgsStep newEnv (newContinuation _env) prms args) with
             | Choice1Of2 error -> fail error
             | Choice2Of2 _ ->
                 match defineVar newEnv envarg _env with
@@ -428,8 +428,31 @@ module Eval =
         | Inert -> More (fun () -> continueEvalStep _env cont (ofList []))
         | _ -> fail (BadSpecialForm ("Expecting a combiner, got ", func))
 
+    /// Seeds the binding walk from an F# argument list rather than a Kernel one, so
+    /// that applying an operative does not build a chain of cells purely to take it
+    /// apart again one cell later. Formals and arguments are paired off directly; a
+    /// formal that is not a pair -- a rest parameter, or a mismatch -- hands the
+    /// remaining arguments over as a Kernel list, which is the only case that has to
+    /// build one.
+    and bindArgsStep env cont formals (args: LispVal list) : Step =
+        let mutable formal = formals
+        let mutable remaining = args
+        let mutable seeded = []
+        let mutable walking = true
+        while walking do
+            match formal, remaining with
+            | Pair cell, value :: rest ->
+                seeded <- (cell.car, value) :: seeded
+                formal <- cell.cdr
+                remaining <- rest
+            | _ -> walking <- false
+        bindPendingStep env cont ((formal, ofList remaining) :: seeded)
+
     and bindStep env cont lf rf : Step =
-        let mutable pending = [lf, rf]
+        bindPendingStep env cont [lf, rf]
+
+    and private bindPendingStep env cont seeded : Step =
+        let mutable pending = seeded
         let mutable bindingError = None
 
         while bindingError.IsNone && not pending.IsEmpty do

--- a/IronKernel.Runtime/Eval.fs
+++ b/IronKernel.Runtime/Eval.fs
@@ -404,7 +404,7 @@ module Eval =
                         Nil)
 
             let newEnv = newEnv [closure]
-            match bind newEnv (newContinuation _env) prms (List args) with
+            match bind newEnv (newContinuation _env) prms (ofList args) with
             | Choice1Of2 error -> fail error
             | Choice2Of2 _ ->
                 match defineVar newEnv envarg _env with
@@ -415,7 +415,7 @@ module Eval =
         // nor `eqv?` to itself, because the predicates and the equivalence walk only
         // know the `List` spelling. ADR 0005 phase 1 removes the duplicate case; until
         // then the producers normalise.
-        | Inert -> More (fun () -> continueEvalStep _env cont (List []))
+        | Inert -> More (fun () -> continueEvalStep _env cont (ofList []))
         | _ -> fail (BadSpecialForm ("Expecting a combiner, got ", func))
 
     and bindStep env cont lf rf : Step =
@@ -437,7 +437,7 @@ module Eval =
             | List (head :: tail) ->
                 match value with
                 | List (valueHead :: valueTail) ->
-                    pending <- (head, valueHead) :: (List tail, List valueTail) :: pending
+                    pending <- (head, valueHead) :: (ofList tail, ofList valueTail) :: pending
                 | badForm -> bindingError <- Some(BadSpecialForm("invalid arguments", badForm))
             | DottedList ([], rest) ->
                 match value with
@@ -447,11 +447,11 @@ module Eval =
                 match value with
                 | List (valueHead :: valueTail) ->
                     pending <-
-                        (head, valueHead) :: (DottedList(tail, rest), List valueTail) :: pending
+                        (head, valueHead) :: (ofDotted tail rest, ofList valueTail) :: pending
                 | DottedList (valueHead :: valueTail, valueRest) ->
                     pending <-
                         (head, valueHead)
-                        :: (DottedList(tail, rest), DottedList(valueTail, valueRest))
+                        :: (ofDotted tail rest, ofDotted valueTail valueRest)
                         :: pending
                 | badForm -> bindingError <- Some(BadSpecialForm("invalid arguments", badForm))
             | badForm -> bindingError <- Some(BadSpecialForm("invalid arguments", badForm))

--- a/IronKernel.Runtime/Eval.fs
+++ b/IronKernel.Runtime/Eval.fs
@@ -242,17 +242,27 @@ module Eval =
             match getVar env id with
             | Choice2Of2 r -> More (fun () -> continueEvalStep env cont r)
             | Choice1Of2 e -> fail e
-        | List (Atom name :: args) ->
-            match getVar' env name with
-            | Some r -> More (fun () -> operateStep env cont r args)
-            | None ->
-                match tryRewrite name args with
-                | Some rewritten -> More (fun () -> evalStep env cont rewritten)
-                | None -> fail (UnboundVar("Getting an unbound variable", name))
-        | List (op :: args) ->
-            let cps e v a _ =
-                operateStep e v a args
-            More (fun () -> evalStep env (makeCPS env cont cps) op)
+        // One walk of the operand chain, not two. Matching `List (Atom name :: args)`
+        // and then `List (op :: args)` materialised the operands twice for every
+        // combination whose operator is not a symbol, and once for every one that is.
+        | Pair cell ->
+            match cell.cdr with
+            | List args ->
+                match cell.car with
+                | Atom name ->
+                    match getVar' env name with
+                    | Some r -> More (fun () -> operateStep env cont r args)
+                    | None ->
+                        match tryRewrite name args with
+                        | Some rewritten -> More (fun () -> evalStep env cont rewritten)
+                        | None -> fail (UnboundVar("Getting an unbound variable", name))
+                | op ->
+                    let cps e v a _ =
+                        operateStep e v a args
+                    More (fun () -> evalStep env (makeCPS env cont cps) op)
+            // An improper combination is not a combination; it evaluates to itself,
+            // which is what falling past both list patterns used to do.
+            | _ -> More (fun () -> continueEvalStep env cont value)
         | z ->
             More (fun () -> continueEvalStep env cont z)
 
@@ -430,28 +440,22 @@ module Eval =
                 match defineVar env var value with
                 | Choice1Of2 error -> bindingError <- Some error
                 | Choice2Of2 _ -> ()
-            | List [] ->
+            // A parameter tree and its value are walked cell by cell. Proper and
+            // improper trees need no separate cases: a dotted formal is just a pair
+            // whose cdr is a symbol, and the `Atom` case above binds it. Matching
+            // through the list patterns instead destructured *and rebuilt* the rest of
+            // both chains on every iteration, which made binding quadratic in the
+            // number of parameters, on every operative call.
+            | Nil ->
                 match value with
-                | List [] -> ()
+                | Nil -> ()
                 | badForm -> bindingError <- Some(BadSpecialForm("invalid arguments", badForm))
-            | List (head :: tail) ->
+            | Pair formalCell ->
                 match value with
-                | List (valueHead :: valueTail) ->
-                    pending <- (head, valueHead) :: (ofList tail, ofList valueTail) :: pending
-                | badForm -> bindingError <- Some(BadSpecialForm("invalid arguments", badForm))
-            | DottedList ([], rest) ->
-                match value with
-                | DottedList ([], valueRest) -> pending <- (rest, valueRest) :: pending
-                | _ -> pending <- (rest, value) :: pending
-            | DottedList (head :: tail, rest) ->
-                match value with
-                | List (valueHead :: valueTail) ->
+                | Pair valueCell ->
                     pending <-
-                        (head, valueHead) :: (ofDotted tail rest, ofList valueTail) :: pending
-                | DottedList (valueHead :: valueTail, valueRest) ->
-                    pending <-
-                        (head, valueHead)
-                        :: (ofDotted tail rest, ofDotted valueTail valueRest)
+                        (formalCell.car, valueCell.car)
+                        :: (formalCell.cdr, valueCell.cdr)
                         :: pending
                 | badForm -> bindingError <- Some(BadSpecialForm("invalid arguments", badForm))
             | badForm -> bindingError <- Some(BadSpecialForm("invalid arguments", badForm))

--- a/IronKernel.Runtime/Interop.fs
+++ b/IronKernel.Runtime/Interop.fs
@@ -292,10 +292,10 @@
         let clr_opens env cont = function
             | [] ->
                 match clrState env with
-                | None -> bounceContinue env cont (List [])
+                | None -> bounceContinue env cont (ofList [])
                 | Some record ->
                     let names = !record.clrNamespaces |> List.map Atom
-                    bounceContinue env cont (List names)
+                    bounceContinue env cont (ofList names)
             | bad -> fail (NumArgs(0, bad))
 
         let print env cont (prms : LispVal list) =

--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -54,24 +54,24 @@
                 | Choice1Of2 error -> fail error
             | _ -> fail (NumArgs(2,prms))
 
+        // The three fundamental operations, each one cell access. Asked through the
+        // list patterns they were linear: `car` walked a whole chain to read its first
+        // cell, and `cdr` and `cons` walked it *and rebuilt it*, so every (cdr rest) in
+        // a library loop copied the rest of the list and every traversal was quadratic.
+        // Sharing the tail rather than copying it is also what R-1RK means by a pair --
+        // and what set-cdr! will need in phase 3.
         let car env cont = function
-            | [List (x::_)] -> bounceContinue env cont x
-            | [DottedList (x::_,_)] -> bounceContinue env cont x
+            | [Pair cell] -> bounceContinue env cont cell.car
             | [badArg] -> fail (TypeMismatch("pair",badArg))
             | badArgList -> fail (NumArgs(1,badArgList))
 
         let cdr env cont = function 
-            | [List(_::xs)] -> bounceContinue env cont (ofList xs)
-            | [DottedList([_],x)] -> bounceContinue env cont x
-            | [DottedList(_::xs,x)] -> bounceContinue env cont (ofDotted xs x)
+            | [Pair cell] -> bounceContinue env cont cell.cdr
             | [badArg] -> fail (TypeMismatch("pair",badArg))
             | badArgList -> fail (NumArgs(1,badArgList))
 
         let cons env cont = function
-            | [x; List []] -> bounceContinue env cont (ofList[x])
-            | [x; List(xs)] -> bounceContinue env cont (ofList(x::xs))
-            | [x;DottedList(xs,xlast)] -> bounceContinue env cont (ofDotted (x::xs) xlast)
-            | [x1;x2] -> bounceContinue env cont (ofDotted [x1] x2)
+            | [x; y] -> bounceContinue env cont (consImmutable x y)
             | badArgList -> fail (NumArgs(2,badArgList))
 
         let private eqvValue left right =

--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -61,17 +61,17 @@
             | badArgList -> fail (NumArgs(1,badArgList))
 
         let cdr env cont = function 
-            | [List(_::xs)] -> bounceContinue env cont (List xs)
+            | [List(_::xs)] -> bounceContinue env cont (ofList xs)
             | [DottedList([_],x)] -> bounceContinue env cont x
-            | [DottedList(_::xs,x)] -> bounceContinue env cont (DottedList(xs, x))
+            | [DottedList(_::xs,x)] -> bounceContinue env cont (ofDotted xs x)
             | [badArg] -> fail (TypeMismatch("pair",badArg))
             | badArgList -> fail (NumArgs(1,badArgList))
 
         let cons env cont = function
-            | [x; List []] -> bounceContinue env cont (List[x])
-            | [x; List(xs)] -> bounceContinue env cont (List(x::xs))
-            | [x;DottedList(xs,xlast)] -> bounceContinue env cont (DottedList(x::xs,xlast))
-            | [x1;x2] -> bounceContinue env cont (DottedList([x1],x2))
+            | [x; List []] -> bounceContinue env cont (ofList[x])
+            | [x; List(xs)] -> bounceContinue env cont (ofList(x::xs))
+            | [x;DottedList(xs,xlast)] -> bounceContinue env cont (ofDotted (x::xs) xlast)
+            | [x1;x2] -> bounceContinue env cont (ofDotted [x1] x2)
             | badArgList -> fail (NumArgs(2,badArgList))
 
         let private eqvValue left right =
@@ -96,14 +96,13 @@
                 | Bool arg1, Bool arg2 -> equal <- arg1 = arg2
                 | Atom arg1, Atom arg2 -> equal <- arg1 = arg2
                 | PromptTag arg1, PromptTag arg2 -> equal <- arg1 = arg2
-                | DottedList (xs, x), DottedList (ys, y) ->
-                    pending.Push(x, y)
-                    pushLists xs ys
-                | List xs, List ys -> pushLists xs ys
-                // Both spellings of the empty list, and either against the other. Left
-                // out, `Nil` was not even equal to itself, which breaks the reflexivity
-                // R-1RK 4.3.1 requires of an equivalence predicate.
-                | Nil, Nil | Nil, List [] | List [], Nil -> ()
+                // Compared cell by cell rather than through the list patterns, which
+                // materialised both chains before comparing them and walked each value
+                // twice over -- once failing DottedList, once matching List.
+                | Pair left, Pair right ->
+                    pending.Push(left.cdr, right.cdr)
+                    pending.Push(left.car, right.car)
+                | Nil, Nil -> ()
                 | _ -> equal <- false
 
             equal
@@ -176,7 +175,7 @@
                 either {
                     let! path = cast filename
                     let! expressions = load path
-                    return List expressions
+                    return ofList expressions
                 }
             | [found] -> throwError(TypeMismatch("string", found))
             | bad -> throwError(NumArgs(1, bad))
@@ -211,11 +210,10 @@
                     ("read-contents", readContents);
                     ("read-all", readAll) ]
 
+        // Nil is the empty list, so this is one comparison. Spelled `List []` it went
+        // through the list pattern, which walks a whole chain to build its elements
+        // before discovering they are not empty -- O(n) for a question about one cell.
         let isNull env cont = function 
-            | [List[]]   -> bounceContinue env cont <| Bool(true) 
-            // The producers normalise to `List []`, but the predicate accepts the bare
-            // case too, so that a future one cannot quietly reintroduce a value that is
-            // not `null?`.
             | [Nil]      -> bounceContinue env cont <| Bool(true) 
             | _          -> bounceContinue env cont <| Bool(false)
 
@@ -227,9 +225,11 @@
             | [Vector _ ]   -> bounceContinue env cont <| Bool(true) 
             | _          -> bounceContinue env cont <| Bool(false)
 
+        // Likewise: a pair is one cell. Asking through the list patterns walked the
+        // chain twice -- once to fail DottedList, once to match List -- which made
+        // every (pair? xs) in the list library linear in the list.
         let isPair env cont = function 
-            | [DottedList _]    -> bounceContinue env cont <| Bool(true) 
-            | [List (_::_) ]    -> bounceContinue env cont <| Bool(true) 
+            | [Pair _]          -> bounceContinue env cont <| Bool(true) 
             | _                 -> bounceContinue env cont <| Bool(false)
 
         /// R-1RK 12.5.1. `number?` and `integer?` are type predicates, so a
@@ -440,7 +440,7 @@
             | [ l; r ] ->
                 let cps e c result _ = bounceBind e c l result
                 bounceEval env (makeCPS env cont cps) r 
-            | badForm -> fail (BadSpecialForm("invalid arguments",List(badForm)))
+            | badForm -> fail (BadSpecialForm("invalid arguments",ofList(badForm)))
 
         let rec private parseContractShape = function
             | Atom "any" -> Some AnyShape
@@ -523,9 +523,9 @@
                     bounceContinue
                         env
                         cont
-                        (List
+                        (ofList
                             [ mode
-                              List(List.map shapeValue contract.operands)
+                              ofList(List.map shapeValue contract.operands)
                               shapeValue contract.result
                               effect
                               Bool contract.inlineable
@@ -693,7 +693,7 @@
             Applicative(
                 PrimitiveOperative
                     { identity = None
-                      invoke = fun e c args -> passAbnormally e c target (List args) })
+                      invoke = fun e c args -> passAbnormally e c target (ofList args) })
 
         /// The whole chain of interceptions is scheduled at once as *normal* passes, so
         /// that handing the value from one interceptor to the next is not itself subject
@@ -1368,7 +1368,7 @@
                         List.length items, (match tail with List [] -> 1 | _ -> 0)
                     | _ -> 0, 0
                 let counted n = Obj(box n)
-                bounceContinue env cont (List [counted pairs; counted nils; counted pairs; counted 0])
+                bounceContinue env cont (ofList [counted pairs; counted nils; counted pairs; counted 0])
             | _ -> fail (NumArgs(1, args))
 
         /// R-1RK 12.10. Like 12.9 the report gives these signatures only, so they take
@@ -1615,18 +1615,18 @@
         let getRealInternalBounds env cont args =
             realArgument args (fun value ->
                 if isExactValue value then
-                    bounceContinue env cont (List [Obj value; Obj value])
+                    bounceContinue env cont (ofList [Obj value; Obj value])
                 else
                     bounceContinue env cont (
-                        List [Obj(internalInfinity value false); Obj(internalInfinity value true)]))
+                        ofList [Obj(internalInfinity value false); Obj(internalInfinity value true)]))
 
         let getRealExactBounds env cont args =
             realArgument args (fun value ->
                 if isExactValue value then
-                    bounceContinue env cont (List [Obj value; Obj value])
+                    bounceContinue env cont (ofList [Obj value; Obj value])
                 else
                     bounceContinue env cont (
-                        List [Obj(box ExactNegativeInfinity); Obj(box ExactPositiveInfinity)]))
+                        ofList [Obj(box ExactNegativeInfinity); Obj(box ExactPositiveInfinity)]))
 
         /// R-1RK 12.6.3. Both signal an error when there is no primary value, which
         /// keeps get-real-exact-primary's promise to return an exact real and
@@ -1691,7 +1691,7 @@
                     [lower; primary; upper]
                     |> List.forall (fun v -> isNumberValue v && not (v :? Numerics.Complex)) ->
                 bounceContinue env cont (Obj(inexactValueOf primary))
-            | [_; _; _] -> fail (TypeMismatch("real", List args))
+            | [_; _; _] -> fail (TypeMismatch("real", ofList args))
             | _ -> fail (NumArgs(3, args))
 
         /// R-1RK 12.6.6 and 12.7.1 are each "the binder and accessor of" a keyed
@@ -1745,7 +1745,7 @@
             | [a; b] ->
                 match opDivAndMod a b with
                 | Choice2Of2 (quotient, remainder) ->
-                    bounceContinue env cont (List [quotient; remainder])
+                    bounceContinue env cont (ofList [quotient; remainder])
                 | Choice1Of2 error -> fail error
             | _ -> fail (NumArgs(2, args))
 
@@ -1820,7 +1820,7 @@
                             | [_] -> fail(Default "encapsulation type mismatch")
                             | bad -> fail(NumArgs(1, bad))))
 
-                List [encapsulator; predicate; decapsulator] |> bounceContinue env cont
+                ofList [encapsulator; predicate; decapsulator] |> bounceContinue env cont
             | bad -> fail(NumArgs(0, bad))
 
         /// R-1RK 10.1.1. Each call returns a fresh `(binder accessor)` pair sharing a
@@ -1860,7 +1860,7 @@
                                     fail (Default "keyed dynamic variable is unbound here")
                             | bad -> fail (NumArgs(0, bad))))
 
-                List [binder; accessor] |> bounceContinue env cont
+                ofList [binder; accessor] |> bounceContinue env cont
             | bad -> fail(NumArgs(0, bad))
 
         /// R-1RK 11.1.1, the static counterpart of 10.1.1. Each call returns a fresh
@@ -1904,7 +1904,7 @@
                                 | None -> fail (Default "keyed static variable is unbound here")
                             | bad -> fail (NumArgs(0, bad))))
 
-                List [binder; accessor] |> bounceContinue env cont
+                ofList [binder; accessor] |> bounceContinue env cont
             | bad -> fail(NumArgs(0, bad))
 
         let primitiveApplicatives : (string * (LispVal -> LispVal -> LispVal list -> Step)) list =

--- a/IronKernel.Runtime/RuntimeDispatch.fs
+++ b/IronKernel.Runtime/RuntimeDispatch.fs
@@ -55,8 +55,10 @@ module RuntimeDispatch =
     type NamedCallSite(name: string, operands: LispVal list) =
         let simpleOperands =
             operands
+            // A pair is a combination that would need evaluating, whatever its shape.
+            // Asking through the list pattern walked each operand's whole structure.
             |> List.forall (function
-                | List (_ :: _) -> false
+                | Pair _ -> false
                 | _ -> true)
 
         /// The whole cache is one immutable snapshot behind a single reference so

--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -39,7 +39,7 @@ let ``analysis handles deeply nested operator positions`` () =
     let depth = 100_000
     let mutable form = Atom "deep-operator"
     for _ in 1..depth do
-        form <- List [form]
+        form <- ofList [form]
 
     let assertShape analyzed =
         let mutable current = analyzed

--- a/IronKernel.Tests/ConformanceTests.fs
+++ b/IronKernel.Tests/ConformanceTests.fs
@@ -140,7 +140,7 @@ let ``operative uses lexical scope and can explicitly evaluate in caller scope``
           "(define caller-value (vau (form) caller (eval form caller)))"
           "(define exercise (wrap (vau (x) _ (list (lexical) (caller-value x)))))"
           "(exercise 2)" ]
-        (List [Obj (1 :> obj); Obj (2 :> obj)])
+        (ofList [Obj (1 :> obj); Obj (2 :> obj)])
 
 [<Fact>]
 let ``environment lookup is depth first in parent order`` () =
@@ -151,7 +151,7 @@ let ``environment lookup is depth first in parent order`` () =
           "(define b (bindings->environment (x 3) (z 4)))"
           "(define c (make-environment a b))"
           "(list (remote-eval x c) (remote-eval y c) (remote-eval z c))" ]
-        (List [Obj (1 :> obj); Obj (2 :> obj); Obj (4 :> obj)])
+        (ofList [Obj (1 :> obj); Obj (2 :> obj); Obj (4 :> obj)])
 
 [<Fact>]
 let ``wrapped combiner evaluates operands while operative receives syntax`` () =
@@ -161,9 +161,9 @@ let ``wrapped combiner evaluates operands while operative receives syntax`` () =
           "(define raw (vau operands _ operands))"
           "(define cooked (wrap raw))"
           "(list (raw (+ 1 2)) (cooked (+ 1 2)))" ]
-        (List
-            [ List [List [Atom "+"; Obj (1 :> obj); Obj (2 :> obj)]]
-              List [Obj (3 :> obj)] ])
+        (ofList
+            [ ofList [ofList [Atom "+"; Obj (1 :> obj); Obj (2 :> obj)]]
+              ofList [Obj (3 :> obj)] ])
 
 [<Fact>]
 let ``applicative operands evaluate from left to right`` () =

--- a/IronKernel.Tests/ContinuationTests.fs
+++ b/IronKernel.Tests/ContinuationTests.fs
@@ -61,14 +61,14 @@ let ``shift and reset core`` () =
 [<Fact>]
 let ``shift and reset with lists`` () =
     evalSessionKernel [
-        "(cons 1 (reset (cons 2 (shift (lambda (k) (cons 3 '()))))))", List [Obj 1; Obj 3]
-        "(cons 1 (reset (cons 2 '())))", List [Obj 1; Obj 2]
+        "(cons 1 (reset (cons 2 (shift (lambda (k) (cons 3 '()))))))", ofList [Obj 1; Obj 3]
+        "(cons 1 (reset (cons 2 '())))", ofList [Obj 1; Obj 2]
         "(cons 'a (reset (cons 'b (shift (lambda (k) (cons 1 (k (k (cons 'c '())))))))))",
-            List [Atom "a"; Obj 1; Atom "b"; Atom "b"; Atom "c"]
+            ofList [Atom "a"; Obj 1; Atom "b"; Atom "b"; Atom "c"]
         "(cons 1 (reset (cons 2 (shift (lambda (k) (cons 3 (k (cons 4 '()))))))))",
-            List [Obj 1; Obj 3; Obj 2; Obj 4]
+            ofList [Obj 1; Obj 3; Obj 2; Obj 4]
         "(cons 1 (reset (cons 2 (shift (lambda (k) (cons 3 (k (k (cons 4 '())))))))))",
-            List [Obj 1; Obj 3; Obj 2; Obj 2; Obj 4]
+            ofList [Obj 1; Obj 3; Obj 2; Obj 2; Obj 4]
     ]
 
 [<Fact>]
@@ -149,7 +149,7 @@ let ``tagged prompt lookup handles deeply nested prompt frames`` () =
 let ``generator style yield via shift`` () =
     evalSessionKernel [
         "(defn (yield x) (shift (lambda (k) (cons x (k (#inert))))))", Inert
-        "(reset (begin (yield 1) (yield 2) (yield 3) ()))", List [Obj 1; Obj 2; Obj 3]
+        "(reset (begin (yield 1) (yield 2) (yield 3) ()))", ofList [Obj 1; Obj 2; Obj 3]
     ]
 
 [<Fact>]

--- a/IronKernel.Tests/ContractTests.fs
+++ b/IronKernel.Tests/ContractTests.fs
@@ -17,7 +17,7 @@ let ``operative contract validates raw operand syntax`` () =
     withKernel (fun env ->
         ignore (evalIn env "(define raw (vau operands _ operands))")
         ignore (evalIn env "(contract raw operative (any) any pure #t)")
-        assertEval env "(raw (+ 1 2))" (List [List [Atom "+"; Obj (1 :> obj); Obj (2 :> obj)]])
+        assertEval env "(raw (+ 1 2))" (ofList [ofList [Atom "+"; Obj (1 :> obj); Obj (2 :> obj)]])
 
         match evalRaw Interpreted env "(raw 1 2)" with
         | Choice1Of2 (ContractViolation message) -> Assert.Contains("expected 1 operands", message)
@@ -32,9 +32,9 @@ let ``applicative contract validates argument and result values`` () =
         assertEval
             env
             "(contract-of double)"
-            (List
+            (ofList
                 [ Atom "applicative"
-                  List [Atom "number"]
+                  ofList [Atom "number"]
                   Atom "number"
                   Atom "pure"
                   Bool true
@@ -64,7 +64,7 @@ let ``wrap preserves contract metadata with eager argument policy`` () =
         [ "(define raw (vau operands _ operands))", Inert
           "(contract raw operative (number) list pure #t)", Inert
           "(define eager (wrap raw))", Inert
-          "(eager (+ 1 2))", List [Obj (3 :> obj)] ]
+          "(eager (+ 1 2))", ofList [Obj (3 :> obj)] ]
 
 [<Fact>]
 let ``wrap preserves applicative contract metadata without nesting`` () =
@@ -75,9 +75,9 @@ let ``wrap preserves applicative contract metadata without nesting`` () =
         assertEval
             env
             "(contract-of wrapped)"
-            (List
+            (ofList
                 [ Atom "applicative"
-                  List [Atom "number"]
+                  ofList [Atom "number"]
                   Atom "number"
                   Atom "pure"
                   Bool true
@@ -88,11 +88,11 @@ let ``wrap preserves applicative contract metadata without nesting`` () =
         assertEval
             env
             "(contract-of wrapped-plus)"
-            (List
+            (ofList
                 [ Atom "applicative"
-                  List
-                      [ List [Atom "number"; Atom "datetime"]
-                        List [Atom "number"; Atom "timespan"] ]
+                  ofList
+                      [ ofList [Atom "number"; Atom "datetime"]
+                        ofList [Atom "number"; Atom "timespan"] ]
                   Atom "any"
                   Atom "pure"
                   Bool true

--- a/IronKernel.Tests/InteropTests.fs
+++ b/IronKernel.Tests/InteropTests.fs
@@ -106,8 +106,8 @@ let ``single-parent environments copy CLR namespace state`` () =
     let child = newEnv [parent]
     ignore (evalIn child "(clr-open System.Text)")
 
-    assertEval parent "(clr-opens)" (List [Atom "System"])
-    assertEval child "(clr-opens)" (List [Atom "System"; Atom "System.Text"])
+    assertEval parent "(clr-opens)" (ofList [Atom "System"])
+    assertEval child "(clr-opens)" (ofList [Atom "System"; Atom "System.Text"])
 
 [<Fact>]
 let ``clr-alias binds a short type name`` () =

--- a/IronKernel.Tests/ListTests.fs
+++ b/IronKernel.Tests/ListTests.fs
@@ -8,10 +8,10 @@ open IronKernel.Tests.TestHelpers
 [<Fact>]
 let ``cons car cdr`` () =
     [
-        "(cons 1 ())", List [Obj 1]
-        "(cons 1 (cons 2 ()))", List [Obj 1; Obj 2]
+        "(cons 1 ())", ofList [Obj 1]
+        "(cons 1 (cons 2 ()))", ofList [Obj 1; Obj 2]
         "(car (cons 1 (cons 2 ())))", Obj 1
-        "(cdr (cons 1 (cons 2 ())))", List [Obj 2]
+        "(cdr (cons 1 (cons 2 ())))", ofList [Obj 2]
         "(null? ())", Bool true
         "(null? (cons 1 ()))", Bool false
         "(pair? (cons 1 2))", Bool true
@@ -32,10 +32,10 @@ let ``structural equality compares lists and dotted tails`` () =
         | Choice2Of2 (Bool actual) -> Assert.Equal(expected, actual)
         | result -> failwithf "unexpected equality result: %A" result
 
-    assertResult true (List [List [Atom "a"]]) (List [List [Atom "a"]])
-    assertResult false (List [Atom "a"]) (List [Atom "a"; Atom "b"])
-    assertResult false (DottedList ([Atom "a"], Atom "b")) (DottedList ([Atom "a"], Atom "c"))
-    assertResult false (DottedList ([Atom "a"], Atom "b")) (List [Atom "a"; Atom "b"])
+    assertResult true (ofList [ofList [Atom "a"]]) (ofList [ofList [Atom "a"]])
+    assertResult false (ofList [Atom "a"]) (ofList [Atom "a"; Atom "b"])
+    assertResult false ((ofDotted [Atom "a"] (Atom "b"))) ((ofDotted [Atom "a"] (Atom "c")))
+    assertResult false ((ofDotted [Atom "a"] (Atom "b"))) (ofList [Atom "a"; Atom "b"])
 
     match eqv' [Atom "a"] with
     | Choice1Of2 (NumArgs (2, [_])) -> ()
@@ -46,8 +46,8 @@ let ``structural equality handles deeply nested lists`` () =
     let mutable left = Atom "leaf"
     let mutable right = Atom "leaf"
     for _ in 1..100000 do
-        left <- List [left]
-        right <- List [right]
+        left <- ofList [left]
+        right <- ofList [right]
 
     match eqv' [left; right] with
     | Choice2Of2 (Bool true) -> ()
@@ -58,7 +58,7 @@ let ``showVal handles deeply nested lists`` () =
     let depth = 100_000
     let mutable value = Atom "leaf"
     for _ in 1..depth do
-        value <- List [value]
+        value <- ofList [value]
 
     let rendered = showVal value
     Assert.Equal(depth * 2 + 4, rendered.Length)
@@ -69,15 +69,15 @@ let ``showVal handles deeply nested lists`` () =
 [<Fact>]
 let ``list library helpers`` () =
     [
-        "(list 1 2 3)", List [Obj 1; Obj 2; Obj 3]
+        "(list 1 2 3)", ofList [Obj 1; Obj 2; Obj 3]
         "(length (list 1 2 3 4))", Obj 4
-        "(map (lambda (x) (+ x 1)) (list 1 2 3))", List [Obj 2; Obj 3; Obj 4]
+        "(map (lambda (x) (+ x 1)) (list 1 2 3))", ofList [Obj 2; Obj 3; Obj 4]
     ] |> evalSessionKernel
 
 [<Fact>]
 let ``quote preserves structure`` () =
     [
-        "'(a b c)", List [Atom "a"; Atom "b"; Atom "c"]
+        "'(a b c)", ofList [Atom "a"; Atom "b"; Atom "c"]
         "(car '(x y))", Atom "x"
     ] |> evalSessionKernel
 

--- a/IronKernel.Tests/ParserTests.fs
+++ b/IronKernel.Tests/ParserTests.fs
@@ -52,7 +52,7 @@ let rec private generateDatum (random: Random) depth =
         | 1 ->
             let values = [ for _ in 0..random.Next(3) -> generateDatum random (depth - 1) ]
             let source = values |> List.map fst |> String.concat " "
-            $"({source})", List(List.map snd values)
+            $"({source})", ofList(List.map snd values)
         | 2 ->
             let values = [ for _ in 0..random.Next(3) -> generateDatum random (depth - 1) ]
             let source = values |> List.map fst |> String.concat "\n"
@@ -61,10 +61,10 @@ let rec private generateDatum (random: Random) depth =
             let head = [ for _ in 0..random.Next(2) -> generateDatum random (depth - 1) ]
             let tailSource, tail = generateDatum random (depth - 1)
             let headSource = head |> List.map fst |> String.concat " "
-            $"({headSource} & {tailSource})", DottedList(List.map snd head, tail)
+            $"({headSource} & {tailSource})", (ofDotted (List.map snd head) tail)
         | _ ->
             let source, value = generateDatum random (depth - 1)
-            $"'{source}", List [Atom "quote"; value]
+            $"'{source}", ofList [Atom "quote"; value]
 
 [<Fact>]
 let ``generated nested datums preserve structure and source spans`` () =
@@ -184,8 +184,8 @@ let ``parses strings atoms and quote`` () =
 
 [<Fact>]
 let ``parses lists dotted lists and vectors`` () =
-    assertEqv (parseOk "(a 1)") (List [Atom "a"; Obj 1])
-    assertEqv (parseOk "()") (List [])
+    assertEqv (parseOk "(a 1)") (ofList [Atom "a"; Obj 1])
+    assertEqv (parseOk "()") (ofList [])
     match parseOk "(a & b)" with
     | DottedList ([Atom "a"], Atom "b") -> ()
     | v -> failwith (showVal v)
@@ -200,7 +200,7 @@ let ``parses lists dotted lists and vectors`` () =
 let ``parses nested combinations`` () =
     assertEqv
         (parseOk "(+ 1 (* 2 3))")
-        (List [Atom "+"; Obj 1; List [Atom "*"; Obj 2; Obj 3]])
+        (ofList [Atom "+"; Obj 1; ofList [Atom "*"; Obj 2; Obj 3]])
 
 [<Fact>]
 let ``parses deeply nested lists without exponential backtracking`` () =

--- a/IronKernel.Tests/StdlibTests.fs
+++ b/IronKernel.Tests/StdlibTests.fs
@@ -42,7 +42,7 @@ let ``defn and compose`` () =
 let ``apply and list-star`` () =
     evalSessionKernel [
         "(apply + (list 1 2))", Obj 3
-        "(list* 1 2 (list 3))", List [Obj 1; Obj 2; Obj 3]
+        "(list* 1 2 (list 3))", ofList [Obj 1; Obj 2; Obj 3]
     ]
 
 [<Fact>]

--- a/IronKernel.Tests/VauTests.fs
+++ b/IronKernel.Tests/VauTests.fs
@@ -11,15 +11,15 @@ open IronKernel.Tests.TestHelpers
 let ``vau receives unevaluated operands`` () =
     [
         "(define quote-one (vau (x) _ x))", Inert
-        "(quote-one (+ 1 2))", List [Atom "+"; Obj 1; Obj 2]
+        "(quote-one (+ 1 2))", ofList [Atom "+"; Obj 1; Obj 2]
     ] |> evalSession
 
 [<Fact>]
 let ``vau rejects operands that do not match formals`` () =
     let cases =
-        [ "((vau (x y) _ 42) 1)", List []
-          "((vau (x y) _ 42) 1 2 3)", List [Obj 3]
-          "((vau ((x y)) _ 42) (1))", List [] ]
+        [ "((vau (x y) _ 42) 1)", ofList []
+          "((vau (x y) _ 42) 1 2 3)", ofList [Obj 3]
+          "((vau ((x y)) _ 42) (1))", ofList [] ]
 
     for expression, badForm in cases do
         for mode in [Interpreted; Compiled] do
@@ -36,7 +36,7 @@ let ``vau rejects operands that do not match formals`` () =
 let ``vau dotted formals collect remaining operands`` () =
     assertParityValueSession
         [ "((vau (x & rest) _ rest) 1 2 3)" ]
-        (List [Obj 2; Obj 3])
+        (ofList [Obj 2; Obj 3])
 
 [<Fact>]
 let ``vau combines nested destructuring with rest formals`` () =
@@ -47,8 +47,8 @@ let ``vau combines nested destructuring with rest formals`` () =
 [<Fact>]
 let ``formal binding handles very long lists`` () =
     let env = freshEnv ()
-    let formals = List(List.replicate 100000 (Atom "value"))
-    let values = List([0..99999] |> List.map (fun value -> Obj(value :> obj)))
+    let formals = ofList(List.replicate 100000 (Atom "value"))
+    let values = ofList([0..99999] |> List.map (fun value -> Obj(value :> obj)))
 
     match bind env (newContinuation env) formals values with
     | Choice1Of2 error -> failwithf "deep formal binding failed: %s" (showError error)
@@ -86,7 +86,7 @@ let ``wrap and unwrap`` () =
         "(define op (vau (x) _ x))", Inert
         "(define ap (wrap op))", Inert
         "(ap (+ 1 2))", Obj 3
-        "((unwrap ap) (+ 1 2))", List [Atom "+"; Obj 1; Obj 2]
+        "((unwrap ap) (+ 1 2))", ofList [Atom "+"; Obj 1; Obj 2]
     ] |> evalSession
 
 [<Fact>]

--- a/IronKernel/Analyze.fs
+++ b/IronKernel/Analyze.fs
@@ -61,7 +61,7 @@ module Analyze =
             | IOFunc _
             | Port _
             | Status _ -> result <- Some(CLit current)
-            | List [] -> result <- Some(CLit(List []))
+            | List [] -> result <- Some(CLit(ofList []))
             | DottedList _ as form -> result <- Some(CResidual form)
             | List (Atom name :: args) ->
                 // Desugar Clojure-style CLR calls before binding analysis so the
@@ -288,7 +288,7 @@ module Analyze =
                 match current with
                 | CLit value -> completed <- value :: completed
                 | CVar name -> completed <- Atom name :: completed
-                | CQuote value -> completed <- List [Atom "quote"; value] :: completed
+                | CQuote value -> completed <- ofList [Atom "quote"; value] :: completed
                 | CIf(condition, consequent, alternative) ->
                     pending <-
                         Reify condition
@@ -314,9 +314,9 @@ module Analyze =
                 | COperate(operator, operands) ->
                     pending <- Reify operator :: BuildOperate operands :: pending
                 | CIntrinsicOperate(PrimitiveIf, operands) ->
-                    completed <- List (Atom "if" :: operands) :: completed
+                    completed <- ofList (Atom "if" :: operands) :: completed
                 | CIntrinsicOperate(PrimitiveDefine, operands) ->
-                    completed <- List (Atom "define" :: operands) :: completed
+                    completed <- ofList (Atom "define" :: operands) :: completed
                 | CGuarded(_, _, fallback)
                 | CContractFold(_, _, fallback) ->
                     pending <- Reify fallback :: pending
@@ -332,32 +332,32 @@ module Analyze =
             | BuildIf ->
                 match takeCompleted 3 with
                 | [condition; consequent; alternative] ->
-                    completed <- List [Atom "if"; condition; consequent; alternative] :: completed
+                    completed <- ofList [Atom "if"; condition; consequent; alternative] :: completed
                 | _ -> invalidOp "Conditional reification is incomplete"
             | BuildSequence count ->
-                completed <- List (Atom "sequence" :: takeCompleted count) :: completed
+                completed <- ofList (Atom "sequence" :: takeCompleted count) :: completed
             | BuildDefine ->
                 match takeCompleted 2 with
-                | [lhs; rhs] -> completed <- List [Atom "define"; lhs; rhs] :: completed
+                | [lhs; rhs] -> completed <- ofList [Atom "define"; lhs; rhs] :: completed
                 | _ -> invalidOp "Definition reification is incomplete"
             | BuildVau(formals, envarg, bodyCount) ->
                 completed <-
-                    List (Atom "vau" :: formals :: Atom envarg :: takeCompleted bodyCount)
+                    ofList (Atom "vau" :: formals :: Atom envarg :: takeCompleted bodyCount)
                     :: completed
             | BuildApp argumentCount ->
-                completed <- List (takeCompleted (argumentCount + 1)) :: completed
+                completed <- ofList (takeCompleted (argumentCount + 1)) :: completed
             | BuildOperate operands ->
                 match takeCompleted 1 with
-                | [operator] -> completed <- List (operator :: operands) :: completed
+                | [operator] -> completed <- ofList (operator :: operands) :: completed
                 | _ -> invalidOp "Operation reification is incomplete"
             | BuildEval ->
                 match takeCompleted 2 with
                 | [environmentExpression; valueExpression] ->
-                    completed <- List [Atom "eval"; environmentExpression; valueExpression] :: completed
+                    completed <- ofList [Atom "eval"; environmentExpression; valueExpression] :: completed
                 | _ -> invalidOp "Eval reification is incomplete"
             | BuildReset ->
                 match takeCompleted 1 with
-                | [body] -> completed <- List [Atom "reset"; body] :: completed
+                | [body] -> completed <- ofList [Atom "reset"; body] :: completed
                 | _ -> invalidOp "Reset reification is incomplete"
 
         match completed with

--- a/IronKernel/Analyze.fs
+++ b/IronKernel/Analyze.fs
@@ -61,21 +61,27 @@ module Analyze =
             | IOFunc _
             | Port _
             | Status _ -> result <- Some(CLit current)
-            | List [] -> result <- Some(CLit(ofList []))
+            // The chain is materialised once and then dispatched on as an ordinary F#
+            // list. Asking through the list pattern per alternative walked and rebuilt
+            // the whole form up to three times for every combination analysed, which is
+            // most of what the analyzer does.
+            | List items ->
+                match items with
+                | [] -> result <- Some(CLit(ofList []))
+                | Atom name :: args ->
+                    // Desugar Clojure-style CLR calls before binding analysis so the
+                    // hybrid compiler sees ordinary `.` / `new` / `.get` combinations.
+                    match tryRewrite name args with
+                    | Some rewritten -> current <- rewritten
+                    | None -> result <- Some(COperate(CVar name, args))
+                | op :: args ->
+                    // Kernel has no syntactically privileged operator names. Preserve
+                    // operand trees exactly and let runtime binding lookup select
+                    // operative semantics. Specialized forms require binding-identity
+                    // guards, which this analyzer intentionally does not yet have.
+                    pendingOperands <- args :: pendingOperands
+                    current <- op
             | DottedList _ as form -> result <- Some(CResidual form)
-            | List (Atom name :: args) ->
-                // Desugar Clojure-style CLR calls before binding analysis so the
-                // hybrid compiler sees ordinary `.` / `new` / `.get` combinations.
-                match tryRewrite name args with
-                | Some rewritten -> current <- rewritten
-                | None -> result <- Some(COperate(CVar name, args))
-            | List (op :: args) ->
-                // Kernel has no syntactically privileged operator names. Preserve operand
-                // trees exactly and let runtime binding lookup select operative semantics.
-                // Specialized forms require binding-identity guards, which this analyzer
-                // intentionally does not yet have.
-                pendingOperands <- args :: pendingOperands
-                current <- op
             | other -> result <- Some(CResidual other)
 
         let mutable analyzed = result.Value
@@ -113,7 +119,10 @@ module Analyze =
                 match form with
                 // Both spellings: `$if` is the report's name (R-1RK 4.5.2), `if` the
                 // dialect's. They denote one combiner, so both deserve the guard.
-                | List (Atom ("if" | "$if" as name) :: [condition; consequent; alternative] as whole) ->
+                // Materialised once, as above.
+                | List items ->
+                  match items with
+                  | (Atom ("if" | "$if" as name) :: [condition; consequent; alternative]) as whole ->
                     let fallback = COperate(CVar name, List.tail whole)
                     match tryCreateBindingGuard env name PrimitiveIf with
                     | Some guard ->
@@ -124,7 +133,7 @@ module Analyze =
                             :: BuildGuardedIf(guard, fallback)
                             :: pending
                     | None -> completed <- fallback :: completed
-                | List (Atom ("define" | "$define!" as definer) :: [Atom name; rhs] as whole) ->
+                  | (Atom ("define" | "$define!" as definer) :: [Atom name; rhs]) as whole ->
                     let fallback = COperate(CVar definer, List.tail whole)
                     match tryCreateBindingGuard env definer PrimitiveDefine with
                     | Some guard ->
@@ -133,7 +142,7 @@ module Analyze =
                             :: BuildGuardedDefine(guard, name, fallback)
                             :: pending
                     | None -> completed <- fallback :: completed
-                | List (Atom name :: operands) ->
+                  | Atom name :: operands ->
                     // Prefer a real binding over CLR call sugar (same rule as Eval).
                     match getVar' env name with
                     | Some _ -> completed <- COperate(CVar name, operands) :: completed
@@ -141,8 +150,9 @@ module Analyze =
                         match tryRewrite name operands with
                         | Some rewritten -> pending <- AnalyzeGuardedForm rewritten :: pending
                         | None -> completed <- COperate(CVar name, operands) :: completed
-                | List (op :: operands) ->
+                  | op :: operands ->
                     pending <- AnalyzeGuardedForm op :: BuildGuardedOperate operands :: pending
+                  | [] -> completed <- analyze form :: completed
                 | other -> completed <- analyze other :: completed
             | BuildGuardedIf (guard, fallback) ->
                 match takeCompleted 3 with

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -150,7 +150,7 @@ module Compiler =
                 | CReset body ->
                     // Delimited continuations must go through the trampoline interpreter so
                     // shift sees the proper meta-continuation chain (including under begin/applicatives).
-                    let form = List [Atom "reset"; toLispVal body]
+                    let form = ofList [Atom "reset"; toLispVal body]
                     completed <- KernelFunc(fun env cont -> bounceEval env cont form) :: completed
                 | CApp (operator, args) ->
                     let operands = List.map toLispVal args |> List.toArray

--- a/IronKernel/CorePackage.fs
+++ b/IronKernel/CorePackage.fs
@@ -78,13 +78,13 @@ module CorePackage =
             List.init count (fun _ -> readValue (depth + 1) reader)
         match reader.ReadByte() with
         | 0uy -> Atom(readString reader)
-        | 1uy -> List(readValues ())
-        | 2uy -> DottedList(readValues (), readValue (depth + 1) reader)
+        | 1uy -> ofList(readValues ())
+        | 2uy -> ofDotted (readValues ()) (readValue (depth + 1) reader)
         | 3uy -> Bool(reader.ReadBoolean())
         | 4uy -> Inert
         // Normalised to the `List` spelling of the empty list: a decoded `Nil` was not
         // `eqv?` to an empty list built at runtime. See Eval's note.
-        | 5uy -> List []
+        | 5uy -> ofList []
         | 6uy -> Keyword(readString reader)
         | 7uy -> Obj null
         | 8uy -> Obj(box (readString reader))

--- a/IronKernel/Emit.fs
+++ b/IronKernel/Emit.fs
@@ -176,7 +176,7 @@ module Emit =
             | Choice2Of2 standardEnv ->
                 let env =
                     bindVars standardEnv
-                        [ "args", List (List.map (fun arg -> Obj(arg :> obj)) args) ]
+                        [ "args", ofList (List.map (fun arg -> Obj(arg :> obj)) args) ]
                 use fs = File.OpenRead path
                 let forms = CorePackage.read env path fs |> List.map compileToFunc
                 runCompiledForms env forms

--- a/IronKernel/PartialEval.fs
+++ b/IronKernel/PartialEval.fs
@@ -58,7 +58,7 @@ module PartialEval =
                     let folded =
                         match tryCreateContractGuard env name with
                         | Some (guard, _) ->
-                            match eval env (newContinuation env) (List(Atom name :: operands)) with
+                            match eval env (newContinuation env) (ofList(Atom name :: operands)) with
                             | Choice2Of2 value when isFoldedValue value ->
                                 CContractFold(guard, value, fallback)
                             | _ -> fallback

--- a/IronKernel/Project.fs
+++ b/IronKernel/Project.fs
@@ -570,7 +570,7 @@ module Project =
                     | Choice2Of2 standardEnv ->
                         let env =
                             bindVars standardEnv
-                                [ "args", List(List.map (fun arg -> Obj(arg :> obj)) args) ]
+                                [ "args", ofList(List.map (fun arg -> Obj(arg :> obj)) args) ]
                         match runFiles env (orderedSources project assets) with
                         | Choice1Of2 error ->
                             eprintfn "Project error: %s" (showError error)

--- a/IronKernel/Repl.fs
+++ b/IronKernel/Repl.fs
@@ -71,7 +71,7 @@ module Repl =
         | Choice2Of2 standardEnv ->
             let env =
                 bindVars standardEnv
-                    [ "args", List (List.map (fun x -> Ast.Obj(x :> obj)) args) ]
+                    [ "args", ofList (List.map (fun x -> Ast.Obj(x :> obj)) args) ]
             match runSourceFile env filename with
             | Choice1Of2 error ->
                 eprintfn "Script error: %s" (showError error)

--- a/IronKernel/Source.fs
+++ b/IronKernel/Source.fs
@@ -64,16 +64,16 @@ module Source =
                 | LQuote quoted ->
                     pending <- Convert quoted :: BuildQuote :: pending
             | BuildList count ->
-                completed <- List (takeCompleted count) :: completed
+                completed <- ofList (takeCompleted count) :: completed
             | BuildDottedList headCount ->
                 match takeCompleted (headCount + 1) |> List.splitAt headCount with
-                | head, [tail] -> completed <- DottedList(head, tail) :: completed
+                | head, [tail] -> completed <- (ofDotted head tail) :: completed
                 | _ -> invalidOp "Located dotted list conversion is incomplete"
             | BuildVector count ->
                 completed <- Vector(Array.ofList (takeCompleted count)) :: completed
             | BuildQuote ->
                 match takeCompleted 1 with
-                | [quoted] -> completed <- List [Atom "quote"; quoted] :: completed
+                | [quoted] -> completed <- ofList [Atom "quote"; quoted] :: completed
                 | _ -> invalidOp "Located quote conversion is incomplete"
 
         match completed with

--- a/IronKernel/StaticCompiler.fs
+++ b/IronKernel/StaticCompiler.fs
@@ -44,11 +44,11 @@ module StaticCompiler =
             values
             |> List.map emitValue
             |> sequenceOptions
-            |> Option.map (fun emitted -> "List [" + String.concat "; " emitted + "]")
+            |> Option.map (fun emitted -> "ofList [" + String.concat "; " emitted + "]")
         | DottedList(head, tail) ->
             match head |> List.map emitValue |> sequenceOptions, emitValue tail with
             | Some emittedHead, Some emittedTail ->
-                Some("DottedList([" + String.concat "; " emittedHead + "], " + emittedTail + ")")
+                Some("ofDotted [" + String.concat "; " emittedHead + "] (" + emittedTail + ")")
             | _ -> None
         | Bool value -> Some(if value then "Bool true" else "Bool false")
         | Inert -> Some "Inert"

--- a/docs/adr/0005-mutable-pairs.md
+++ b/docs/adr/0005-mutable-pairs.md
@@ -1,6 +1,6 @@
 # ADR 0005: Mutable pairs
 
-Status: Accepted — phase 0 done, phases 1-6 outstanding
+Status: Accepted — phases 0 and 1 done, phases 2-6 outstanding
 
 ## Decision
 
@@ -171,13 +171,53 @@ Collapsing the two cases on top of that inconsistency would have buried the bug
 rather than fixed it, so it is fixed first and phase 1 removes the duplicate case
 outright.
 
-**Phase 1 — introduce the cell.** Replace the two union cases with `Pair of
-PairCell` plus `Nil`, keep `List`/`DottedList` as the active patterns described
-above, and edit the construction sites to the renamed helpers. The type checker
-locates every site that needs more than that. No behaviour changes: pairs are still created immutable, and nothing mutates
-them yet. Validated by the existing suite and by `CompilerBenchmarks` against the
-numbers below — this is the phase most likely to cost performance, and it should
-be measured before anything is built on it.
+**Phase 1 — introduce the cell.** *Done.* `LispVal` has `Pair of PairCell` with a
+mutable car, a mutable cdr and an immutability flag, and `Nil` is the only empty
+list. `List` and `DottedList` survive as active patterns, so the match sites
+compiled untouched and only construction moved, to `ofList` / `ofDotted`.
+Everything is still built immutable and nothing mutates a cell, so no behaviour
+changes.
+
+The active-pattern cost was worse than this plan guessed, and the guess about
+*where* was wrong. It is not confined to argument dispatch and arity matching: any
+site that asks a question about **one cell** through a list pattern became linear,
+and the damage was concentrated in a handful of places that are called constantly.
+
+- `car` walked a whole chain to read its first cell. `cdr` and `cons` walked it
+  *and rebuilt it*, so every `(cdr rest)` in a library loop copied the rest of the
+  list and every traversal was quadratic.
+- `bind` destructured and rebuilt both the parameter chain and the argument chain
+  on every iteration, making operative application quadratic in its arity.
+- The evaluator matched `List (Atom name :: args)` and then `List (op :: args)`,
+  materialising the operands twice per combination.
+- The analyzer matched up to seven list patterns against the same form, walking
+  and rebuilding it each time — most of what compiling a form does.
+- `null?`, `pair?`, the `ListShape` contract check and the equivalence walk each
+  walked a chain to answer a question about one cell.
+
+The rule that falls out, and the one to apply in later phases: **anything asking
+about a cell matches `Pair` or `Nil` directly; only code that genuinely wants the
+elements uses the list pattern, and then only once.** Where a function needs the
+elements repeatedly it materialises them once at the top and matches on the F#
+list from there.
+
+Against the baseline below, after those changes:
+
+| Method | before | after | |
+|---|---:|---:|---|
+| ColdCompile | 105.4 ns / 592 B | 145.8 ns / 808 B | +38% |
+| Interpreted | 371.1 ns / 1872 B | 401.0 ns / 2024 B | +8% |
+| CompiledGeneric | 173.6 ns / 808 B | 175.1 ns / 808 B | +1%, allocation identical |
+| CompiledFolded | 51.9 ns / 304 B | 52.6 ns / 304 B | +1%, allocation identical |
+
+The steady-state compiled paths are at parity, which is what this plan named as
+the number to hold. What remains is paid where a cons chain has to be turned into
+an F# list for code that wants the elements: compiling a form, and evaluating one
+interpreted. That is inherent to keeping the list patterns rather than rewriting
+the analyzer and evaluator against cells directly, and it is the obvious place to
+look if the interpreted path ever needs to be faster.
+
+The full suite is 114s against 107s on master, all 342 tests passing.
 
 **Phase 2 — `eq?` becomes identity.** With cells, two `equal?` lists can be
 different objects, which is the distinction 4.2.1 asks for and IronKernel has


### PR DESCRIPTION
`LispVal` now has `Pair of PairCell` — mutable car, mutable cdr, immutability flag, reference equality — and `Nil` is the only empty list. `List` and `DottedList` survive as active patterns, so the match sites compiled untouched and only construction moved, to `ofList` / `ofDotted`.

**No behaviour changes.** Everything is still built immutable and nothing mutates a cell yet. 342 tests pass.

## The ADR's bet paid off; its guess about cost did not

The active-pattern plan worked for the *conversion*: the compiler located every site and the solution builds with 0 warnings.

The plan guessed the cost would land on "argument dispatch and arity matching". That was wrong, and instructively so. The real rule is that **any site asking a question about one cell through a list pattern became linear** — and a few of those are called constantly:

- **`car` walked a whole chain to read its first cell. `cdr` and `cons` walked it *and rebuilt it*** — so every `(cdr rest)` in a library loop copied the rest of the list, and every traversal was quadratic. This was most of it.
- **`bind`** destructured and rebuilt both the parameter chain and the argument chain every iteration, making operative application quadratic in its arity.
- The **evaluator** matched `List (Atom name :: args)` then `List (op :: args)`, materialising operands twice per combination.
- The **analyzer** matched up to seven list patterns against the same form — most of what compiling a form does.
- `null?`, `pair?`, the `ListShape` contract check and the equivalence walk each walked a chain to answer a one-cell question.

All now match `Pair`/`Nil` directly, or materialise once and dispatch on the F# list. The rule is recorded in the ADR for phases 2–6.

Sharing the tail in `cdr` rather than copying it is also what §4.7.1 actually means by a pair, and what `set-cdr!` will need in phase 3.

## One thing that had to change beyond patterns

The static backend **emits F# source text**, and the text it emitted said `List [...]` — which no longer compiles in the generated program. That surfaced as seven CliTests failing to produce a runnable artifact.

## Results

| Method | master | branch | |
|---|---:|---:|---|
| ColdCompile | 105.4 ns / 592 B | 145.8 ns / 808 B | +38% |
| Interpreted | 371.1 ns / 1872 B | 401.0 ns / 2024 B | +8% |
| CompiledGeneric | 173.6 ns / 808 B | 175.1 ns / 808 B | +1%, **allocation identical** |
| CompiledFolded | 51.9 ns / 304 B | 52.6 ns / 304 B | +1%, **allocation identical** |

The steady-state compiled paths — the number the ADR named as the one to hold — are at parity. What remains is paid where a cons chain must be turned into an F# list for code that wants the elements: compiling a form, and evaluating one interpreted. That is inherent to keeping the list patterns rather than rewriting the analyzer and evaluator against cells directly, and it's the obvious place to look if the interpreted path ever needs to be faster. I'd rather name that cost than hide it.

Suite: 114s against 107s on master.

## Verification

- 342 tests pass; clean `--no-incremental` rebuild, 0 warnings
- every example runs (`yingyang.ikr` is the non-terminating puzzle by design)
- CLR fault sweep: zero process aborts across 172 cases
- conformance matrix unchanged

Phase 2 next: `eq?` becomes object identity, which retires the 4.2.1 divergence and moves `assq`/`memq?` out from under their current tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789618733&installation_model_id=427656&pr_number=56&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F56&signature=d8be25dc564c6b582371e239be4e2dd5d4200ecea2c04de1f203534b4e968a5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->