### PR TITLE
Measure cycles in get-list-metrics and the shape predicates (ADR 0005 phase 4)

### DIFF
--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -1434,18 +1434,79 @@
         /// IronKernel's pairs are immutable and it does not implement the optional Pair
         /// mutation module, so no cyclic structure can be built and c is always zero
         /// and a always equals p. The shape of the answer is still the report's.
+        /// R-1RK 5.7.1. Returns `(p n a c)`: the number of pairs, the number of nils
+        /// (0 or 1), the acyclic prefix length, and the cycle length of the improper
+        /// list starting at the argument. `a + c = p`, and `n` and `c` are never both
+        /// non-zero.
+        ///
+        /// This used to answer "acyclic, of this length" unconditionally, which was
+        /// true only because no list could be cyclic. `set-cdr!` changed that, and this
+        /// is the primitive the whole derived list library asks about shape, so it is
+        /// the one place a cycle has to be measured rather than merely survived.
+        ///
+        /// Floyd: a second reference advancing at half speed meets the first inside any
+        /// cycle. From that meeting point the cycle length is one lap, and restarting
+        /// one reference at the beginning and advancing both in step meets at the
+        /// cycle's first pair, which is the acyclic prefix length.
         let getListMetrics env cont args =
             match args with
             | [value] ->
-                let pairs, nils =
-                    match value with
-                    | List [] -> 0, 1
-                    | List items -> List.length items, 1
-                    | DottedList(items, tail) ->
-                        List.length items, (match tail with List [] -> 1 | _ -> 0)
-                    | _ -> 0, 0
-                let counted n = Obj(box n)
-                bounceContinue env cont (ofList [counted pairs; counted nils; counted pairs; counted 0])
+                let cdrOf = function
+                    | Pair cell -> Some cell.cdr
+                    | _ -> None
+                let rec advance steps current =
+                    if steps = 0 then current
+                    else
+                        match cdrOf current with
+                        | Some next -> advance (steps - 1) next
+                        | None -> current
+                // Look for a meeting point.
+                let mutable slow = value
+                let mutable fast = value
+                let mutable met = false
+                let mutable ended = false
+                while not met && not ended do
+                    match cdrOf fast with
+                    | None -> ended <- true
+                    | Some once ->
+                        match cdrOf once with
+                        | None -> ended <- true
+                        | Some twice ->
+                            fast <- twice
+                            slow <- advance 1 slow
+                            if obj.ReferenceEquals(slow, fast) then met <- true
+                let pairs, nils, acyclic, cycle =
+                    if not met then
+                        // Acyclic: count pairs to the terminator, which is a nil or not.
+                        let mutable current = value
+                        let mutable count = 0
+                        let mutable walking = true
+                        while walking do
+                            match cdrOf current with
+                            | Some next -> count <- count + 1; current <- next
+                            | None -> walking <- false
+                        let terminatorIsNil = (match current with Nil -> 1 | _ -> 0)
+                        count, terminatorIsNil, count, 0
+                    else
+                        // One lap from the meeting point gives the cycle length.
+                        let mutable cycleLength = 1
+                        let mutable current = advance 1 fast
+                        while not (obj.ReferenceEquals(current, fast)) do
+                            current <- advance 1 current
+                            cycleLength <- cycleLength + 1
+                        // Advancing in step from the start and from the meeting point
+                        // brings both to the cycle's first pair.
+                        let mutable fromStart = value
+                        let mutable fromMeeting = fast
+                        let mutable prefix = 0
+                        while not (obj.ReferenceEquals(fromStart, fromMeeting)) do
+                            fromStart <- advance 1 fromStart
+                            fromMeeting <- advance 1 fromMeeting
+                            prefix <- prefix + 1
+                        prefix + cycleLength, 0, prefix, cycleLength
+                let counted (n: int) = Obj(box n)
+                bounceContinue env cont (
+                    ofList [counted pairs; counted nils; counted acyclic; counted cycle])
             | _ -> fail (NumArgs(1, args))
 
         /// R-1RK 12.10. Like 12.9 the report gives these signatures only, so they take

