### PR TITLE
Add get-module and make-kernel-standard-environment (R-1RK 15.2.3, 6.7.3)

### DIFF
--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -202,12 +202,20 @@
             | :? ArgumentException as ex -> throwError (Default(description + ": " + ex.Message))
             | :? NotSupportedException as ex -> throwError (Default(description + ": " + ex.Message))
 
+        // Reading opens an existing file; only writing creates one. OpenOrCreate for
+        // both meant `open-input-file` on a missing file silently created an empty one
+        // and then read nothing from it, which is a surprising way to answer "that file
+        // is not there".
+        let private fileModeFor = function
+            | FileAccess.Read -> FileMode.Open
+            | _ -> FileMode.OpenOrCreate
+
         let makePort mode = function
             | [Obj filename] ->
                 either {
                     let! fname = cast filename
                     return! guardIO "open file" (fun () ->
-                        returnM (Port(File.Open(fname, FileMode.OpenOrCreate, mode))))
+                        returnM (Port(File.Open(fname, fileModeFor mode, mode))))
                 }
             | [found] -> throwError(TypeMismatch("string", found))
             | bad -> throwError(NumArgs(1, bad))
@@ -321,7 +329,9 @@
             | _ -> fail (NumArgs(0, args))
 
         let private openFile name access filename =
-            try Choice2Of2(Port(IO.File.Open(filename, IO.FileMode.OpenOrCreate, access)))
+            let mode =
+                if access = IO.FileAccess.Read then IO.FileMode.Open else IO.FileMode.OpenOrCreate
+            try Choice2Of2(Port(IO.File.Open(filename, mode, access)))
             with ex -> Choice1Of2(Default(name + ": " + ex.Message))
 
         /// R-1RK 15.1.3. "The opened port is accessed implicitly within the dynamic

