### PR TITLE
Make eq? object identity (ADR 0005 phase 2)

### DIFF
--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -74,7 +74,20 @@
             | [x; y] -> bounceContinue env cont (consImmutable x y)
             | badArgList -> fail (NumArgs(2,badArgList))
 
-        let private eqvValue left right =
+        /// R-1RK 4.2.1 and 4.3.1. One walk serves both predicates; `pairsByIdentity`
+        /// is what separates them.
+        ///
+        /// `eq?` is "effectively the same object, even in the presence of mutation",
+        /// and the report is explicit that "two pairs returned by different calls to
+        /// cons are not eq?, even if they have the same car and cdr and the
+        /// implementation doesn't support pair mutation". So eq? compares pairs by
+        /// cell identity. `equal?` compares them structurally -- "look the same as
+        /// long as nothing is mutated" -- which is weaker, as 4.3.1 requires.
+        ///
+        /// Everything else is judged the same way by both. Two equal exact integers,
+        /// or two equal symbols, are interchangeable in every way a program can
+        /// observe, and the report leaves eq? on such objects to the implementation.
+        let private compareValues pairsByIdentity left right =
             let pending = System.Collections.Generic.Stack<LispVal * LispVal>()
             pending.Push(left, right)
             let mutable equal = true
@@ -91,6 +104,12 @@
 
             while equal && pending.Count > 0 do
                 match pending.Pop() with
+                // An object is the same object as itself, whatever its type. Without
+                // this an environment, a vector or a primitive combiner was not equal
+                // to itself, because the cases below cover only the types with a
+                // structural comparison and everything else fell through to false --
+                // which breaks the reflexivity 4.2.1 and 4.3.1 both require.
+                | first, second when obj.ReferenceEquals(first, second) -> ()
                 | Inert, Inert -> ()
                 | Obj arg1, Obj arg2 -> equal <- arg1.Equals(arg2)
                 | Bool arg1, Bool arg2 -> equal <- arg1 = arg2
@@ -100,21 +119,40 @@
                 // materialised both chains before comparing them and walked each value
                 // twice over -- once failing DottedList, once matching List.
                 | Pair left, Pair right ->
-                    pending.Push(left.cdr, right.cdr)
-                    pending.Push(left.car, right.car)
+                    if pairsByIdentity then
+                        // Reference-equal cells were settled above; distinct cells are
+                        // distinct pairs however alike they look.
+                        equal <- false
+                    else
+                        pending.Push(left.cdr, right.cdr)
+                        pending.Push(left.car, right.car)
                 | Nil, Nil -> ()
                 | _ -> equal <- false
 
             equal
 
+        let private eqvValue left right = compareValues false left right
+
+        let private eqValue left right = compareValues true left right
+
         let eqv' = function
             | [left; right] -> returnM (Bool(eqvValue left right))
             | badArgList -> throwError (NumArgs(2,badArgList))
 
-        let eqv env cont parms =
-            match eqv' parms with
-            | Choice1Of2 e -> fail e
-            | Choice2Of2 q -> bounceContinue env cont q
+        /// R-1RK 6.5.1 and 6.6.1 generalize both predicates to zero or more arguments:
+        /// true unless some two of the arguments differ. Comparing neighbours settles
+        /// that, because both relations are transitive (4.2.1 rule 1, 4.3.1 rule 1).
+        let private variadicEquivalence compare env cont args =
+            let rec loop = function
+                | first :: (second :: _ as rest) ->
+                    if compare first second then loop rest
+                    else bounceContinue env cont (Bool false)
+                | _ -> bounceContinue env cont (Bool true)
+            loop args
+
+        let eqv env cont args = variadicEquivalence eqvValue env cont args
+
+        let eq env cont args = variadicEquivalence eqValue env cont args
 
         open System.IO
 
@@ -1931,7 +1969,7 @@
                   ("car", car);
                   ("cdr", cdr);
                   ("cons", cons);