--- a/IronKernel.Tests/KernelConformanceTests.fs
+++ b/IronKernel.Tests/KernelConformanceTests.fs
@@ -168,7 +168,17 @@ let private behaviouralChecks () : (string * string list) list = [
     "5.7.1", [ "(equal? (get-list-metrics (list 1 2 3)) (list 3 1 3 0))"
                "(equal? (get-list-metrics ()) (list 0 1 0 0))"
                // A non-pair is the start of an improper list of just itself.
-               "(equal? (get-list-metrics 5) (list 0 0 0 0))" ]
+               "(equal? (get-list-metrics 5) (list 0 0 0 0))"
+               // "if n = c = 0, the improper list is not a list"
+               "(equal? (get-list-metrics (cons 1 2)) (list 1 0 1 0))"
+               // A cycle is measured rather than walked into, and a + c = p.
+               "(let ((p (list 1 2 3))) (set-cdr! (cdr (cdr p)) p)"
+               + " (equal? (get-list-metrics p) (list 3 0 0 3)))"
+               "(let ((q (list 1 2 3 4 5)))"
+               + " (set-cdr! (cdr (cdr (cdr (cdr q)))) (cdr (cdr q)))"
+               + " (equal? (get-list-metrics q) (list 5 0 2 3)))"
+               "(let ((r (list 1))) (set-cdr! r r)"
+               + " (equal? (get-list-metrics r) (list 1 0 0 1)))" ]
     "5.7.2", [ "(equal? (list-tail (list 1 2 3 4) 2) (list 3 4))"
                "(equal? (list-tail (list 1 2) 0) (list 1 2))" ]
     "6.2.1", [ "(combiner? car)"; "(combiner? vau)"; "(eqv? (combiner? 1) #f)" ]
