### PR TITLE
Route error signalling through the guard machinery (ADR 0006 phase 2)

### DIFF
--- a/IronKernel.Runtime/Eval.fs
+++ b/IronKernel.Runtime/Eval.fs
@@ -26,23 +26,39 @@ module Eval =
     /// phase 1 this is reserved for the places that have no continuation to signal
     /// from -- where the continuation *argument* is itself malformed, and the internal
     /// error for a metacontinuation in the wrong position. Everywhere else uses
-    /// `signal` below, which will become 7.2.7's abnormal pass.
+    /// `signal` below, which is 7.2.7's abnormal pass.
     let inline fail (e: LispError) : Step = Done (throwError e)
 
-    /// R-1RK 7.2.7 makes signalling an error an abnormal pass to a continuation in the
-    /// extent of error-continuation. This is the seam that will become one: today it
-    /// ignores its continuation and unwinds directly, exactly as `fail` does, so
-    /// nothing changes yet (ADR 0006 phase 1).
+    /// R-1RK 7.2.7: "the signaling action consists of an abnormal pass to some
+    /// continuation in the dynamic extent of error-continuation". Since ADR 0006
+    /// phase 2 this does exactly that, through the 7.2.5 guard machinery, so an exit
+    /// guard selecting on error-continuation is selected when the guarded extent
+    /// signals.
+    ///
+    /// With no guards installed the pass selects nothing and reaches a destination
+    /// that reports the original error, which is what `fail` does directly -- so this
+    /// is invisible to programs that do not use guards.
     ///
     /// The continuation passed is the one the failing operation would have returned to,
     /// which means the *innermost* one in scope -- inside a CPS callback that is the
-    /// callback's own, not the enclosing primitive's. Getting that right is the whole
-    /// point of migrating the call sites before the behaviour changes, because phase 2
-    /// is what makes a wrong one visible.
+    /// callback's own, not the enclosing primitive's. Getting that right was the whole
+    /// point of migrating the call sites in phase 1 before the behaviour changed here.
     ///
-    /// `fail` remains for the paths that genuinely have no continuation: bootstrap, and
-    /// host entry points.
-    let inline signal (_cont: LispVal) (e: LispError) : Step = Done (throwError e)
+    /// The pass itself lives in Runtime, which owns the guard machinery and compiles
+    /// after this module, so it is installed through the hook below -- the same idiom
+    /// as configureSourceServices and configureBodyCompiler. Unconfigured, in a host
+    /// that builds no primitive bindings, signalling unwinds directly as before.
+    ///
+    /// A delegate rather than a curried function, and not inline: all three shapes
+    /// were measured and this one is the fastest (see the ADR).
+    let mutable private errorSignal : System.Func<LispVal, LispError, Step> =
+        System.Func<_, _, _>(fun _ e -> Done (throwError e))
+
+    let configureErrorSignal (handler: LispVal -> LispError -> Step) =
+        errorSignal <- System.Func<_, _, _>(fun cont e -> handler cont e)
+
+    let signal (cont: LispVal) (e: LispError) : Step = errorSignal.Invoke(cont, e)
+
     let inline ofResult (r: ThrowsError<LispVal>) : Step = Done r
 
     let rec runAsync (step: Step) : Task<ThrowsError<LispVal>> =

--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -896,6 +896,54 @@
                         | _ -> signal resultCont (TypeMismatch("applicative", interceptor))
             chain interceptions value
 