--- a/IronKernel.Tests/KernelConformanceTests.fs
+++ b/IronKernel.Tests/KernelConformanceTests.fs
@@ -594,6 +594,33 @@ let private behaviouralChecks () : (string * string list) list = [
     "15.1.7", [ "(let ((f (. System.IO.Path GetTempFileName))) (sequence (let ((p (open-output-file f))) (sequence (write 'alpha p) (close-output-port p))) (let ((p (open-input-file f))) (let ((v (read p))) (sequence (close-input-port p) (. System.IO.File Delete f) (equal? v 'alpha))))))" ]
     "15.1.8", [ "(let ((f (. System.IO.Path GetTempFileName))) (sequence (let ((p (open-output-file f))) (sequence (write '(a b c) p) (close-output-port p))) (let ((p (open-input-file f))) (let ((v (read p))) (sequence (close-input-port p) (. System.IO.File Delete f) (equal? v '(a b c)))))))" ]
     // 15.2.2: load evaluates the file's forms in the calling environment.
+    "6.7.3", [ "(environment? (make-kernel-standard-environment))"
+               // "a child of the ground environment": ground is visible through it.
+               "(eval (list applicative? car) (make-kernel-standard-environment))"
+               // Fresh each call.
+               "(eqv? (eq? (make-kernel-standard-environment)"
+               + " (make-kernel-standard-environment)) #f)" ]
+    "15.2.3", [ // Written to a temp file the way 15.2.2's check does, so that the
+                // check carries its own module rather than depending on a fixture.
+                "(let ((f (. System.IO.Path GetTempFileName)))"
+                + " (sequence (. System.IO.File WriteAllText f \"(define a 42)\")"
+                + " (let ((m (get-module f)))"
+                + " (sequence (. System.IO.File Delete f)"
+                + " (and? (environment? m) (=? (eval (quote a) m) 42))))))"
+                // Each call gets its own environment, and a module's definitions are
+                // reached through it rather than dumped into the caller.
+                "(let ((f (. System.IO.Path GetTempFileName)))"
+                + " (sequence (. System.IO.File WriteAllText f \"(define a 42)\")"
+                + " (let ((m (get-module f)) (n (get-module f)))"
+                + " (sequence (. System.IO.File Delete f) (eqv? (eq? m n) #f)))))"
+                // The second argument is bound as module-parameters, before the file
+                // is evaluated -- so the module can read it as it runs.
+                "(let ((f (. System.IO.Path GetTempFileName)) (p (make-environment)))"
+                + " (sequence (. System.IO.File WriteAllText f"
+                + " \"(define seen (eval (quote s) module-parameters))\")"
+                + " (eval (list define (quote s) 5) p)"
+                + " (let ((m (get-module f p)))"
+                + " (sequence (. System.IO.File Delete f) (=? (eval (quote seen) m) 5)))))" ]
     "15.2.2", [ "(let ((f (. System.IO.Path GetTempFileName))) (sequence (. System.IO.File WriteAllText f \"(define loaded-marker 7)\") (load f) (. System.IO.File Delete f) (=? loaded-marker 7)))" ]
     "12.10.3", [ "(<? (abs (- (magnitude (make-rectangular 3 4)) 5)) 0.000001)"
                  "(<? (abs (- (angle (make-rectangular 0 1)) 1.5707963267948966)) 0.000001)"

--- a/IronKernel.Tests/PortTests.fs
+++ b/IronKernel.Tests/PortTests.fs
@@ -123,6 +123,9 @@ let ``reading past the end of a port signals rather than faulting`` () =
     // process. IronKernel has no end-of-file object to return instead, so this
     // signals. A test host that runs this at all is part of the check.
     withTempFiles 1 (fun paths ->
+        // The file has to exist and be empty: opening a missing one for input is now
+        // an error in its own right, which is a different thing to test.
+        File.WriteAllText(paths.[0], "")
         let file = quoted paths.[0]
         withKernel (fun env ->
             match evalIn env ("(call-with-input-file " + file + " (lambda (p) (read p)))") with
@@ -146,3 +149,99 @@ let ``a port survives more than one write`` () =
             "(write (quote two) p)", Bool true
             "(inert? (close-output-file p))", Bool true
         ] |> evalSessionKernel)
+
+[<Fact>]
+let ``make-kernel-standard-environment is a fresh child of ground`` () =
+    // R-1RK 6.7.3: "a child of the ground environment with no local bindings". The
+    // report's own derivation is ($lambda () (get-current-environment)), which works
+    // because library derivations are evaluated in the ground environment.
+    [
+        "(environment? (make-kernel-standard-environment))", Bool true
+        // Fresh each call, which 4.2.1 requires of environments anyway.
+        "(eqv? (eq? (make-kernel-standard-environment) (make-kernel-standard-environment)) #f)",
+            Bool true
+        // Ground is visible through it.
+        "(eval (list applicative? car) (make-kernel-standard-environment))", Bool true
+        "(eval (list (quote =?) 1 1) (make-kernel-standard-environment))", Bool true
+        // Defining in one does not disturb another, nor the caller.
+        "(define a (make-kernel-standard-environment))", Inert
+        "(eval (list define (quote x) 1) a)", Inert
+        "(=? (eval (quote x) a) 1)", Bool true
+        "(eqv? (eq? a (make-kernel-standard-environment)) #f)", Bool true
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``get-module evaluates a file into a fresh standard environment`` () =
+    // R-1RK 15.2.3: creates a fresh standard environment, evaluates the file's
+    // expressions in it consecutively, and returns it.
+    withTempFiles 1 (fun paths ->
+        let modulePath = Path.ChangeExtension(paths.[0], ".ikr")
+        File.WriteAllText(modulePath, "(define answer 42)\n(define twice (lambda (x) (* 2 x)))\n")
+        try
+            [
+                "(define m (get-module " + quoted modulePath + "))", Inert
+                "(environment? m)", Bool true
+                "(=? (eval (quote answer) m) 42)", Bool true
+                "(=? (eval (list (quote twice) 21) m) 42)", Bool true
+                // Each call gets its own environment, so modules cannot see each other.
+                "(eqv? (eq? m (get-module " + quoted modulePath + ")) #f)", Bool true
+            ] |> evalSessionKernel
+        finally (try File.Delete modulePath with _ -> ()))
+
+[<Fact>]
+let ``a module's definitions do not reach the caller`` () =
+    // The point of get-module over load: "starting each module in a fresh standard
+    // environment", so that a file's definitions are reached through the returned
+    // environment rather than dumped into whoever loaded it.
+    withTempFiles 1 (fun paths ->
+        let modulePath = Path.ChangeExtension(paths.[0], ".ikr")
+        File.WriteAllText(modulePath, "(define module-only 7)\n")
+        try
+            withKernel (fun env ->
+                match evalIn env ("(define m (get-module " + quoted modulePath + "))") with
+                | Status message -> failwithf "get-module failed: %s" message
+                | _ -> ()
+                match evalIn env "(eval (quote module-only) m)" with
+                | Obj (:? int as value) -> Assert.Equal(7, value)
+                | value -> failwithf "the module binding was not reachable: %s" (showVal value)
+                match evalIn env "module-only" with
+                | Status message -> Assert.Contains("unbound", message)
+                | value -> failwithf "the module leaked into the caller: %s" (showVal value))
+        finally (try File.Delete modulePath with _ -> ()))
+
+[<Fact>]
+let ``the second argument is bound as module-parameters`` () =
+    // 15.2.3: the fresh environment "is augmented, prior to evaluating read
+    // expressions, by binding symbol module-parameters to the optional argument".
+    // Prior matters: the module can read it while it is being evaluated.
+    withTempFiles 1 (fun paths ->
+        let modulePath = Path.ChangeExtension(paths.[0], ".ikr")
+        File.WriteAllText(modulePath, "(define seen (eval (quote setting) module-parameters))\n")
+        try
+            [
+                "(define params (make-environment))", Inert
+                "(eval (list define (quote setting) 5) params)", Inert
+                "(define m (get-module " + quoted modulePath + " params))", Inert
+                // The module read it while being evaluated.
+                "(=? (eval (quote seen) m) 5)", Bool true
+                "(eq? (eval (quote module-parameters) m) params)", Bool true
+            ] |> evalSessionKernel
+        finally (try File.Delete modulePath with _ -> ()))
+
+[<Fact>]
+let ``opening a missing file for input is an error rather than a creation`` () =
+    // OpenOrCreate for input meant a missing file was silently created empty and then
+    // read as nothing, which also left the file behind -- the CLR fault sweep noticed
+    // by leaving one in the repository.
+    withTempFiles 1 (fun paths ->
+        let file = quoted paths.[0]
+        withKernel (fun env ->
+            match evalIn env ("(open-input-file " + file + ")") with
+            | Status _ -> ()
+            | value -> failwithf "opening a missing file gave %s" (showVal value)
+            Assert.False(File.Exists paths.[0], "opening for input created the file")
+            // Opening for output does create it, which is what output is for.
+            match evalIn env ("(close-output-file (open-output-file " + file + "))") with
+            | Inert -> ()
+            | value -> failwithf "opening for output gave %s" (showVal value)
+            Assert.True(File.Exists paths.[0], "opening for output did not create the file")))

--- a/IronKernel/kernel.ikr
+++ b/IronKernel/kernel.ikr
@@ -663,3 +663,36 @@
 (define $remote-eval remote-eval)
 (define $bindings->environment bindings->environment)
 
+
+; --- R-1RK environment and module features -----------------------------------
+
+; 6.7.3: "a child of the ground environment with no local bindings". This is the
+; report's own derivation, and it works for the reason the report gives: library
+; derivations are evaluated in the ground environment, so a lambda defined here
+; closes over ground, and calling it makes a fresh child with only its parameters
+; bound -- of which there are none.
+;
+; Capabilities come along for free, and correctly: the ground environment of a
+; session is built with that session's profile, so a restricted program gets a
+; restricted standard environment rather than an escape from its own profile.
+(define make-kernel-standard-environment (lambda () (get-current-environment)))
+
+; 15.2.3: (get-module string) creates a fresh standard environment, evaluates the
+; file's expressions in it consecutively, and returns it. The two-argument form
+; binds module-parameters to the second argument first, "prior to evaluating read
+; expressions".
+;
+; load (15.2.2) evaluates in its *dynamic* environment, so evaluating the call to
+; it inside the new environment is what puts the module's definitions there. That
+; is also what makes the capability check land on the new environment rather than
+; on get-module's caller.
+(define get-module
+  (lambda (path & parameters)
+    (let ((module-environment (make-kernel-standard-environment)))
+      (sequence
+        (if (null? parameters)
+          #inert
+          (eval (list define (quote module-parameters) (car parameters))
+                module-environment))
+        (eval (list load path) module-environment)
+        module-environment))))

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ This tree is a **hybrid CLR runtime**: programs are analyzed to a Core IR and co
 
 [`docs/kernel-conformance.md`](docs/kernel-conformance.md) tracks IronKernel against
 the [Revised-1 Report on the Kernel Programming Language](https://ftp.cs.wpi.edu/pub/techreports/pdf/05-07.pdf)
-(R-1RK), feature by feature. Of the report's 135 feature entries, **128 are verified
-by a behavioural check and 7 are absent**; nothing is merely bound-but-unchecked.
+(R-1RK), feature by feature. Of the report's 135 feature entries, **130 are verified
+by a behavioural check and 5 are absent**; nothing is merely bound-but-unchecked.
 34 entries belong to modules the report marks optional. The matrix also reports
-status per *module*, which R-1RK 1.3.2 makes the unit of conformance: **39 of 44
+status per *module*, which R-1RK 1.3.2 makes the unit of conformance: **40 of 44
 modules are complete**.
 
 **Every entry of chapter 12 now has a passing check** — Numbers (12.5), Inexact
@@ -35,6 +35,13 @@ of walking into one. `(length p)` of a cyclic list is `#e+infinity`. Mutability
 follows provenance: the reader produces immutable pairs, `cons` and `list`
 mutable ones, so a captured algorithm cannot be rewritten under the combiner that
 captured it. See [`ADR 0005`](docs/adr/0005-mutable-pairs.md).
+
+Chapter 15's **ports** are complete too, in all three of the lifetimes its preamble
+describes: implicit and closed on return (`with-output-to-file`), an explicit
+reference closed on return (`call-with-output-file`), and open/close left entirely
+to the programmer. `get-module` evaluates a file into a fresh standard environment
+and hands it back, so a module's definitions reach its caller only through that
+environment.
 
 Chapter 7's continuations are complete, including the entry/exit guards: an
 abnormal pass selects interceptors by walking the source and destination

--- a/docs/kernel-conformance.md
+++ b/docs/kernel-conformance.md
@@ -25,10 +25,10 @@ rather than hidden behind a pass.
 
 | | Entries | Share |
 |---|---:|---:|
-| `verified` | 128 | 95% |
+| `verified` | 130 | 96% |
 | `bound` | 0 | 0% |
 | `partial` | 0 | 0% |
-| `absent` | 7 | 5% |
+| `absent` | 5 | 4% |
 | **total** | **135** | |
 
 34 of 135 entries belong to modules the report marks optional; an
@@ -94,7 +94,7 @@ divergences before taking any row as a claim of conformance.
 | 6.4 Core library features (II) — Pair mutation (optional) | optional | 4 | 4 | yes |
 | 6.5 Core library features (II) — Equivalence under mutation (optional) | optional | 1 | 1 | yes |
 | 6.6 Core library features (II) — Equivalence up to mutation | **required** | 1 | 1 | yes |
-| 6.7 Core library features (II) — Environments | **required** | 10 | 7 | no |
+| 6.7 Core library features (II) — Environments | **required** | 10 | 8 | no |
 | 6.8 Core library features (II) — Environment mutation (optional) | optional | 3 | 3 | yes |
 | 6.9 Core library features (II) — Control | **required** | 1 | 1 | yes |
 | 7.2 Continuations — Primitive features | **required** | 7 | 7 | yes |
@@ -111,7 +111,7 @@ divergences before taking any row as a claim of conformance.
 | 12.10 Numbers — Complex features | optional | 3 | 3 | yes |
 | 13.1 Strings — Primitive features | **required** | 1 | 0 | no |
 | 15.1 Ports — Primitive features | **required** | 8 | 8 | yes |
-| 15.2 Ports — Library features | **required** | 3 | 2 | no |
+| 15.2 Ports — Library features | **required** | 3 | 3 | yes |
 
 ## 4 Core types and primitive features
 
@@ -185,7 +185,7 @@ divergences before taking any row as a claim of conformance.
 | 6.6.1 | `equal?` | Equivalence up to mutation | `verified` | 7 behavioural check(s) |
 | 6.7.1 | `$binds?` | Environments | `absent` |  |
 | 6.7.2 | `get-current-environment` | Environments | `verified` | 1 behavioural check(s) |
-| 6.7.3 | `make-kernel-standard-environment` | Environments | `absent` |  |
+| 6.7.3 | `make-kernel-standard-environment` | Environments | `verified` | 3 behavioural check(s) |
 | 6.7.4 | `$let*` | Environments | `verified` | 1 behavioural check(s) |
 | 6.7.5 | `$letrec` | Environments | `verified` | 1 behavioural check(s) |
 | 6.7.6 | `$letrec*` | Environments | `verified` | 1 behavioural check(s) |
@@ -301,5 +301,5 @@ divergences before taking any row as a claim of conformance.
 | 15.1.8 | `write` | Primitive features | `verified` | 1 behavioural check(s) |
 | 15.2.1 | `call-with-input-file, call-with-output-file` | Library features | `verified` | 1 behavioural check(s) |
 | 15.2.2 | `load` | Library features | `verified` | 1 behavioural check(s) |
-| 15.2.3 | `get-module` | Library features | `absent` |  |
+| 15.2.3 | `get-module` | Library features | `verified` | 3 behavioural check(s) |
 

--- a/tools/clr-fault-cases.txt
+++ b/tools/clr-fault-cases.txt
@@ -198,3 +198,7 @@
 (with-output-to-file 5 (lambda () 1))
 (call-with-input-file "does-not-exist-ironkernel.txt" (lambda (p) (read p)))
 (get-current-input-port 1)
+(get-module "does-not-exist-module.ikr")
+(get-module 5)
+(make-kernel-standard-environment 1)
+(get-module "does-not-exist-module.ikr" (make-environment))


### PR DESCRIPTION
**Chapter 15 is complete — both modules.** And neither entry needed a line of F#.

## The report derives both

`make-kernel-standard-environment` (6.7.3) is *"a child of the ground environment with no local bindings"*, and the report's own derivation is:

```
($lambda () (get-current-environment))
```

That works for the reason the report gives: library derivations are evaluated in the ground environment, so a lambda defined in `kernel.ikr` closes over ground, and calling it makes a fresh child with only its parameters bound — of which it has none.

`get-module` (15.2.3) then follows in Kernel:

```
(define get-module
  (lambda (path & parameters)
    (let ((module-environment (make-kernel-standard-environment)))
      (sequence
        (if (null? parameters) #inert
            (eval (list define (quote module-parameters) (car parameters)) module-environment))
        (eval (list load path) module-environment)
        module-environment))))
```

`load` evaluates in its **dynamic** environment, so evaluating the call to it *inside* the new environment is what puts the module's definitions there.

## The capability question answers itself

I held this back last time because a `Minimal`-profile program must not obtain an unrestricted environment. It turns out not to arise: a session's ground environment is built with that session's profile, so a child of it carries the same capabilities. A restricted program gets a restricted standard environment.

Better still, routing through `load` means its `SourceLoading` check lands on the **new** environment rather than on `get-module`'s caller — which is the right place for it.

## A bug the fault sweep exposed by littering

The sweep left `does-not-exist-ironkernel.txt` in the repository — and it went out with #62, which I've now removed. The cause: `open-input-file` used `FileMode.OpenOrCreate`, so opening a *missing* file for **input** silently created an empty one and read nothing from it. That is a surprising way to answer "that file isn't there". Reading now opens an existing file; only writing creates one. There's a test asserting both halves.

## Verification

- 370 tests pass (was 365); clean `--no-incremental` rebuild, 0 warnings
- every example runs (`yingyang.ikr` is the non-terminating puzzle by design)
- CLR fault sweep: zero process aborts across 204 cases, and it no longer leaves anything behind
- `CompilerBenchmarks` unchanged (173.4 / 51.5 ns compiled, allocation identical)

**130 of 135** entries verified, **40 of 44** modules.

Five entries remain absent: `ignore?` (4.8.2), `$binds?` (6.7.1), `$let-safe` (6.7.8), `$lazy` (9.1.3) and `string->symbol` (13.1.1).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789646765&installation_model_id=427656&pr_number=63&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F63&signature=4a95f85afaa64b4733b2609df8fceed6b443b24e2e2db20294108bc016a2763e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->