-                  ("eq?", eqv);
+                  ("eq?", eq);
                   ("equal?", eqv);
                   ("boolean?", isBoolean);
                   ("symbol?", isSymbol);

--- a/IronKernel.Tests/KernelConformanceTests.fs
+++ b/IronKernel.Tests/KernelConformanceTests.fs
@@ -82,18 +82,38 @@ let private behaviouralChecks () : (string * string list) list = [
                "(eqv? (if #t 1 no-such-variable) 1)" ]
     "4.1.1", [ "(boolean? #t)"; "(boolean? #f)"; "(eqv? (boolean? 1) #f)"; "(boolean?)" ]
     "4.3.1", [ "(equal? (list 1 2) (list 1 2))"; "(eqv? (equal? 1 2) #f)"
-               "(equal? \"ab\" \"ab\")" ]
+               "(equal? \"ab\" \"ab\")"
+               // Weaker than eq?: true where eq? is false, and never the other way.
+               "(equal? (list 1) (list 1))"
+               // Reflexive on objects with no structural comparison of their own.
+               "(let ((v (vector 1 2))) (equal? v v))"
+               "(equal? car car)" ]
     "4.4.1", [ "(symbol? 'a)"; "(eqv? (symbol? 1) #f)"; "(symbol?)" ]
     "4.5.1", [ "(inert? #inert)"; "(eqv? (inert? 1) #f)"; "(inert?)" ]
     // 4.2.1 / 6.5.1: eq? is coarser here than the report's (see the divergence), so
     // these check what it does guarantee.
