### PR TITLE
Close out ADR 0005: retire the stale claims (phase 6)

### DIFF
--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -1385,11 +1385,11 @@
             typePredicate (function Inert -> true | _ -> false) env cont args
 
         /// R-1RK 4.7.2. The result must have an immutable evaluation structure and be
-        /// initially equal? to the argument. Every IronKernel pair is already immutable,
-        /// and the report is explicit that in that case the result "may or may not be
-        /// eq? to object at the discretion of the implementation" -- so returning the
-        /// argument satisfies it exactly rather than approximately. Contrast copy-es
-        /// (6.4.2), which the report requires to return a *fresh* pair.
+        /// initially equal? to the argument. A mutable argument is therefore copied --
+        /// "if object is a mutable pair, then the result is not eq? to object" -- while
+        /// one that is already immutable may come back as itself, which the report
+        /// permits and `acquireImmutable` does. Contrast copy-es (6.4.2), which must
+        /// return a fresh pair either way.
         let copyEsImmutable env cont args =
             match args with
             | [object'] -> bounceContinue env cont (acquireImmutable object')
@@ -1428,12 +1428,6 @@
         let isCombiner env cont args =
             typePredicate (fun v -> isApplicativeValue v || isOperativeValue v) env cont args
 
-        /// R-1RK 5.7.1. Returns (p n a c): pairs, nils, acyclic prefix length and cycle
-        /// length of the improper list starting at the argument.
-        ///
-        /// IronKernel's pairs are immutable and it does not implement the optional Pair
-        /// mutation module, so no cyclic structure can be built and c is always zero
-        /// and a always equals p. The shape of the answer is still the report's.
         /// R-1RK 5.7.1. Returns `(p n a c)`: the number of pairs, the number of nils
         /// (0 or 1), the acyclic prefix length, and the cycle length of the improper
         /// list starting at the argument. `a + c = p`, and `n` and `c` are never both

--- a/IronKernel.Tests/ListTests.fs
+++ b/IronKernel.Tests/ListTests.fs
@@ -101,9 +101,8 @@ let ``type predicates cover the report's types`` () =
 
 [<Fact>]
 let ``get-list-metrics reports the shape of an improper list`` () =
-    // R-1RK 5.7.1 returns (pairs nils acyclic-prefix cycle-length). IronKernel's
-    // pairs are immutable and the optional Pair mutation module is unimplemented, so
-    // no cycle can be built: the cycle length is always zero.
+    // R-1RK 5.7.1 returns (pairs nils acyclic-prefix cycle-length). The cyclic cases
+    // live in PairMutationTests, beside the mutation that can build one.
     [
         "(equal? (get-list-metrics (list 1 2 3)) (list 3 1 3 0))", Bool true
         "(equal? (get-list-metrics ()) (list 0 1 0 0))", Bool true

--- a/IronKernel.Tests/PairMutationTests.fs
+++ b/IronKernel.Tests/PairMutationTests.fs
@@ -44,9 +44,8 @@ let ``copy-es copies the evaluation structure and leaves non-pairs alone`` () =
 
 [<Fact>]
 let ``copy-es-immutable returns something equal? with an immutable structure`` () =
-    // R-1RK 4.7.2. Every IronKernel pair is already immutable, and the report allows
-    // the result to be eq? to the argument in exactly that case, so returning the
-    // argument satisfies the entry rather than approximating it.
+    // R-1RK 4.7.2. A mutable argument is copied, and one that is already immutable may
+    // come back as itself, which the report permits and this does.
     [
         "(=? (copy-es-immutable 5) 5)", Bool true
         "(define nested (list (list 1 2) 3))", Inert

--- a/IronKernel/kernel.ikr
+++ b/IronKernel/kernel.ikr
@@ -522,9 +522,9 @@
                       (if (equal? object (car rest)) #t (aux (cdr rest)))))))
       (aux ls))))
 
-; --- R-1RK pair mutation features that do not mutate (6.4) -------------------
-; The Pair mutation module also has set-car!, set-cdr!, encycle! and append!,
-; which IronKernel's immutable pairs cannot support; these four need no mutation.
+; --- R-1RK module Pair mutation, the entries derived here (6.4) --------------
+; set-car! and set-cdr! are primitives; encycle! and append! are further down,
+; after the shape predicates they depend on.
 
 ; 6.4.3 / 6.4.4: assq and memq? are assoc and member? with eq? in place of
 ; equal?. IronKernel binds eq? to the same structural comparison as eqv?
@@ -548,14 +548,6 @@
 (define copy-es
   (lambda (x)
     (if (pair? x) (cons (copy-es (car x)) (copy-es (cdr x))) x)))