@@ -185,8 +195,17 @@ let private behaviouralChecks () : (string * string list) list = [
     "6.3.6", [ "(equal? (assoc 'b (list (list 'a 1) (list 'b 2))) (list 'b 2))"
                "(equal? (assoc 'z (list (list 'a 1))) ())" ]
     "6.3.7", [ "(member? 2 (list 1 2 3))"; "(eqv? (member? 9 (list 1 2)) #f)" ]
-    "6.3.8", [ "(finite-list? (list 1 2))"; "(finite-list? ())"; "(eqv? (finite-list? 5) #f)" ]
-    "6.3.9", [ "(countable-list? (list 1 2))"; "(eqv? (countable-list? 5) #f)" ]
+    "6.3.8", [ "(finite-list? (list 1 2))"; "(finite-list? ())"; "(eqv? (finite-list? 5) #f)"
+               // The acyclic lists: a cyclic one is a list but not a finite one, and
+               // an improper one is not a list at all.
+               "(let ((p (list 1 2 3))) (set-cdr! (cdr (cdr p)) p) (eqv? (finite-list? p) #f))"
+               "(eqv? (finite-list? (cons 1 2)) #f)"
+               "(finite-list?)" ]
+    "6.3.9", [ "(countable-list? (list 1 2))"; "(eqv? (countable-list? 5) #f)"
+               // The lists: finite or cyclic, but not improper.
+               "(let ((p (list 1 2 3))) (set-cdr! (cdr (cdr p)) p) (countable-list? p))"
+               "(eqv? (countable-list? (cons 1 2)) #f)"
+               "(countable-list?)" ]
     // 6.3.10: (reduce list binary identity) -- the list comes first here.
     "6.3.10", [ "(=? (reduce (list 1 2 3 4) + 0) 10)"; "(=? (reduce () + 0) 0)"
                 "(=? (reduce (list 5) + 0) 5)" ]
@@ -226,7 +245,11 @@ let private behaviouralChecks () : (string * string list) list = [
                "(eqv? ($and? #f (/ 1 0)) #f)" ]
     "6.1.5", [ "($or? #f #t)"; "(eqv? ($or? #f #f) #f)"; "(eqv? ($or?) #f)"
                "($or? #t (/ 1 0))" ]
-    "6.3.1", [ "(eqv? (length (list 1 2 3)) 3)"; "(eqv? (length ()) 0)" ]
+    "6.3.1", [ "(eqv? (length (list 1 2 3)) 3)"; "(eqv? (length ()) 0)"
+               // "If object is not a pair, it returns zero; if object is a cyclic
+               // list, it returns positive infinity."
+               "(eqv? (length 5) 0)"; "(eqv? (length (cons 1 2)) 1)"
+               "(let ((p (list 1 2 3))) (set-cdr! (cdr (cdr p)) p) (eqv? (length p) #e+infinity))" ]
     "6.7.2", [ "(environment? (get-current-environment))" ]
     "6.7.4", [ "(eqv? (let* ((x 1) (y (+ x 1))) y) 2)" ]
     "6.7.5", [ "(eqv? (letrec ((f (lambda (n) (if (eqv? n 0) 0 (f (- n 1)))))) (f 3)) 0)" ]
@@ -610,9 +633,16 @@ let private divergences () = [
            + "mutable cons cells. Mutability follows where the structure came from: "
            + "the reader produces immutable pairs, because a program is an algorithm "
            + "rather than data the program made, while `cons` and `list` produce "
-           + "mutable ones. The remaining two, and the cycle-safety their cycles "
-           + "demand of `get-list-metrics` and the derived list library, are phases 4 "
-           + "and 5 of [ADR 0005](adr/0005-mutable-pairs.md)."
+           + "mutable ones. The two remaining entries are phase 5 of "
+           + "[ADR 0005](adr/0005-mutable-pairs.md)."
+    "6.3", "The derived list library divides on whether a derivation asks about a "
+           + "list's *shape* or walks its *elements*. `length`, `finite-list?` and "
+           + "`countable-list?` go through `get-list-metrics`, which measures a cycle "
+           + "rather than walking into one. `list-tail`, `filter`, `reduce`, `append` "
+           + "and the rest walk elements and diverge on a cyclic argument, as the "
+           + "report's own derivations of them do. The report's six-argument `reduce` "
+           + "(6.3.10), which is the entry that would handle a cyclic list, is not "
+           + "implemented: only the three-argument form is."
     "12.10", "Complex numbers are `System.Numerics.Complex`, so components are "
              + "double precision and a result whose imaginary part is zero collapses "
              + "back to a real. The report specifies 12.10 by signature only."

--- a/IronKernel.Tests/PairMutationTests.fs
+++ b/IronKernel.Tests/PairMutationTests.fs
@@ -299,3 +299,58 @@ let ``an operative keeps the body it captured even if the source is mutated`` ()
         "(=? (f) 3)", Bool true
         "(=? (f) 3)", Bool true
     ] |> evalSessionKernel
+
+[<Fact>]
+let ``get-list-metrics measures a cycle rather than walking into one`` () =
+    // R-1RK 5.7.1: (p n a c) -- pairs, nils, acyclic prefix length, cycle length --
+    // with a + c = p, and n and c never both non-zero. It used to answer "acyclic, of
+    // this length" unconditionally, which was true only because no list could be
+    // cyclic.
+    [
+        "(define metrics (lambda (x) (get-list-metrics x)))", Inert
+        "(equal? (metrics ()) (list 0 1 0 0))", Bool true
+        // "if a = c = 0, object is not a pair"
+        "(equal? (metrics 5) (list 0 0 0 0))", Bool true
+        "(equal? (metrics (list 1 2 3)) (list 3 1 3 0))", Bool true
+        // "if n = c = 0, the improper list is not a list"
+        "(equal? (metrics (cons 1 2)) (list 1 0 1 0))", Bool true
+        // A list that is all cycle.
+        "(define p (list 1 2 3))", Inert
+        "(set-cdr! (cdr (cdr p)) p)", Inert
+        "(equal? (metrics p) (list 3 0 0 3))", Bool true
+        // A cycle behind an acyclic prefix: a + c = p still holds.
+        "(define q (list 1 2 3 4 5))", Inert
+        "(set-cdr! (cdr (cdr (cdr (cdr q)))) (cdr (cdr q)))", Inert
+        "(equal? (metrics q) (list 5 0 2 3))", Bool true
+        // A pair whose cdr is itself.
+        "(define r (list 1))", Inert
+        "(set-cdr! r r)", Inert
+        "(equal? (metrics r) (list 1 0 0 1))", Bool true
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``length and the list predicates read the shape rather than walking it`` () =
+    // R-1RK 6.3.1: length is "the number of consecutive cdr references that can be
+    // followed", zero for a non-pair and positive infinity for a cyclic list. 6.3.8
+    // and 6.3.9: finite-list? is the acyclic lists, countable-list? the lists at all.
+    // All three would run forever on a cyclic argument if they cdr'd down it.
+    [
+        "(define p (list 1 2 3))", Inert
+        "(set-cdr! (cdr (cdr p)) p)", Inert
+        "(=? (length (list 1 2 3)) 3)", Bool true
+        "(=? (length ()) 0)", Bool true
+        "(=? (length 5) 0)", Bool true
+        "(=? (length (cons 1 2)) 1)", Bool true
+        "(eqv? (length p) #e+infinity)", Bool true
+        "(finite-list? (list 1 2))", Bool true
+        "(finite-list? ())", Bool true
+        "(eqv? (finite-list? p) #f)", Bool true
+        "(eqv? (finite-list? (cons 1 2)) #f)", Bool true
+        "(countable-list? (list 1 2))", Bool true
+        // A cyclic list is a list; an improper one is not.
+        "(countable-list? p)", Bool true
+        "(eqv? (countable-list? (cons 1 2)) #f)", Bool true
+        // Both are variadic and true for no arguments.
+        "(finite-list?)", Bool true
+        "(countable-list?)", Bool true
+    ] |> evalSessionKernel

--- a/IronKernel/kernel.ikr
+++ b/IronKernel/kernel.ikr
@@ -48,12 +48,18 @@
            (aux args)))))
 
 ;TODO: consider making length a native primitive		   