-    "4.2.1", [ "(eq? 'a 'a)"; "(eqv? (eq? 'a 'b) #f)"; "(eq? 1 1)" ]
+    "4.2.1", [ "(eq? 'a 'a)"; "(eqv? (eq? 'a 'b) #f)"; "(eq? 1 1)"
+               // "Two pairs returned by different calls to cons are not eq?, even if
+               // they have the same car and cdr" -- the distinction equal? does not
+               // make, and the reason eq? cannot be the structural comparison.
+               "(eqv? (eq? (list 1) (list 1)) #f)"
+               "(equal? (list 1) (list 1))"
+               // Reflexive, and the same pair reached two ways is the same pair.
+               "(let ((p (list 1 2))) (eq? p p))"
+               "(let ((p (list 1 2))) (eq? p (car (list p))))"
+               "(let ((p (list 1 2))) (eq? (cdr p) (cdr p)))"
+               // Environments have identity too, per the same section.
+               "(let ((e (make-environment))) (eq? e e))"
+               "(eqv? (eq? (make-environment) (make-environment)) #f)" ]
     "4.6.1", [ "(pair? (cons 1 2))"; "(eqv? (pair? ()) #f)" ]
     // 4.9.1: $define! binds in the current environment and returns inert.
     "4.7.2", [ "(=? (copy-es-immutable 5) 5)"
                "(equal? (copy-es-immutable (list (list 1 2) 3)) (list (list 1 2) 3))"
                "(pair? (copy-es-immutable (list 1 2)))" ]
     "6.4.2", [ "(=? (copy-es 5) 5)"
+               // "always returns a non-eq? pair when given a pair as argument"
+               "(let ((p (list 1 2))) (eqv? (eq? (copy-es p) p) #f))"
+               "(let ((p (list 1 2))) (equal? (copy-es p) p))"
                "(equal? (copy-es (list (list 1 2) 3)) (list (list 1 2) 3))"
                "(pair? (copy-es (list 1 2)))"
                // The structure is walked to the leaves, and the cdr of an improper
@@ -111,7 +131,10 @@ let private behaviouralChecks () : (string * string list) list = [
                "(eqv? (memq? 1 (list)) #f)" ]
     "4.9.1", [ "(let ((e (get-current-environment))) (sequence (eval (list $define! 'dz 11) e) (=? dz 11)))"
                "(inert? ($define! dy 1))" ]
-    "6.5.1", [ "(eq? 'a 'a)"; "(eqv? (eq? 'a 'b) #f)" ]
+    "6.5.1", [ "(eq? 'a 'a)"; "(eqv? (eq? 'a 'b) #f)"
+               // Generalized to zero or more arguments: true unless some two differ.
+               "(eq?)"; "(eq? 'a)"; "(eq? 'a 'a 'a)"
+               "(eqv? (eq? 'a 'a 'b) #f)" ]
     "6.7.6", [ // $letrec* binds sequentially, so a later binding sees an earlier one.
                "(=? (letrec* ((a 1) (b (+ a 1))) b) 2)" ]
     "6.7.7", [ "(=? (let-redirect (make-environment) ((x 5)) x) 5)"
@@ -152,7 +175,11 @@ let private behaviouralChecks () : (string * string list) list = [
     "6.3.10", [ "(=? (reduce (list 1 2 3 4) + 0) 10)"; "(=? (reduce () + 0) 0)"
                 "(=? (reduce (list 5) + 0) 5)" ]
     "6.6.1", [ "(equal? (list 1 (list 2)) (list 1 (list 2)))"
-               "(eqv? (equal? (list 1) (list 2)) #f)" ]
+               "(eqv? (equal? (list 1) (list 2)) #f)"
+               "(equal?)"; "(equal? 1)"; "(equal? 1 1 1)"
+               "(eqv? (equal? 1 1 2) #f)"
+               // 4.3.1: equal? must return true whenever eq? would.
+               "(let ((p (list 1))) (equal? p p))" ]
     "4.6.2", [ "(null? ())"; "(eqv? (null? (cons 1 2)) #f)" ]
     "4.6.3", [ "(eqv? (car (cons 1 2)) 1)"; "(eqv? (cdr (cons 1 2)) 2)" ]
     "4.8.1", [ "(environment? (get-current-environment))" ]
@@ -568,15 +595,12 @@ let private divergences () = [
            + "have no cell to write into and are absent. The four entries that need no "
            + "mutation are implemented. `copy-es-immutable` returns its argument, which "
            + "4.7.2 permits outright for an argument that is already an immutable pair; "
-           + "`copy-es` copies the structure, but the report's promise that the result "
-           + "is not `eq?` to a pair argument is unobservable here, since `eq?` compares "
-           + "structurally (see 4.2.1). Supporting the module fully means replacing the "
+           + "`copy-es` copies the structure, and its result is not `eq?` to a pair "
+           + "argument now that `eq?` compares pairs by identity. Supporting the module "
+           + "fully means replacing the "
            + "list representation with mutable cons cells and making every traversal "
            + "cycle-safe, including `equal?`. That work is planned in "
            + "[ADR 0005](adr/0005-mutable-pairs.md)."
-    "4.2.1", "`eq?` is bound to the same structural comparison as `eqv?`, so it is "
-             + "coarser than the report's, which distinguishes objects that `equal?` "
-             + "does not."
     "12.10", "Complex numbers are `System.Numerics.Complex`, so components are "
              + "double precision and a result whose imaginary part is zero collapses "
              + "back to a real. The report specifies 12.10 by signature only."

--- a/IronKernel.Tests/PairMutationTests.fs
+++ b/IronKernel.Tests/PairMutationTests.fs
@@ -120,3 +120,85 @@ let ``the empty list has one spelling that a program can observe`` () =
         "(eqv? (pair? (#inert)) #f)", Bool true
         "(=? (length (#inert)) 0)", Bool true
     ] |> evalSessionKernel
+
+[<Fact>]
+let ``eq? distinguishes pairs that equal? does not`` () =
+    // R-1RK 4.2.1: eq? is "effectively the same object, even in the presence of
+    // mutation", and the report is explicit that "two pairs returned by different
+    // calls to cons are not eq?, even if they have the same car and cdr and the
+    // implementation doesn't support pair mutation". equal? is the weaker predicate
+    // (4.3.1) and still says they look alike.
+    [
+        "(eqv? (eq? (list 1) (list 1)) #f)", Bool true
+        "(eqv? (eq? (cons 1 2) (cons 1 2)) #f)", Bool true
+        "(equal? (list 1) (list 1))", Bool true
+        // The same pair, reached two different ways, is the same pair.
+        "(define p (list 1 2))", Inert
+        "(eq? p p)", Bool true
+        "(eq? p (car (list p)))", Bool true
+        // cdr shares the tail rather than copying it, so the tail is one object.
+        "(eq? (cdr p) (cdr p))", Bool true
+        "(eq? (car (cdr (list 0 p))) p)", Bool true
+        // Environments have identity for the same reason the report gives.
+        "(eqv? (eq? (make-environment) (make-environment)) #f)", Bool true
+        "(define e (make-environment))", Inert
+        "(eq? e e)", Bool true
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``both equivalence predicates are reflexive on every kind of object`` () =
+    // The structural walk covered only the types with a structural comparison and let
+    // everything else fall through to false, so an environment, a vector and even a
+    // primitive combiner were not equal to themselves. Reflexivity is rule 1 of both
+    // 4.2.1 and 4.3.1.
+    [
+        "(define e (get-current-environment))", Inert
+        "(define v (vector 1 2))", Inert
+        "(eq? e e)", Bool true
+        "(equal? e e)", Bool true
+        "(eq? v v)", Bool true
+        "(equal? v v)", Bool true
+        "(eq? car car)", Bool true
+        "(equal? car car)", Bool true
+        "(define f (lambda (x) x))", Inert
+        "(eq? f f)", Bool true
+        "(call/cc (lambda (k) (eq? k k)))", Bool true
+        // and on the values that already had a comparison
+        "(eq? 'a 'a)", Bool true
+        "(eq? 1 1)", Bool true
+        "(eq? () ())", Bool true
+        "(eq? #t #t)", Bool true
+        "(eq? #inert #inert)", Bool true
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``eq? and equal? take zero or more arguments`` () =
+    // R-1RK 6.5.1 and 6.6.1 generalize both to zero or more: true unless some two of
+    // the arguments differ. Both used to require exactly two.
+    [
+        "(eq?)", Bool true
+        "(eq? 'a)", Bool true
+        "(eq? 'a 'a 'a)", Bool true
+        "(eqv? (eq? 'a 'a 'b) #f)", Bool true
+        "(equal?)", Bool true
+        "(equal? 1)", Bool true
+        "(equal? (list 1) (list 1) (list 1))", Bool true
+        "(eqv? (equal? (list 1) (list 1) (list 2)) #f)", Bool true
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``copy-es returns a pair that is not eq? to its argument`` () =
+    // R-1RK 6.4.2 promises this outright. It was unobservable while eq? compared
+    // structurally, which is why the 4.7 divergence used to say so.
+    [
+        "(define p (list 1 (list 2)))", Inert
+        "(eqv? (eq? (copy-es p) p) #f)", Bool true
+        "(equal? (copy-es p) p)", Bool true
+        // The copy goes all the way down: the nested pair is fresh too.
+        "(eqv? (eq? (car (cdr (copy-es p))) (car (cdr p))) #f)", Bool true
+        // Non-pair referents come through as themselves (4.7.2's "corresponding
+        // non-pair referents being eq?").
+        "(eq? (car (copy-es (list 'a))) 'a)", Bool true
+        // copy-es-immutable may return its argument, and does.
+        "(eq? (copy-es-immutable p) p)", Bool true
+    ] |> evalSessionKernel

--- a/docs/adr/0005-mutable-pairs.md
+++ b/docs/adr/0005-mutable-pairs.md
@@ -1,6 +1,6 @@
 # ADR 0005: Mutable pairs
 
-Status: Accepted — phases 0 and 1 done, phases 2-6 outstanding
+Status: Accepted — phases 0-2 done, phases 3-6 outstanding
 
 ## Decision
 
@@ -219,13 +219,32 @@ look if the interpreted path ever needs to be faster.
 
 The full suite is 114s against 107s on master, all 342 tests passing.
 
-**Phase 2 — `eq?` becomes identity.** With cells, two `equal?` lists can be
-different objects, which is the distinction 4.2.1 asks for and IronKernel has
-never been able to make. `eq?` moves to reference identity on pairs, keeping its
-current behaviour on atoms, numbers and the rest. This retires the 4.2.1
-divergence and changes `assq` and `memq?` (6.4.3, 6.4.4), which are `assoc` and
-`member?` over `eq?` — their tests currently pass *because* `eq?` is structural
-and will need revisiting deliberately.
+**Phase 2 — `eq?` becomes identity.** *Done.* `eq?` and `equal?` were both bound
+to the same structural walk; they now share one traversal that differs in a single
+respect — `eq?` compares pairs by cell identity, `equal?` compares them
+structurally. That is exactly what 4.2.1 asks for: "two pairs returned by
+different calls to cons are not eq?, even if they have the same car and cdr and
+the implementation doesn't support pair mutation". Environments were already
+distinguished the same way. The 4.2.1 divergence is retired.
+
+Two further bugs surfaced while splitting them, both in required entries and both
+of the same shape as the `Nil` one that preceded phase 1. The structural walk
+covered only the types with a structural comparison and let everything else fall
+through to *not equal*, so an environment, a vector, a primitive combiner and a
+continuation were **not equal to themselves** — reflexivity is rule 1 of both
+4.2.1 and 4.3.1. A reference-equality case ahead of the type-specific ones fixes
+all of them at once. And neither predicate was variadic, though 6.5.1 and 6.6.1
+generalize both to zero or more arguments.
+
+`copy-es`'s promise that its result is not `eq?` to a pair argument (6.4.2) became
+observable at this point, so the 4.7 divergence no longer has to record it as
+unobservable.
+
+The expected fallout did not materialise: `assq` and `memq?` are `assoc` and
+`member?` over `eq?`, and this plan expected their tests to need revisiting. They
+did not, because they are exercised with symbols and numbers, which remain `eq?`
+when equal. That is worth knowing rather than assuming — a program that used
+`memq?` over freshly built lists would now get a different answer.
 
 **Phase 3 — mutation.** `set-car!` and `set-cdr!` (4.7.1), signalling on an
 immutable pair. `copy-es` (6.4.2) becomes a real copy with an observably fresh

--- a/docs/kernel-conformance.md
+++ b/docs/kernel-conformance.md
@@ -48,8 +48,7 @@ exercised, not that IronKernel matches the report exactly.
 | 12.3.3 | Under strict arithmetic the report signals on numeric overflow and underflow as well as on a result with no primary value. IronKernel signals only the latter: an overflow still yields an infinity and an underflow a zero, which is the report's behaviour for *cleared* strict-arithmetic. Its initial value here is true, which the report leaves open. |
 | 7.2.7 | Signalling an error is not an abnormal pass to `error-continuation`. IronKernel reports errors on a separate channel that unwinds the computation directly, so an exit guard is *not* selected when an error is signalled within the guarded extent -- passing to the continuation explicitly does work, and provides the diagnostic. One consequence is that the report's derivation of `$binds?` from an error exit-guard would not work here. |
 | 7.2.6 | `root-continuation` is not literally at the end of every continuation chain: IronKernel's drivers give each top-level form its own continuation. Its extent is instead defined to contain everything, which is what "the ancestor of all other continuations" means for the selection algorithm, so a clause selecting on it is always selected. Receiving a value ends the session, and the process exit status is 0. |
-| 4.7 | Module Pair mutation is only half implemented, and deliberately so. IronKernel's pairs are immutable -- lists are F# immutable lists rather than cons cells -- so `set-car!`, `set-cdr!`, `encycle!` and `append!` have no cell to write into and are absent. The four entries that need no mutation are implemented. `copy-es-immutable` returns its argument, which 4.7.2 permits outright for an argument that is already an immutable pair; `copy-es` copies the structure, but the report's promise that the result is not `eq?` to a pair argument is unobservable here, since `eq?` compares structurally (see 4.2.1). Supporting the module fully means replacing the list representation with mutable cons cells and making every traversal cycle-safe, including `equal?`. That work is planned in [ADR 0005](adr/0005-mutable-pairs.md). |
-| 4.2.1 | `eq?` is bound to the same structural comparison as `eqv?`, so it is coarser than the report's, which distinguishes objects that `equal?` does not. |
+| 4.7 | Module Pair mutation is only half implemented, and deliberately so. IronKernel's pairs are immutable -- lists are F# immutable lists rather than cons cells -- so `set-car!`, `set-cdr!`, `encycle!` and `append!` have no cell to write into and are absent. The four entries that need no mutation are implemented. `copy-es-immutable` returns its argument, which 4.7.2 permits outright for an argument that is already an immutable pair; `copy-es` copies the structure, and its result is not `eq?` to a pair argument now that `eq?` compares pairs by identity. Supporting the module fully means replacing the list representation with mutable cons cells and making every traversal cycle-safe, including `equal?`. That work is planned in [ADR 0005](adr/0005-mutable-pairs.md). |
 | 12.10 | Complex numbers are `System.Numerics.Complex`, so components are double precision and a result whose imaginary part is zero collapses back to a real. The report specifies 12.10 by signature only. |
 | 12.8 | Exactness is carried by a value's representation rather than by the exactness tag the report describes, since module Inexact (12.6) is unimplemented: `1/2` is an exact ratio and `0.5` is a double. One consequence is that `numerator` and `denominator` of an inexact real return exact integers -- `(denominator 0.1)` is 2^55 -- rather than inexact ones. |
 
@@ -117,8 +116,8 @@ divergences before taking any row as a claim of conformance.
 | Entry | Feature | Module | Status | Notes |
 |---|---|---|---|---|
 | 4.1.1 | `boolean?` | Booleans | `verified` | 4 behavioural check(s) |
-| 4.2.1 | `eq?` | Equivalence under mutation (optional) | `verified` | optional module; 3 behavioural check(s) |
-| 4.3.1 | `equal?` | Equivalence up to mutation | `verified` | 3 behavioural check(s) |
+| 4.2.1 | `eq?` | Equivalence under mutation (optional) | `verified` | optional module; 10 behavioural check(s) |
+| 4.3.1 | `equal?` | Equivalence up to mutation | `verified` | 6 behavioural check(s) |
 | 4.4.1 | `symbol?` | Symbols | `verified` | 3 behavioural check(s) |
 | 4.5.1 | `inert?` | Control | `verified` | 3 behavioural check(s) |
 | 4.5.2 | `$if` | Control | `verified` | 3 behavioural check(s) |
@@ -177,11 +176,11 @@ divergences before taking any row as a claim of conformance.
 | 6.3.9 | `countable-list?` | Pairs and lists | `verified` | 2 behavioural check(s) |
 | 6.3.10 | `reduce` | Pairs and lists | `verified` | 3 behavioural check(s) |
 | 6.4.1 | `append!` | Pair mutation (optional) | `absent` | optional module |
-| 6.4.2 | `copy-es` | Pair mutation (optional) | `verified` | optional module; 6 behavioural check(s) |
+| 6.4.2 | `copy-es` | Pair mutation (optional) | `verified` | optional module; 8 behavioural check(s) |
 | 6.4.3 | `assq` | Pair mutation (optional) | `verified` | optional module; 4 behavioural check(s) |
 | 6.4.4 | `memq?` | Pair mutation (optional) | `verified` | optional module; 3 behavioural check(s) |
-| 6.5.1 | `eq?` | Equivalence under mutation (optional) | `verified` | optional module; 2 behavioural check(s) |
-| 6.6.1 | `equal?` | Equivalence up to mutation | `verified` | 2 behavioural check(s) |
+| 6.5.1 | `eq?` | Equivalence under mutation (optional) | `verified` | optional module; 6 behavioural check(s) |
+| 6.6.1 | `equal?` | Equivalence up to mutation | `verified` | 7 behavioural check(s) |
 | 6.7.1 | `$binds?` | Environments | `absent` |  |
 | 6.7.2 | `get-current-environment` | Environments | `verified` | 1 behavioural check(s) |
 | 6.7.3 | `make-kernel-standard-environment` | Environments | `absent` |  |

--- a/tools/clr-fault-cases.txt
+++ b/tools/clr-fault-cases.txt
@@ -170,3 +170,7 @@
 (#inert)
 (null? (#inert))
 (eqv? (#inert) (list))
+(eq? (list 1) (list 1))
+(eq?)
+(equal? car car)
+(eq? (make-environment) (make-environment))


### PR DESCRIPTION
`eq?` and `equal?` were both bound to the same structural walk. They now share one traversal that differs in a single respect: **`eq?` compares pairs by cell identity, `equal?` compares them structurally.**

```
(eq? (list 1) (list 1))     => #f      ; different calls to cons
(equal? (list 1) (list 1))  => #t      ; but they look alike
(let ((p (list 1 2))) (eq? p (car (list p))))  => #t
(let ((p (list 1 2))) (eq? (cdr p) (cdr p)))   => #t   ; cdr shares the tail
```

That is exactly §4.2.1: *"two pairs returned by different calls to cons are not eq?, even if they have the same car and cdr and the implementation doesn't support pair mutation"*. `equal?` stays the weaker predicate §4.3.1 describes. **The 4.2.1 divergence is retired.**

## Two more bugs, same shape as the `Nil` one

Splitting the predicates surfaced them, both in **required** entries:

**Neither predicate was reflexive on most types.** The structural walk covered only the types with a structural comparison and let everything else fall through to *not equal*:

```
(eq? e e)         was #f   for an environment
(equal? v v)      was #f   for a vector
(eq? car car)     was #f   for a primitive combiner
```

Reflexivity is rule 1 of both §4.2.1 and §4.3.1. A reference-equality case ahead of the type-specific ones fixes all of them at once — including continuations and compound procedures.

**Neither was variadic**, though §6.5.1 and §6.6.1 generalize both to zero or more arguments. `(eq? 'a)` used to be an arity error.

## Consequences

`copy-es`'s promise that its result is not `eq?` to a pair argument (§6.4.2) became **observable** here, so the 4.7 divergence no longer has to record it as unobservable.

The fallout the ADR predicted **did not happen**. It expected `assq`/`memq?` tests to need revisiting, since they are `assoc`/`member?` over `eq?`. They didn't — they're exercised with symbols and numbers, which stay `eq?` when equal. Worth stating rather than assuming: a program using `memq?` over freshly built lists now gets a different answer, which is the point of the change.

I also strengthened the conformance checks for all four entries. The old ones (`(eq? 'a 'a)`, `(equal? (list 1 2) (list 1 2))`) could not tell `eq?` from `equal?` and would have passed either way.

## Verification

- 346 tests pass (was 342); clean `--no-incremental` rebuild, 0 warnings
- every example runs (`yingyang.ikr` is the non-terminating puzzle by design)
- CLR fault sweep: zero process aborts across 176 cases
- `CompilerBenchmarks` unchanged from phase 1 (173.4 / 52.6 ns on the compiled paths, allocation identical)

Phase 3 next: `set-car!` / `set-cdr!` and the immutability flag — the first point at which anything can actually change under a reference.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789620069&installation_model_id=427656&pr_number=57&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F57&signature=0b31ec4d67a883b0dc2c7868e68c4d70f205c7221bf200d1f89360e4d7842400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->