+        /// R-1RK 7.2.7: signalling is an abnormal pass "to some continuation in the
+        /// dynamic extent of error-continuation". This builds that continuation, one
+        /// per signal so the extent test is exact.
+        ///
+        /// It carries the original error rather than reconstructing one from the value
+        /// that arrives, so the diagnostic an unintercepted error reports is the same
+        /// one it reported before the pass existed. An interceptor that
+        /// returns normally therefore does not cancel the error; to handle one it must
+        /// divert to its second argument, which is the escape 7.2.5 gives it and what
+        /// the report's own $binds? derivation does.
+        let private errorDestination (error: LispError) =
+            match errorContinuation () with
+            | Continuation(errorRecord, metaCont, continuationType) ->
+                Continuation(
+                    { closure = Nil
+                      currentCont =
+                        Some(NativeCode { cont = (fun _ _ _ _ -> Done(throwError error)); args = None })
+                      nextCont = Some(Continuation(errorRecord, None, Full))
+                      args = None },
+                    metaCont, continuationType)
+            | other -> other
+
+        /// Whether the signalling point is already inside error-continuation's extent.
+        /// An error raised while handling an error would otherwise start a fresh pass
+        /// from inside the first one's interception chain, and a guard that always
+        /// signals would never finish. Once inside the error extent, signalling just
+        /// unwinds -- which is also what it means there.
+        let private alreadyHandlingError source =
+            match errorContinuation () with
+            | Continuation(errorRecord, _, _) ->
+                withinExtent (continuationAncestry source) errorRecord
+            | _ -> false
+
+        /// The signalling action of 7.2.7. With no guards installed the pass selects
+        /// nothing, reaches the destination above, and returns exactly what the direct
+        /// unwind returned -- which is what keeps this invisible to programs that do
+        /// not use guards.
+        let private signalAbnormally (cont: LispVal) (error: LispError) : Step =
+            match cont with
+            | Continuation(record, _, _) when not (alreadyHandlingError cont) ->
+                match record.closure with
+                | Environment _ as env ->
+                    passAbnormally env cont (errorDestination error) (Obj(box error))
+                // A continuation with no environment to run interceptors in cannot
+                // carry a pass; unwind directly rather than invent one.
+                | _ -> Done(throwError error)
+            | _ -> Done(throwError error)
+
         let continuationToApplicative env cont args =
             match args with
             | [Continuation _ as target] -> bounceContinue env cont (abnormalPass target)
@@ -2469,6 +2517,10 @@
 
         /// Fresh environment containing only primitive operators (safe for isolated tests).
         let makePrimitiveBindingsForProfile profile =
+            // Installed here rather than at module initialisation, because every path
+            // that builds an environment comes through this one and a module-level
+            // binding would depend on when the initialiser happened to run.
+            configureErrorSignal signalAbnormally
             let capabilities = forProfile profile
             let operativeIdentity = function
                 | "if" -> Some PrimitiveIf