-
-; 6.3.8 / 6.3.9: with no cycles possible, a countable list is a finite list, and both
-; reduce to "the improper list starting here is terminated by nil".
-(define $list-shaped?
-  (lambda (xs)
-    (letrec ((aux (lambda (ys)
-                    (if (null? ys) #t (if (pair? ys) (aux (cdr ys)) #f)))))
-      (aux xs))))
 
 (define $every?
   (lambda (ok? xs)
@@ -632,8 +624,8 @@
         (aux (car lists) (cdr lists))))))
 
 ; 6.3.10: (reduce list binary identity). The report also gives a six-argument form
-; for cyclic lists; with no cycles to describe, the three-argument form is the whole
-; of it here.
+; that handles a cyclic list; only the three-argument form is implemented, so this
+; one walks its argument and diverges on a cycle. Recorded as a 6.3 divergence.
 (define reduce
   (lambda (ls binary identity)
     (letrec ((aux (lambda (rest acc)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ reals take the representation 12.2 sanctions directly — non-robust, bounded by
 infinities — and `with-strict-arithmetic` decides whether a result with no primary
 value signals or is returned.
 
+Pairs are mutable cons cells, so module **Pair mutation** (4.7, 5.8, 6.4) is
+complete: `set-car!`, `set-cdr!`, `encycle!` and `append!` all work, `eq?` is
+object identity, and the traversals that a cycle would otherwise trap — `equal?`,
+the reader's list patterns, `get-list-metrics`, `length` — measure a cycle instead
+of walking into one. `(length p)` of a cyclic list is `#e+infinity`. Mutability
+follows provenance: the reader produces immutable pairs, `cons` and `list`
+mutable ones, so a captured algorithm cannot be rewritten under the combiner that
+captured it. See [`ADR 0005`](docs/adr/0005-mutable-pairs.md).
+
 Chapter 7's continuations are complete, including the entry/exit guards: an
 abnormal pass selects interceptors by walking the source and destination
 continuation chains, and `dynamic-wind` is derivable from them exactly as the

--- a/docs/adr/0005-mutable-pairs.md
+++ b/docs/adr/0005-mutable-pairs.md
@@ -1,6 +1,6 @@
 # ADR 0005: Mutable pairs
 
-Status: Accepted — phases 0-5 done, phase 6 outstanding
+Status: Implemented
 
 ## Decision
 
@@ -320,9 +320,23 @@ The test that guarded the 4.7 divergence's "these are absent" claim has now
 asserted the opposite of what it started as, having forced a deliberate update in
 each of phases 3 and 5. That was the point of writing it.
 
-**Phase 6 — re-validate and record.** Benchmarks against the baseline, the CLR
-fault sweep extended with cyclic and mutation cases, the conformance matrix
-regenerated, and the 4.7 and 4.2.1 divergences removed.
+**Phase 6 — re-validate and record.** *Done.* Most of it happened in each phase
+rather than at the end: benchmarks were re-measured every time, the fault sweep
+grew mutation and cyclic cases as they became reachable, the matrix was
+regenerated, and the divergences were updated as they stopped being true. What was
+left for a final pass was finding the claims that had quietly gone stale — seven
+of them, in `kernel.ikr`, `Runtime.fs` and the tests, all asserting that pairs are
+immutable or that cycles cannot arise. One was a duplicated doc comment left
+sitting above the corrected one on `get-list-metrics`, saying the opposite of the
+code beneath it. `$list-shaped?` was dead once the shape predicates moved to the
+metrics, and is gone.
+
+The 4.2.1 divergence is retired, and 4.7 now records one condition rather than a
+missing half: 6.4.1 makes it an error for two arguments of `append!` to share a
+last pair, which is a condition on the caller and is not checked. A 6.3 divergence
+was added along the way, recording that the derivations that walk a list's
+elements diverge on a cyclic argument exactly as the report's own derivations of
+them do.
 
 ## Baseline to hold
 
@@ -345,19 +359,34 @@ will show it first.
 
 ## Consequences
 
-The change retires two divergences (4.7 and 4.2.1), completes an optional module,
-and makes two required entries — `equal?` and `get-list-metrics` — honest about
-cycles rather than correct only because cycles cannot occur.
+The change retired two divergences (4.2.1 and the missing half of 4.7), completed
+an optional module, and made `equal?` and `get-list-metrics` honest about cycles
+rather than correct only because cycles could not occur. It also found five bugs
+that had nothing to do with pairs and everything to do with the assumption the
+representation encouraged: the empty list had two spellings and only one was
+recognised, and `eq?`/`equal?` were not reflexive on environments, vectors,
+combiners or continuations. All were in required entries, and all were found by
+looking hard at a traversal rather than by a test failing.
 
-It also removes a simplifying assumption the codebase currently benefits from
-everywhere: that a value's structure is finite and cannot change while being
-walked. Every traversal added after this lands has to be written with that in
-mind, and the analyzer and compiler are protected only by phase 0's copying, not
-by the type system.
+It removes a simplifying assumption the codebase benefited from everywhere: that a
+value's structure is finite and cannot change while being walked. Every traversal
+added from here has to be written with that in mind. The rule the phases converged
+on is worth keeping: **anything asking about a cell matches `Pair` or `Nil`
+directly; only code that genuinely wants the elements uses the list pattern, and
+then once.** Ignoring it is what made the first cut of phase 1 several times
+slower.
 
-The phases are ordered so that each is independently reviewable and the suite
-stays green throughout. Phases 0 and 1 change no behaviour at all; phase 2 changes
-behaviour that is currently a recorded divergence; phases 3 to 5 add the module.
-If the work stops after any phase, the result is a consistent system rather than a
-half-migration — which is the main reason for doing it in this order rather than
-starting with the entries the module is named for.
+The final cost, against the baseline above:
+
+| Method | before | after | |
+|---|---:|---:|---|
+| ColdCompile | 105.4 ns / 592 B | ~150 ns / 808 B | +40% |
+| Interpreted | 371.1 ns / 1872 B | ~405 ns / 2024 B | +9% |
+| CompiledGeneric | 173.6 ns / 808 B | ~176 ns / 808 B | +1%, allocation identical |
+| CompiledFolded | 51.9 ns / 304 B | ~52 ns / 304 B | +1%, allocation identical |
+
+The steady-state compiled paths are where they were. The residue is paid turning a
+cons chain into an F# list for code that wants the elements — compiling a form, and
+evaluating one interpreted — and is the obvious lever if the interpreted path ever
+needs to be faster: rewrite the analyzer and evaluator against cells directly
+rather than through the list patterns.


### PR DESCRIPTION
Most of phase 6 happened *in* each phase rather than at the end — benchmarks re-measured every time, the fault sweep grown as mutation and cycles became reachable, the matrix regenerated, divergences updated as they stopped being true.

What was left for a final pass was finding the claims that had quietly gone stale. **There were seven.**

## The stale claims

| Where | Said |
|---|---|
| `kernel.ikr` | the mutating entries "IronKernel's immutable pairs cannot support" |
| `kernel.ikr` | "with no cycles possible, a countable list is a finite list" |
| `kernel.ikr` | `reduce` has no cyclic case "to describe" |
| `Runtime.fs` | `copy-es-immutable` returns its argument because every pair is already immutable |
| `Runtime.fs` | `get-list-metrics` — "no cyclic structure can be built and c is always zero" |
| `ListTests.fs` | the cycle length is always zero |
| `PairMutationTests.fs` | every IronKernel pair is already immutable |

Each was true when written; none was true any more.

**One was worse than stale.** The old `get-list-metrics` doc comment survived *above* the corrected one, so the file carried two doc comments in a row — the first saying the cycle length is always zero, the second explaining how the cycle length is computed. Exactly the kind of thing that outlives the code it described.

`$list-shaped?` became dead when the shape predicates moved to the metrics, and is removed.

## Recorded

The README now says what the module got: mutable cons cells, `eq?` as object identity, traversals that measure a cycle rather than walk into one, and `(length p)` of a cyclic list as `#e+infinity`.

## Final cost, against the pre-phase-1 baseline

| Method | before | after | |
|---|---:|---:|---|
| CompiledGeneric | 173.6 ns / 808 B | 178.6 ns / 808 B | +3%, allocation identical |
| CompiledFolded | 51.9 ns / 304 B | 53.7 ns / 304 B | +3%, allocation identical |
| ColdCompile | 105.4 ns / 592 B | 146.0 ns / 808 B | +39% |
| Interpreted | 371.1 ns / 1872 B | 406.1 ns / 2024 B | +9% |

The steady-state compiled paths are where they were. The residue is the price of turning a cons chain into an F# list for code that wants the elements — compiling a form, evaluating one interpreted — and is the obvious lever if the interpreted path ever needs to be faster.

## Verification

- 357 tests pass; clean `--no-incremental` rebuild, 0 warnings
- every example runs (`yingyang.ikr` is the non-terminating puzzle by design)
- CLR fault sweep: zero process aborts across 193 cases
- conformance matrix unchanged by this commit

**ADR 0005 is Implemented.**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789644213&installation_model_id=427656&pr_number=61&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F61&signature=b7d888edc3181deaf1d011eb3d2756c4718565c6c2cf0efc7e81822acdbe4d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->