-(define length
+; 6.3.1: the improper-list length -- "the number of consecutive cdr references
+; that can be followed starting from object". Zero for a non-pair, and positive
+; infinity for a cyclic list, which is why this asks get-list-metrics rather than
+; cdring down: cdring down a cyclic list does not finish.
+; Written with wrap/vau rather than lambda because lambda is defined further down.
+(define $length-from-metrics
   (wrap
-    (vau (x) _
-      (if (null? x)
-        0
-        (+ 1 (length (cdr x)))))))		   
+    (vau (m) _
+      (if (zero? (car (cdr (cdr (cdr m))))) (car m) #e+infinity))))
+
+(define length
+  (wrap (vau (x) _ ($length-from-metrics (get-list-metrics x)))))
 		   
 ; This operative generalizes primitive operative $vau , §4.10.3, so that the con-
 ;structed compound operative will evaluate a sequence of expressions in its local en-
@@ -441,9 +447,12 @@
 
 ; --- R-1RK list features (5.7, 6.3) ------------------------------------------
 ; get-list-metrics is a primitive; the rest are derived from it and from the pair
-; primitives. IronKernel's pairs are immutable and the optional Pair mutation
-; module is unimplemented, so no list can be cyclic: every list here is finite,
-; and the cycle-handling the report describes has nothing to act on.
+; primitives. set-cdr! can build a cycle, so the derivations that ask about a
+; list's *shape* go through get-list-metrics, which measures a cycle rather than
+; walking into one. The derivations that walk a list's elements -- list-tail,
+; filter, reduce and the rest -- still assume the caller passes a finite list, as
+; the report's own derivations of them do; a cyclic argument makes them diverge,
+; which is recorded as a divergence rather than papered over.
 
 ; 5.7.2
 (define list-tail
@@ -553,8 +562,19 @@
     (letrec ((aux (lambda (ys) (if (null? ys) #t (if (ok? (car ys)) (aux (cdr ys)) #f)))))
       (aux xs))))
 
-(define finite-list? (lambda xs ($every? $list-shaped? xs)))
-(define countable-list? (lambda xs ($every? $list-shaped? xs)))
+; 6.3.8 / 6.3.9. A finite list is an acyclic one -- it ends at nil, which the
+; metrics report as n = 1. A countable list is a list at all: finite, or cyclic,
+; which is c > 0. Neither can walk the list itself now that one may be cyclic.
+(define $finite-list-one?
+  (lambda (x) (=? (car (cdr (get-list-metrics x))) 1)))
+
+(define $countable-list-one?
+  (lambda (x)
+    (let ((m (get-list-metrics x)))
+      (if (=? (car (cdr m)) 1) #t (<? 0 (car (cdr (cdr (cdr m)))))))))
+
+(define finite-list? (lambda xs ($every? $finite-list-one? xs)))
+(define countable-list? (lambda xs ($every? $countable-list-one? xs)))
 
 ; 6.3.10: (reduce list binary identity). The report also gives a six-argument form
 ; for cyclic lists; with no cycles to describe, the three-argument form is the whole

--- a/docs/adr/0005-mutable-pairs.md
+++ b/docs/adr/0005-mutable-pairs.md
@@ -1,6 +1,6 @@
 # ADR 0005: Mutable pairs
 
-Status: Accepted — phases 0-3 done, phases 4-6 outstanding
+Status: Accepted — phases 0-4 done, phases 5-6 outstanding
 
 ## Decision
 
@@ -279,12 +279,29 @@ What is left for phase 4 is narrower than this plan assumed: `get-list-metrics`
 still answers "acyclic, of this length" unconditionally, and the `kernel.ikr` list
 derivations built on it still carry their no-cycles comments.
 
-**Phase 4 — cycle safety.** Now that `encycle!` is buildable, before it is built:
-`equal?` gets a termination-safe algorithm; `showVal` — already an explicit work
-stack — gets cycle detection; `get-list-metrics` computes the four metrics for
-real. Then the `kernel.ikr` list library derivations that carry "no list can be
-cyclic" comments are revisited one at a time against the report's cyclic cases.
-`equal?` is a required entry, so this phase is not optional.
+**Phase 4 — cycle safety.** *Done*, and narrower than planned, because phase 3
+had already taken the traversals that would otherwise hang.
+
+`get-list-metrics` (5.7.1) now measures rather than assumes. It returns
+`(p n a c)` for real — pairs, nils, acyclic prefix length, cycle length — found
+with Floyd: a second reference at half speed meets the first inside any cycle, one
+lap from the meeting point gives the cycle length, and restarting one reference at
+the beginning and advancing both in step meets at the cycle's first pair. It is
+the primitive the derived library asks about shape, so it is the one place a cycle
+has to be measured.
+
+The three derivations that ask about shape now go through it. `length` (6.3.1)
+returns positive infinity for a cyclic list, which is the report's answer and a
+use for the exact infinities of 12.3.2. `finite-list?` (6.3.8) is `n = 1` and
+`countable-list?` (6.3.9) is `n = 1 or c > 0`; both previously walked the list,
+which a cyclic argument would not have survived.
+
+The derivations that walk *elements* — `list-tail`, `filter`, `reduce`, `append`
+and the rest — still assume a finite argument, exactly as the report's own
+derivations of them do, and diverge on a cyclic one. That is recorded as a 6.3
+divergence rather than left implicit, together with the fact that the report's
+six-argument `reduce` (6.3.10), the entry that would handle a cyclic list, is not
+implemented.
 
 **Phase 5 — the mutating library entries.** `encycle!` (5.8.1) and `append!`
 (6.4.1), which is where a cycle first enters the system from Kernel code.

--- a/docs/kernel-conformance.md
+++ b/docs/kernel-conformance.md
@@ -48,7 +48,8 @@ exercised, not that IronKernel matches the report exactly.
 | 12.3.3 | Under strict arithmetic the report signals on numeric overflow and underflow as well as on a result with no primary value. IronKernel signals only the latter: an overflow still yields an infinity and an underflow a zero, which is the report's behaviour for *cleared* strict-arithmetic. Its initial value here is true, which the report leaves open. |
 | 7.2.7 | Signalling an error is not an abnormal pass to `error-continuation`. IronKernel reports errors on a separate channel that unwinds the computation directly, so an exit guard is *not* selected when an error is signalled within the guarded extent -- passing to the continuation explicitly does work, and provides the diagnostic. One consequence is that the report's derivation of `$binds?` from an error exit-guard would not work here. |
 | 7.2.6 | `root-continuation` is not literally at the end of every continuation chain: IronKernel's drivers give each top-level form its own continuation. Its extent is instead defined to contain everything, which is what "the ancestor of all other continuations" means for the selection algorithm, so a clause selecting on it is always selected. Receiving a value ends the session, and the process exit status is 0. |
-| 4.7 | Module Pair mutation is not complete: `encycle!` (5.8.1) and `append!` (6.4.1) are absent. Everything else is implemented, over genuinely mutable cons cells. Mutability follows where the structure came from: the reader produces immutable pairs, because a program is an algorithm rather than data the program made, while `cons` and `list` produce mutable ones. The remaining two, and the cycle-safety their cycles demand of `get-list-metrics` and the derived list library, are phases 4 and 5 of [ADR 0005](adr/0005-mutable-pairs.md). |
+| 4.7 | Module Pair mutation is not complete: `encycle!` (5.8.1) and `append!` (6.4.1) are absent. Everything else is implemented, over genuinely mutable cons cells. Mutability follows where the structure came from: the reader produces immutable pairs, because a program is an algorithm rather than data the program made, while `cons` and `list` produce mutable ones. The two remaining entries are phase 5 of [ADR 0005](adr/0005-mutable-pairs.md). |
+| 6.3 | The derived list library divides on whether a derivation asks about a list's *shape* or walks its *elements*. `length`, `finite-list?` and `countable-list?` go through `get-list-metrics`, which measures a cycle rather than walking into one. `list-tail`, `filter`, `reduce`, `append` and the rest walk elements and diverge on a cyclic argument, as the report's own derivations of them do. The report's six-argument `reduce` (6.3.10), which is the entry that would handle a cyclic list, is not implemented: only the three-argument form is. |
 | 12.10 | Complex numbers are `System.Numerics.Complex`, so components are double precision and a result whose imaginary part is zero collapses back to a real. The report specifies 12.10 by signature only. |
 | 12.8 | Exactness is carried by a value's representation rather than by the exactness tag the report describes, since module Inexact (12.6) is unimplemented: `1/2` is an exact ratio and `0.5` is a double. One consequence is that `numerator` and `denominator` of an inexact real return exact integers -- `(denominator 0.1)` is 2^55 -- rather than inexact ones. |
 
@@ -149,7 +150,7 @@ divergences before taking any row as a claim of conformance.
 | 5.4.1 | `car, cdr` | Pairs and lists | `verified` | 2 behavioural check(s) |
 | 5.5.1 | `apply` | Combiners | `verified` | 1 behavioural check(s) |
 | 5.6.1 | `$cond` | Control | `verified` | 1 behavioural check(s) |
-| 5.7.1 | `get-list-metrics` | Pairs and lists | `verified` | 3 behavioural check(s) |
+| 5.7.1 | `get-list-metrics` | Pairs and lists | `verified` | 7 behavioural check(s) |
 | 5.7.2 | `list-tail` | Pairs and lists | `verified` | 2 behavioural check(s) |
 | 5.8.1 | `encycle!` | Pair mutation (optional) | `absent` | optional module |
 | 5.9.1 | `map` | Combiners | `verified` | 1 behavioural check(s) |
@@ -165,15 +166,15 @@ divergences before taking any row as a claim of conformance.
 | 6.1.4 | `$and?` | Booleans | `verified` | 4 behavioural check(s) |
 | 6.1.5 | `$or?` | Booleans | `verified` | 4 behavioural check(s) |
 | 6.2.1 | `combiner?` | Combiners | `verified` | 3 behavioural check(s) |
-| 6.3.1 | `length` | Pairs and lists | `verified` | 2 behavioural check(s) |
+| 6.3.1 | `length` | Pairs and lists | `verified` | 5 behavioural check(s) |
 | 6.3.2 | `list-ref` | Pairs and lists | `verified` | 2 behavioural check(s) |
 | 6.3.3 | `append` | Pairs and lists | `verified` | 4 behavioural check(s) |
 | 6.3.4 | `list-neighbors` | Pairs and lists | `verified` | 3 behavioural check(s) |
 | 6.3.5 | `filter` | Pairs and lists | `verified` | 2 behavioural check(s) |
 | 6.3.6 | `assoc` | Pairs and lists | `verified` | 2 behavioural check(s) |
 | 6.3.7 | `member?` | Pairs and lists | `verified` | 2 behavioural check(s) |
-| 6.3.8 | `finite-list?` | Pairs and lists | `verified` | 3 behavioural check(s) |
-| 6.3.9 | `countable-list?` | Pairs and lists | `verified` | 2 behavioural check(s) |
+| 6.3.8 | `finite-list?` | Pairs and lists | `verified` | 6 behavioural check(s) |
+| 6.3.9 | `countable-list?` | Pairs and lists | `verified` | 5 behavioural check(s) |
 | 6.3.10 | `reduce` | Pairs and lists | `verified` | 3 behavioural check(s) |
 | 6.4.1 | `append!` | Pair mutation (optional) | `absent` | optional module |
 | 6.4.2 | `copy-es` | Pair mutation (optional) | `verified` | optional module; 8 behavioural check(s) |

--- a/tools/clr-fault-cases.txt
+++ b/tools/clr-fault-cases.txt
@@ -180,3 +180,7 @@
 (let ((p (list 1 2))) (set-cdr! (cdr p) p) (equal? p p))
 (let ((p (list 1 2))) (set-cdr! (cdr p) p) (null? p))
 (copy-es-immutable (list (list 1) 2))
+(let ((p (list 1 2 3))) (set-cdr! (cdr (cdr p)) p) (get-list-metrics p))
+(let ((p (list 1 2 3))) (set-cdr! (cdr (cdr p)) p) (length p))
+(let ((p (list 1 2 3))) (set-cdr! (cdr (cdr p)) p) (finite-list? p))
+(let ((p (list 1))) (set-cdr! p p) (countable-list? p))


### PR DESCRIPTION
`get-list-metrics` (§5.7.1) now **measures** rather than assumes. It used to answer "acyclic, of this length" unconditionally — true only because no list could be cyclic.

```
(get-list-metrics ())            => (0 1 0 0)
(get-list-metrics 5)             => (0 0 0 0)   ; a = c = 0: not a pair
(get-list-metrics (cons 1 2))    => (1 0 1 0)   ; n = c = 0: not a list
(get-list-metrics p)             => (3 0 0 3)   ; all cycle
(get-list-metrics q)             => (5 0 2 3)   ; prefix 2, cycle 3; a + c = p
```

Found with Floyd: a second reference at half speed meets the first inside any cycle; one lap from the meeting point gives the cycle length; restarting one reference at the beginning and advancing both in step meets at the cycle's first pair.

## The shape derivations go through it

It's the primitive the derived library asks about shape, so it's the one place a cycle has to be measured rather than merely survived:

- **`length` (6.3.1) returns positive infinity for a cyclic list** — the report's answer, and a use for the exact infinities from 12.3.2.
- `finite-list?` (6.3.8) is `n = 1`; `countable-list?` (6.3.9) is `n = 1 or c > 0`.

All three previously walked the list, which a cyclic argument would not have survived. (`length` kept its `wrap`/`vau` spelling — `lambda` is defined further down the bootstrap than it is.)

## What still assumes finiteness, and why that's recorded

The derivations that walk *elements* — `list-tail`, `filter`, `reduce`, `append` and the rest — still assume a finite argument and diverge on a cyclic one, **exactly as the report's own derivations of them do**. That's now a 6.3 divergence rather than left implicit, together with the fact that the report's six-argument `reduce` (6.3.10) — the entry that would handle a cyclic list — is not implemented.

## Narrower than planned

Phase 3 had already taken the traversals that would otherwise hang, because `set-cdr!` builds a cycle and the list patterns and `equal?` couldn't wait for phase 4. That reordering is recorded in the ADR.

## Verification

- 353 tests pass (was 351); clean `--no-incremental` rebuild, 0 warnings
- every example runs (`yingyang.ikr` is the non-terminating puzzle by design)
- CLR fault sweep: zero process aborts across 186 cases, including cyclic ones
- `CompilerBenchmarks` unchanged (174.8 / 52.2 ns compiled, allocation identical)

Phase 5 is the last of the module: `encycle!` and `append!`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789642399&installation_model_id=427656&pr_number=59&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F59&signature=4b658e5dcaf714fa1cefbeff91e775f0521fd6d361ca0e780c0c0b87c036c9d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->