--- a/IronKernel.Tests/ErrorPassTests.fs
+++ b/IronKernel.Tests/ErrorPassTests.fs
@@ -1,0 +1,106 @@
+module IronKernel.Tests.ErrorPassTests
+
+open Xunit
+open IronKernel.Ast
+open IronKernel.Tests.TestHelpers
+
+// R-1RK 7.2.7: "the signaling action consists of an abnormal pass to some
+// continuation in the dynamic extent of error-continuation". These check that the
+// pass actually happens. Nothing else in the suite can: a signalling action that
+// quietly went back to unwinding directly would leave every other test passing,
+// which is exactly the property that makes the change safe and also the property
+// that makes it invisible.
+
+/// The guard shape the report uses for $binds? (6.7.1): an exit guard selecting on
+/// error-continuation, whose interceptor diverts rather than returning.
+let private trying = """
+    (define try
+      (lambda (thunk)
+        (call/cc (lambda (escape)
+          (guard-dynamic-extent
+            ()
+            thunk
+            (list (list error-continuation (lambda (obj divert) (escape "caught")))))))))"""
+
+[<Fact>]
+let ``an exit guard on error-continuation intercepts a signalled error`` () =
+    [
+        trying, Inert
+        """(equal? (try (lambda () (car 5))) "caught")""", Bool true
+        // A body that does not signal is untouched, and returns its own value.
+        "(=? (try (lambda () (+ 1 2))) 3)", Bool true
+        // The nearest guard wins, as for any abnormal pass.
+        """(equal? (try (lambda () (try (lambda () (car 5))))) "caught")""", Bool true
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``the guard only intercepts errors signalled within its own extent`` () =
+    withKernel (fun env ->
+        match evalIn env trying with
+        | Status message -> failwithf "setup failed: %s" message
+        | _ -> ()
+        // Signalled outside any guarded extent: still reported, not swallowed.
+        match evalIn env "(car 5)" with
+        | Status message -> Assert.Contains("pair", message)
+        | value -> failwithf "(car 5) should still signal, got %s" (showVal value)
+        // And the guard is gone once its extent is over.
+        match evalIn env """(try (lambda () 0))""" with
+        | Obj (:? int as n) -> Assert.Equal(0, n)
+        | value -> failwithf "the guard returned %s" (showVal value)
+        match evalIn env "(car 5)" with
+        | Status message -> Assert.Contains("pair", message)
+        | value -> failwithf "(car 5) after the guard should signal, got %s" (showVal value))
+
+[<Fact>]
+let ``an interceptor that returns normally does not cancel the error`` () =
+    // 7.2.5 gives the interceptor two ways out, and only one of them handles the
+    // error: returning passes the value along the chain to the destination, which
+    // is in the extent of error-continuation and reports. Handling means diverting.
+    withKernel (fun env ->
+        let expression =
+            """(guard-dynamic-extent
+                 ()
+                 (lambda () (car 5) "the body continued")
+                 (list (list error-continuation (lambda (obj divert) obj))))"""
+        match evalIn env expression with
+        | Status message -> Assert.Contains("pair", message)
+        | value -> failwithf "returning normally should not cancel the error, got %s" (showVal value))
+
+[<Fact>]
+let ``an error signalled inside an interceptor terminates`` () =
+    // The interceptor runs while a pass to the error extent is in progress. Starting
+    // a second pass from there would select the same guard again and never finish, so
+    // signalling inside the error extent unwinds directly instead. The check is that
+    // this returns at all -- and reports the interceptor's error, not the body's.
+    withKernel (fun env ->
+        let expression =
+            """(guard-dynamic-extent
+                 ()
+                 (lambda () (car 5))
+                 (list (list error-continuation (lambda (obj divert) (car 7)))))"""
+        match evalIn env expression with
+        | Status message -> Assert.Contains("7", message)
+        | value -> failwithf "expected the interceptor's own error, got %s" (showVal value))
+
+[<Fact>]
+let ``the error's diagnostic survives the pass`` () =
+    // The pass carries the original error rather than rebuilding one from the value
+    // that arrives, so an intercepted-and-released error reports what it would have
+    // reported with no guard at all. (Source spans are attached on the unwind by the
+    // dispatch layer, not carried by the error, so they are not what this checks;
+    // they were compared against master separately and are unchanged.)
+    withKernel (fun env ->
+        let bare =
+            match evalIn env "(car 5)" with
+            | Status message -> message
+            | value -> failwithf "(car 5) should signal, got %s" (showVal value)
+        let guarded =
+            let expression =
+                """(guard-dynamic-extent
+                     ()
+                     (lambda () (car 5))
+                     (list (list error-continuation (lambda (obj divert) obj))))"""
+            match evalIn env expression with
+            | Status message -> message
+            | value -> failwithf "the guarded form should signal, got %s" (showVal value)
+        Assert.Equal(bare, guarded))

--- a/IronKernel.Tests/IronKernel.Tests.fsproj
+++ b/IronKernel.Tests/IronKernel.Tests.fsproj
@@ -37,6 +37,7 @@
     <Compile Include="ContinuationFeatureTests.fs" />
     <Compile Include="PairMutationTests.fs" />
     <Compile Include="PortTests.fs" />
+    <Compile Include="ErrorPassTests.fs" />
     <Compile Include="KernelConformanceTests.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/docs/adr/0006-errors-as-abnormal-passes.md
+++ b/docs/adr/0006-errors-as-abnormal-passes.md
@@ -1,6 +1,6 @@
 # ADR 0006: Errors as abnormal passes
 
-Status: Accepted — phase 1 done, phases 2-4 outstanding
+Status: Accepted — phases 1-2 done, phases 3-4 outstanding
 
 ## Decision
 
@@ -166,9 +166,43 @@ and one of them, `realArgument`, needed one threaded in from its callers; and a
 handful spelled the call `fail(` without a space, so a pattern requiring one missed
 them.
 
-**Phase 2 — route through the machinery.** Make `signal` perform the abnormal pass.
-With no guards installed, every existing test must still pass unchanged; that suite
-is the specification for "invisible to programs that do not use guards".
+**Phase 2 — route through the machinery.** *Done.* `signal` performs the abnormal
+pass. The 382 tests passed unchanged, which was the specification for "invisible to
+programs that do not use guards"; five new tests in `ErrorPassTests.fs` check the
+other half, because a signalling action that quietly went back to unwinding directly
+would also leave those 382 passing.
+
+The pass is installed from `Runtime` through a mutable hook, the idiom already used
+for `configureSourceServices` and `configureBodyCompiler`, rather than moving the
+guard machinery above `Eval`. Less churn for the same result, and the fallback when
+unconfigured is the old direct unwind.
+
+Two details the design settled:
+
+- **Regress** was answered by the extent test rather than a depth counter. An error
+  signalled from inside `error-continuation`'s extent — which is where an interceptor
+  handling an error runs — unwinds directly instead of starting a second pass. That
+  is not just a cutoff: once inside the error extent, unwinding is what signalling
+  means. A guard whose interceptor always signals now terminates, reporting the
+  interceptor's error.
+- **Diagnostics** were checked rather than assumed. The destination carries the
+  original `LispError` instead of rebuilding one from the value that arrives, and the
+  message an unintercepted error reports was compared against master on the same
+  inputs: byte-identical. Source spans turn out not to be carried by the error at all
+  — the dispatch layer attaches them on the unwind — so they were never at risk.
+
+**What the benchmark caught.** The ADR predicted `CompilerBenchmarks` would be
+unchanged and said a change would mean something had been added to the ordinary path.
+Something did change: `Interpreted` allocates 2048 B against master's 2024 B. The
+prediction's reasoning was wrong rather than its measurement. Instrumenting `signal`
+shows it is never called while evaluating `(+ value 1)`, so no work was added to the
+ordinary path; the 24 bytes are codegen around the indirection, which appears only
+once the hook is actually dispatched through. Three shapes were measured — a curried
+function behind an option, an inline delegate, and a non-inline delegate — and all
+three allocate the same 24 bytes, so it is the indirection itself and not the calling
+convention. The non-inline delegate is the fastest of the three and the one shipped:
+411 ns against master's 421 ns, with the compiled paths unchanged. Time improved and
+allocation rose 1.2%, on the interpreted path only.
 
 **Phase 3 — the payoffs.** An exit guard selecting on `error-continuation` fires
 when the guarded extent signals. `dynamic-wind` cleans up after a failure. The

--- a/tools/clr-fault-cases.txt
+++ b/tools/clr-fault-cases.txt
@@ -216,4 +216,4 @@
 (* 1e308 10)
 (with-strict-arithmetic #f (lambda () (* 1e308 10)))
 (* 1e-300 1e-300)
-(call/cc (lambda (out) (with-output-to-file "ovf-esc.txt" (lambda () (apply-continuation out 1)))))
+(call/cc (lambda (out) (with-output-to-file "/tmp/ironkernel-ovf-esc.txt" (lambda () (apply-continuation out 1)))))


### PR DESCRIPTION
R-1RK 7.2.7: the signalling action "consists of an abnormal pass to some continuation in the dynamic extent of `error-continuation`". Phase 1 put a `signal` seam at every site with a continuation to signal from. This makes the seam do what the report says.

## What changes

`signal` now performs the abnormal pass, running 7.2.5's selection and interception on the way out. An exit guard selecting on `error-continuation` is selected when the guarded extent signals, so the report's own `$binds?` shape works:

```
(define try
  (lambda (thunk)
    (call/cc (lambda (escape)
      (guard-dynamic-extent () thunk
        (list (list error-continuation (lambda (obj divert) (escape "caught")))))))))
(try (lambda () (car 5)))   ; => "caught"
(try (lambda () (+ 1 2)))   ; => 3
```

With no guards installed the pass selects nothing and reaches a destination that reports the original error — exactly what the direct unwind did.

## Verification

The 382 existing tests pass unchanged. That was the stated specification for "invisible to programs that do not use guards", but it is not sufficient on its own: a signalling action that quietly reverted to unwinding directly would leave all 382 passing too. `ErrorPassTests.fs` adds five tests for the half the old suite cannot see — interception, diversion, nesting, extent boundaries, and that an interceptor which merely returns does not cancel the error.

- clean `--no-incremental` rebuild, 0 warnings
- 387 tests pass
- all 12 examples run (`yingyang.ikr` skipped, non-terminating by design)
- CLR fault sweep: 0 faults, 172 signalled, 47 returned

## Two things the design settled

**Regress** is handled by the extent test rather than the depth counter the ADR floated. An error signalled from inside `error-continuation`'s extent — where an interceptor handling an error runs — unwinds directly instead of starting a second pass from inside the first one's interception chain. That is what signalling means there, not merely a cutoff. A guard whose interceptor always signals now terminates, reporting the interceptor's error.

**Diagnostics** were checked rather than assumed. The destination carries the original `LispError` instead of rebuilding one from the value that arrives; unintercepted errors were compared against master on the same inputs and are byte-identical. Source spans turn out not to be carried by the error at all — the dispatch layer attaches them on the unwind — so they were never at risk, and the ADR now says so instead of claiming otherwise.

## What the benchmark caught

The ADR predicted `CompilerBenchmarks` would be unchanged, and said a change would mean something had been added to the ordinary path. The measurement changed; the reasoning behind the prediction was wrong.

| | master | this branch |
|---|---:|---:|
| ColdCompile | 149.10 ns / 808 B | 144.57 ns / 808 B |
| Interpreted | 420.95 ns / 2024 B | 411.44 ns / **2048 B** |
| CompiledGeneric | 181.20 ns / 808 B | 176.80 ns / 808 B |
| CompiledFolded | 53.04 ns / 304 B | 51.84 ns / 304 B |

Instrumenting `signal` shows it is never called while evaluating `(+ value 1)`, so no work was added to the ordinary path. The 24 bytes are codegen around the indirection, appearing only once the hook is dispatched through. Three shapes were measured — curried behind an option, inline delegate, non-inline delegate — and all three allocate the same 24 bytes, so it is the indirection itself and not the calling convention. The fastest is shipped. Time improved; allocation rose 1.2% on the interpreted path only.

## Unrelated fix

A CLR fault case wrote `ovf-esc.txt` into the repo root and left it there. The sweep runs before every PR and a stray file it created has been accidentally committed once already, so it now writes under `/tmp`.

## Not in this PR

Phase 3 (the payoffs: `dynamic-wind` cleaning up after failures, the `$binds?` derivation as a test) and phase 4 (retire the 7.2.7 divergence, re-validate the matrix). The divergence stays recorded until then.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789654913&installation_model_id=427656&pr_number=69&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F69&signature=3ada5375e0e30d29fa6045b30b057b9be7653263aa78a3b619cbd5fe3b7ac2e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->