### PR TITLE
Complete the error-signalling migration and land 7.2.7's payoffs (ADR 0006 phase 3)

### DIFF
--- a/IronKernel.Runtime/Eval.fs
+++ b/IronKernel.Runtime/Eval.fs
@@ -277,7 +277,7 @@ module Eval =
         | Atom id ->
             match getVar env id with
             | Choice2Of2 r -> More (fun () -> continueEvalStep env cont r)
-            | Choice1Of2 e -> fail e
+            | Choice1Of2 e -> signal cont e
         // One walk of the operand chain, not two. Matching `List (Atom name :: args)`
         // and then `List (op :: args)` materialised the operands twice for every
         // combination whose operator is not a symbol, and once for every one that is.
@@ -350,13 +350,13 @@ module Eval =
         | CompiledCombiner f -> f _env cont args
         | ContractedCombiner contracted ->
             match validateArguments contracted.contract args with
-            | Some error -> fail error
+            | Some error -> signal cont error
             | None when contracted.contract.result = AnyShape ->
                 More (fun () -> operateStep _env cont contracted.combiner args)
             | None ->
                 let validate e c value _ =
                     match validateResult contracted.contract value with
-                    | Some error -> fail error
+                    | Some error -> signal c error
                     | None -> More (fun () -> continueEvalStep e c value)
                 More (fun () ->
                     operateStep
@@ -369,7 +369,7 @@ module Eval =
                 signal cont (CapabilityDenied(sprintf "I/O requires %A" requiredCapability))
             else
                 match evalArgs _env (newContinuation _env) args with
-                | Choice1Of2 e -> fail e
+                | Choice1Of2 e -> signal cont e
                 // The result has to be handed to `cont`, not returned as `Done`.
                 // `Done` ends the trampoline, which was harmless while every combiner
                 // ran inside its own nested `run`, but since compiled code shares one
@@ -378,7 +378,7 @@ module Eval =
                 // whole form and the binding never happened.
                 | Choice2Of2 q ->
                     match f q with
-                    | Choice1Of2 error -> fail error
+                    | Choice1Of2 error -> signal cont error
                     | Choice2Of2 value -> More (fun () -> continueEvalStep _env cont value)
         | Applicative f -> evalArgsExStep _env cont args f
         | Continuation (cr, capturedPrompt, ct') ->
@@ -451,10 +451,10 @@ module Eval =
 
             let newEnv = newEnv [closure]
             match run (bindArgsStep newEnv (newContinuation _env) prms args) with
-            | Choice1Of2 error -> fail error
+            | Choice1Of2 error -> signal cont error
             | Choice2Of2 _ ->
                 match defineVar newEnv envarg _env with
-                | Choice1Of2 error -> fail error
+                | Choice1Of2 error -> signal cont error
                 | Choice2Of2 _ -> evalBody newEnv
         // The empty list is spelled `List []` everywhere a Kernel program can observe
         // it. Returning the bare `Nil` case here made a value that was neither `null?`
@@ -523,7 +523,7 @@ module Eval =
             | badForm -> bindingError <- Some(BadSpecialForm("invalid arguments", badForm))
 
         match bindingError with
-        | Some error -> fail error
+        | Some error -> signal cont error
         | None -> More(fun () -> continueEvalStep env cont Inert)
 
     and resumeEvaluatedStep env cont (resumption: ResumptionRecord) argument : Step =

--- a/IronKernel.Runtime/Interop.fs
+++ b/IronKernel.Runtime/Interop.fs
@@ -96,10 +96,10 @@
                     | Some typ ->
                         // Evaluate constructor arguments (operative operands arrive raw).
                         match sequence (List.map (eval env (newContinuation env)) args) [] with
-                        | Choice1Of2 e -> fail e
+                        | Choice1Of2 e -> signal cont e
                         | Choice2Of2 evaluated ->
                             match sequence (List.map toObjects evaluated) [] with
-                            | Choice1Of2 e -> fail e
+                            | Choice1Of2 e -> signal cont e
                             | Choice2Of2 mapargs ->
                                 try
                                     let obj = Activator.CreateInstance(typ, List.toArray mapargs)
@@ -219,7 +219,7 @@
                     | Atom _
                     | Obj _ ->
                         match sequence (List.map (eval env (newContinuation env)) args) [] with
-                        | Choice1Of2 e -> fail e
+                        | Choice1Of2 e -> signal cont e
                         | Choice2Of2 args' ->
                             let result =
                                 match clazz with
@@ -238,7 +238,7 @@
                                         | Choice1Of2 e -> throwError e
                                 | bad -> throwError (TypeMismatch("object", bad))
                             match result with
-                            | Choice1Of2 e -> fail e
+                            | Choice1Of2 e -> signal cont e
                             | Choice2Of2 r -> bounceContinue env cont r
                     | exp ->
                         let cps e c result _ =
@@ -313,7 +313,7 @@
                 signal cont (CapabilityDenied "host output requires HostIO")
           | Obj(sf)::tail when typeof<string> = sf.GetType() -> 
                 match sequence (List.map toObjects tail) [] with
-                | Choice1Of2 e -> fail e
+                | Choice1Of2 e -> signal cont e
                 | Choice2Of2 mapargs ->
                     // A format string with more placeholders than arguments raises
                     // FormatException, which escaped the evaluator and aborted the

--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -43,7 +43,7 @@
             | [a;b] ->
                 match op a b with
                 | Choice2Of2 result -> bounceContinue env cont result
-                | Choice1Of2 error -> fail error
+                | Choice1Of2 error -> signal cont error
             | _ -> signal cont (NumArgs(2,prms))
 
         let numBoolBinop env cont (op: LispVal -> LispVal -> ThrowsError<LispVal>) prms : Step = 
@@ -51,7 +51,7 @@
             | [a;b] ->
                 match op a b with
                 | Choice2Of2 result -> bounceContinue env cont result
-                | Choice1Of2 error -> fail error
+                | Choice1Of2 error -> signal cont error
             | _ -> signal cont (NumArgs(2,prms))
 
         // The three fundamental operations, each one cell access. Asked through the
@@ -531,10 +531,10 @@
                 signal cont (CapabilityDenied "source loading requires SourceLoading")
             | [Obj(filename)] ->
                 match cast filename with
-                | Choice1Of2 e -> fail e
+                | Choice1Of2 e -> signal cont e
                 | Choice2Of2 fname ->
                     match load fname with
-                    | Choice1Of2 e -> fail e
+                    | Choice1Of2 e -> signal cont e
                     | Choice2Of2 lisp ->
                         // Each loaded form gets a fresh continuation. Passing the
                         // caller's `cont` ran the rest of the caller's computation once
@@ -547,7 +547,7 @@
                         // own structure through `vau` above (ADR 0005 phase 0).
                         let evaluateForm form = eval env (newContinuation env) form
                         match sequence (List.map evaluateForm lisp) [] with
-                        | Choice1Of2 e -> fail e
+                        | Choice1Of2 e -> signal cont e
                         | Choice2Of2 _ -> bounceContinue env cont Inert
             | badform -> signal cont (NumArgs(1, badform))
 
@@ -633,11 +633,11 @@
                     match Contracts.attach contract value with
                     | Some contracted ->
                         match defineVar env name contracted with
-                        | Choice1Of2 error -> fail error
+                        | Choice1Of2 error -> signal cont error
                         | Choice2Of2 _ -> bounceContinue env cont Inert
                     | None ->
                         signal cont (ContractViolation(name + " contract mode does not match its combiner"))
-                | _, _, _, Choice1Of2 error -> fail error
+                | _, _, _, Choice1Of2 error -> signal cont error
                 | _ -> signal cont (ContractViolation("invalid contract specification for " + name))
             | bad -> signal cont (NumArgs(6, bad))
 
@@ -992,7 +992,7 @@
             let extend target applicative dynamicEnv =
                 match extendWith target applicative dynamicEnv with
                 | Choice2Of2 extended -> bounceContinue env cont extended
-                | Choice1Of2 error -> fail error
+                | Choice1Of2 error -> signal cont error
             match args with
             | [target; applicative; (Environment _ as dynamicEnv)] ->
                 extend target applicative dynamicEnv
@@ -1092,14 +1092,14 @@
             match args with
             | [Obj filename; combiner] when (filename :? string) ->
                 match openFile name access (filename :?> string) with
-                | Choice1Of2 error -> fail error
+                | Choice1Of2 error -> signal cont error
                 | Choice2Of2 (Port stream as port) ->
                     let closeAfter _ c value _ =
                         try stream.Close() with _ -> ()
                         More(fun () -> continueEvalStep env c value)
                     let afterCall = makeCPS env cont closeAfter
                     match buildGuarded env afterCall Nil (closingGuard stream) with
-                    | Choice1Of2 error -> fail error
+                    | Choice1Of2 error -> signal cont error
                     | Choice2Of2 guarded ->
                         let isolated = newEnvWithClr (ofEnvironment env) [] []
                         bounceOperate
@@ -1123,14 +1123,14 @@
             match args with
             | [Obj filename; combiner] when (filename :? string) ->
                 match openFile name access (filename :?> string) with
-                | Choice1Of2 error -> fail error
+                | Choice1Of2 error -> signal cont error
                 | Choice2Of2 (Port stream as port) ->
                     let closeAfter _ c value _ =
                         try stream.Close() with _ -> ()
                         More(fun () -> continueEvalStep env c value)
                     let afterCall = makeCPS env cont closeAfter
                     match buildGuarded env afterCall Nil (closingGuard stream) with
-                    | Choice1Of2 error -> fail error
+                    | Choice1Of2 error -> signal cont error
                     | Choice2Of2 guarded -> bounceOperate env guarded combiner [port]
                 | Choice2Of2 _ -> signal cont (Default(name + ": could not open the file"))
             | [found; _] -> signal cont (TypeMismatch("string", found))
@@ -1171,7 +1171,7 @@
         let writeValue env cont args =
             let finish result =
                 match result with
-                | Choice1Of2 error -> fail error
+                | Choice1Of2 error -> signal cont error
                 | Choice2Of2 value -> bounceContinue env cont value
             match args with
             | [value] -> finish (writeTo (currentOutput cont) value)
@@ -1206,7 +1206,7 @@
         let readValue env cont args =
             let finish result =
                 match result with
-                | Choice1Of2 error -> fail error
+                | Choice1Of2 error -> signal cont error
                 | Choice2Of2 value -> bounceContinue env cont value
             match args with
             | [] -> finish (readFrom (currentInput cont))
@@ -1219,7 +1219,7 @@
             | [entry; (Continuation _ as target); exit] ->
                 match buildGuarded env target entry exit with
                 | Choice2Of2 inner -> bounceContinue env cont inner
-                | Choice1Of2 error -> fail error
+                | Choice1Of2 error -> signal cont error
             | [_; found; _] -> signal cont (TypeMismatch("continuation", found))
             | _ -> signal cont (NumArgs(3, args))
 
@@ -1239,7 +1239,7 @@
             match args with
             | [entry; combiner; exit] ->
                 match buildGuarded env cont entry exit with
-                | Choice1Of2 error -> fail error
+                | Choice1Of2 error -> signal cont error
                 | Choice2Of2 inner -> bounceOperate env inner combiner []
             | _ -> signal cont (NumArgs(3, args))
 
@@ -1358,7 +1358,7 @@
                             |> ignore
                       resume =
                         function
-                        | Choice1Of2 error -> fail error
+                        | Choice1Of2 error -> signal cont error
                         | Choice2Of2 value -> bounceContinue env cont value }
             | [found] -> signal cont (TypeMismatch("Task", found))
             | bad -> signal cont (NumArgs(1, bad))
@@ -1477,7 +1477,7 @@
                     | next :: remaining ->
                         match op acc next with
                         | Choice2Of2 result -> loop result remaining
-                        | Choice1Of2 error -> fail error
+                        | Choice1Of2 error -> signal cont error
                 loop first rest
 
         /// The binary case is matched directly. Two arguments is overwhelmingly the
@@ -1488,7 +1488,7 @@
             | [a; b] ->
                 match op a b with
                 | Choice2Of2 result -> continueNumericFrom args env cont result
-                | Choice1Of2 error -> fail error
+                | Choice1Of2 error -> signal cont error
             | _ -> foldNumeric op identity env cont args
 
         let plus env cont args = binaryOrFold opAdd (box 0) env cont args
@@ -1511,7 +1511,7 @@
             | [a; b] ->
                 match opDivide a b with
                 | Choice2Of2 result -> continueNumericFrom args env cont result
-                | Choice1Of2 error -> fail error
+                | Choice1Of2 error -> signal cont error
             | numerator :: (_ :: _ as divisors) ->
                 let rec product acc = function
                     | [] -> Choice2Of2 acc
@@ -1520,11 +1520,11 @@
                         | Choice2Of2 value -> product value rest
                         | Choice1Of2 error -> Choice1Of2 error
                 match product (List.head divisors) (List.tail divisors) with
-                | Choice1Of2 error -> fail error
+                | Choice1Of2 error -> signal cont error
                 | Choice2Of2 divisor ->
                     match opDivide numerator divisor with
                     | Choice2Of2 result -> continueNumericFrom args env cont result
-                    | Choice1Of2 error -> fail error
+                    | Choice1Of2 error -> signal cont error
             | _ -> signal cont (NumArgs(2, args))
         /// R-1RK 12.9. The report gives these entries signatures only: Appendix A.2
         /// records that it is an incomplete draft whose unwritten portions were "only
@@ -2227,7 +2227,7 @@
                 match opDivAndMod a b with
                 | Choice2Of2 (quotient, remainder) ->
                     bounceContinue env cont (ofList [quotient; remainder])
-                | Choice1Of2 error -> fail error
+                | Choice1Of2 error -> signal cont error
             | _ -> signal cont (NumArgs(2, args))
 
         let lessThan env cont args = numBoolBinop env cont opLessThan args
@@ -2252,7 +2252,7 @@
             | [Vector arr; Obj pos'; value] when typeof<int> = pos'.GetType() ->
                 let index = pos' :?> int
                 match checkedIndex arr index "vector-set!" with
-                | Some error -> fail error
+                | Some error -> signal cont error
                 | None ->
                     arr.[index] <- value
                     bounceContinue env cont Inert
@@ -2264,7 +2264,7 @@
             | [Vector arr; Obj pos'] when typeof<int> = pos'.GetType() ->
                 let index = pos' :?> int
                 match checkedIndex arr index "vector-ref" with
-                | Some error -> fail error
+                | Some error -> signal cont error
                 | None -> arr.[index] |> bounceContinue env cont
             | [_; pos] -> signal cont (TypeMismatch("vector/int", pos))
             | _ -> signal cont (NumArgs(2, args))
@@ -2372,7 +2372,7 @@
                             | [value; (Environment _ as target)] ->
                                 let child = newEnv [target]
                                 match defineVar child key value with
-                                | Choice1Of2 error -> fail error
+                                | Choice1Of2 error -> signal cont error
                                 | Choice2Of2 _ -> bounceContinue e c child
                             | [_; found] -> signal c (TypeMismatch("environment", found))
                             | bad -> signal c (NumArgs(2, bad))))

--- a/IronKernel.Runtime/RuntimeDispatch.fs
+++ b/IronKernel.Runtime/RuntimeDispatch.fs
@@ -16,7 +16,7 @@ module RuntimeDispatch =
     /// and turn `Await` into a blocking wait. See ADR 0004.
     let appNamed env cont name (operands: LispVal[]) : Step =
         match getVar env name with
-        | Choice1Of2 error -> Done(throwError error)
+        | Choice1Of2 error -> signal cont error
         | Choice2Of2 combiner -> bounceOperate env cont combiner (Array.toList operands)
 
     /// One call site's resolved binding, immutable once constructed so that it can
@@ -98,7 +98,7 @@ module RuntimeDispatch =
             match resolved.EagerUnderlying with
             | ValueSome underlying ->
                 match evaluateSimpleOperands env [] operands with
-                | Choice1Of2 error -> Done(throwError error)
+                | Choice1Of2 error -> signal cont error
                 | Choice2Of2 args -> bounceOperate env cont underlying args
             | ValueNone -> bounceOperate env cont resolved.Combiner operands
 
@@ -122,7 +122,7 @@ module RuntimeDispatch =
                 // snapshot that could never be revalidated.
                 | ValueNone ->
                     match getVar env name with
-                    | Choice1Of2 error -> Done(throwError error)
+                    | Choice1Of2 error -> signal cont error
                     | Choice2Of2 combiner -> bounceOperate env cont combiner operands
 
     type GeneratedFunc = Func<LispVal, LispVal, Step>
@@ -144,14 +144,14 @@ module RuntimeDispatch =
                 match value with
                 | Bool true -> consequent.Invoke(e, c)
                 | Bool false -> alternative.Invoke(e, c)
-                | found -> Done(throwError (TypeMismatch("bool", found)))))
+                | found -> signal c (TypeMismatch("bool", found))))
 
     let runDefine env cont name (rhs: GeneratedFunc) =
         rhs.Invoke(
             env,
             makeCPS env cont (fun e c value _ ->
                 match defineVar e name value with
-                | Choice1Of2 error -> Done(throwError error)
+                | Choice1Of2 error -> signal c error
                 | Choice2Of2 _ -> bounceContinue e c Inert))
 
     let runSequence env cont (forms: GeneratedFunc[]) =

--- a/IronKernel.Tests/ErrorPassTests.fs
+++ b/IronKernel.Tests/ErrorPassTests.fs
@@ -104,3 +104,84 @@ let ``the error's diagnostic survives the pass`` () =
             | Status message -> message
             | value -> failwithf "the guarded form should signal, got %s" (showVal value)
         Assert.Equal(bare, guarded))
+
+[<Fact>]
+let ``errors that reach the guard are not limited to one kind`` () =
+    // Phase 2 routed `signal`, but 39 sites still converted a ThrowsError to a Step
+    // with `fail`, which consults no continuation -- so whether an error could be
+    // intercepted depended on which primitive raised it. A guard caught (car 5) and
+    // missed an unbound variable. These are the kinds that were escaping.
+    [
+        trying, Inert
+        // Symbol lookup: Eval's bare-Atom case, the one that surfaced the gap.
+        """(equal? (try (lambda () nope)) "caught")""", Bool true
+        """(equal? (try (lambda () (eval (quote nope) (get-current-environment)))) "caught")""", Bool true
+        // Arithmetic, through the numeric fold.
+        """(equal? (try (lambda () (/ 1 0))) "caught")""", Bool true
+        """(equal? (try (lambda () (+ 1 "x"))) "caught")""", Bool true
+        // Vectors, through the index check.
+        """(equal? (try (lambda () (vector-ref (vector 1 2) 9))) "caught")""", Bool true
+        // Applying a non-combiner, and the wrong operand count.
+        """(equal? (try (lambda () (car))) "caught")""", Bool true
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``dynamic-wind cleans up after a failure`` () =
+    // R-1RK 7.2.5's derivation of dynamic-wind, unchanged from the version in
+    // ContinuationFeatureTests. What is new is the third case: before 7.2.7 routed
+    // through the guards, `after` ran on a normal return and on an abnormal pass but
+    // not when the body signalled -- which is most of what one wants dynamic-wind for.
+    [
+        "(define top (get-current-environment))", Inert
+        "(define trace (list))", Inert
+        "(define note (lambda (x) (set! top trace (cons x trace))))", Inert
+        """(define dynamic-wind
+              (lambda (before thunk after)
+                (guard-dynamic-extent
+                  (list (list root-continuation (lambda (value ignored) (before) value)))
+                  (lambda () (before) (let ((result (thunk))) (after) result))
+                  (list (list root-continuation (lambda (value ignored) (after) value))))))""", Inert
+        trying, Inert
+        """(equal?
+              (try (lambda ()
+                     (dynamic-wind (lambda () (note 1)) (lambda () (car 5)) (lambda () (note 2)))))
+              "caught")""", Bool true
+        // `before` and `after` each ran once, and `after` ran last -- on the way out
+        // of an extent left by signalling, not by returning or escaping.
+        "(=? (length trace) 2)", Bool true
+        "(=? (car trace) 2)", Bool true
+    ] |> evalSessionKernel
+
+[<Fact>]
+let ``the report's $binds? derivation works`` () =
+    // R-1RK 6.7.1 derives $binds? in Kernel: guard the lookup with an exit guard on
+    // error-continuation and let the interceptor divert with #f. The report writes
+    // the divert as `(apply divert #f)`, passing #f as an *atomic* operand tree.
+    // IronKernel represents an operand tree as a list, so an atomic tree has no
+    // spelling (the recorded 7.2.5 divergence) and `(divert #f)` delivers `(#f)`.
+    // The body returns `(list #t)` to match, and the caller takes the car of either.
+    // That is a transcription difference, not a semantic one: what decides the
+    // predicate is still whether looking the symbol up signals.
+    [
+        """(define binds?
+              (vau (exp & ss) dynamic
+                (car
+                  (guard-dynamic-extent
+                    ()
+                    (lambda ()
+                      (let ((env (eval exp dynamic)))
+                        (map (lambda (sym) (eval sym env)) ss))
+                      (list #t))
+                    (list (list error-continuation (lambda (_ divert) (divert #f))))))))""", Inert
+        "(define here (get-current-environment))", Inert
+        "(define bound 1)", Inert
+        "(binds? here bound)", Bool true
+        "(binds? here bound here)", Bool true
+        "(not? (binds? here nope))", Bool true
+        // All the symbols have to be bound, not just one of them.
+        "(not? (binds? here bound nope))", Bool true
+        // And it agrees with the primitive, which stays: the point of the derivation
+        // is that it introduces no capability the language did not already have.
+        "(eq? (binds? here bound) ($binds? here bound))", Bool true
+        "(eq? (binds? here nope) ($binds? here nope))", Bool true
+    ] |> evalSessionKernel

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -40,7 +40,7 @@ module Compiler =
         static member Lookup(env: LispVal, cont: LispVal, name: string) : Step =
             match SymbolTable.getVar env name with
             | Choice2Of2 r -> bounceContinue env cont r
-            | Choice1Of2 e -> Done(throwError e)
+            | Choice1Of2 e -> signal cont e
         static member IfThenElse(env: LispVal, cont: LispVal, fc: KernelFunc, fa: KernelFunc, fb: KernelFunc) : Step =
             fc.Invoke(
                 env,
@@ -48,7 +48,7 @@ module Compiler =
                     match value with
                     | Bool true -> fa.Invoke(e, c)
                     | Bool false -> fb.Invoke(e, c)
-                    | found -> Done(throwError (TypeMismatch("bool", found)))))
+                    | found -> signal c (TypeMismatch("bool", found))))
         static member Seq(env: LispVal, cont: LispVal, forms: KernelFunc[]) : Step =
             if forms.Length = 0 then bounceContinue env cont Inert
             else
@@ -61,7 +61,7 @@ module Compiler =
                 env,
                 makeCPS env cont (fun e c value _ ->
                     match SymbolTable.defineVar e name value with
-                    | Choice1Of2 error -> Done(throwError error)
+                    | Choice1Of2 error -> signal c error
                     | Choice2Of2 _ -> bounceContinue e c Inert))
         static member EvalForms(env: LispVal, cont: LispVal, fe: KernelFunc, fx: KernelFunc) : Step =
             fe.Invoke(

--- a/IronKernel/StaticCompiler.fs
+++ b/IronKernel/StaticCompiler.fs
@@ -117,7 +117,7 @@ module StaticCompiler =
                 Some(
                     generated(
                     "match getVar env " + quote name
-                    + " with | Choice1Of2 error -> Done(throwError error)"
+                    + " with | Choice1Of2 error -> signal cont error"
                     + " | Choice2Of2 value -> bounceContinue env cont value"))
             | COperate(operator, operands) ->
                 match operands |> List.map emitValue |> sequenceOptions with

--- a/docs/adr/0006-errors-as-abnormal-passes.md
+++ b/docs/adr/0006-errors-as-abnormal-passes.md
@@ -1,6 +1,6 @@
 # ADR 0006: Errors as abnormal passes
 
-Status: Accepted — phases 1-2 done, phases 3-4 outstanding
+Status: Accepted — phases 1-3 done, phase 4 outstanding
 
 ## Decision
 
@@ -151,6 +151,12 @@ ignores its continuation, so nothing changes yet. 200 sites now signal; 8 still
 where the continuation *argument* is itself malformed, and the internal error for a
 metacontinuation in the wrong position.
 
+> **Corrected in phase 3.** The second sentence was wrong. 47 sites were still
+> unmigrated, not 8, and they were not the ones without a continuation: 39 `fail`
+> sites in the runtime and 8 `Done(throwError ...)` sites in the compiled and dispatch
+> paths, almost all with a continuation in scope. The count of 8 is right only for
+> what remains *after* phase 3. See phase 3 below.
+
 The migration was not quite as mechanical as this plan assumed, and the part that
 was not is the part phase 2 depends on. `signal` takes the continuation the failing
 operation would have returned to, which is the *innermost* one in scope, and eleven
@@ -204,13 +210,46 @@ convention. The non-inline delegate is the fastest of the three and the one ship
 411 ns against master's 421 ns, with the compiled paths unchanged. Time improved and
 allocation rose 1.2%, on the interpreted path only.
 
-**Phase 3 — the payoffs.** An exit guard selecting on `error-continuation` fires
-when the guarded extent signals. `dynamic-wind` cleans up after a failure. The
-report's `$binds?` derivation becomes expressible, and should be added as a test
-even though the direct implementation stays.
+**Phase 3 — the payoffs.** *Done.* `dynamic-wind` cleans up after a failure, and
+the report's `$binds?` derivation works. Both are tests; the direct `$binds?`
+implementation stays.
+
+Neither worked when the phase began, and the reason is the part of this ADR worth
+keeping. **Phases 1 and 2 had missed 47 signalling sites**, so whether an error could
+be intercepted depended on which primitive raised it: a guard caught `(car 5)` and
+missed an unbound variable.
+
+- **39 `fail` sites in `Eval`, `Runtime` and `Interop`.** Phase 1's note claimed 8
+  remained and that they were "exactly the ones with no continuation to signal from".
+  That was a miscount. Almost all 39 are the `| Choice1Of2 error -> fail error`
+  conversions this ADR had already identified as "where the pass begins" — the
+  inventory named them and the migration then skipped them. 8 sites genuinely do stay
+  `fail`, and those are the malformed-continuation and internal-error cases.
+- **8 sites in the compiled and dispatch paths** — `Compiler.fs`,
+  `RuntimeDispatch.fs`, and the source text `StaticCompiler.fs` emits — which called
+  `Done(throwError ...)` and so never went through `signal` at all. The site inventory
+  in this ADR counted `fail` and `throwError` in the runtime and never considered
+  compiled code, which is what a lambda body becomes. This is why the gap showed up as
+  "the guard catches an error from `(car 5)` but not from evaluating a symbol": the
+  first is a primitive, the second is compiled.
+
+Two of the 47 sit inside CPS callbacks binding their own continuation, and take that
+one rather than the enclosing primitive's — the same trap phase 1 documented, which
+the compiler cannot catch because both names are in scope.
+
+**On the `$binds?` transcription.** The report's derivation diverts with
+`(apply divert #f)`, which passes `#f` as an *atomic* operand tree. IronKernel's
+`apply` is the report's derivation verbatim, so that is not where the difference is:
+a combination's operand tree is represented as a list, so a non-list tree has no
+spelling, and `(divert #f)` delivers `(#f)`. That is the 7.2.5 divergence already on
+record. The test has the body return `(list #t)` and takes the car of either path,
+which is a transcription difference and not a semantic one — what decides the
+predicate is still whether looking the symbol up signals.
 
 **Phase 4 — record.** Retire the 7.2.7 divergence, narrow 15.1.3's successor if
-ports can now close on error too, and re-validate.
+ports can now close on error too, and re-validate. Note that the 7.2.5 divergence
+does *not* retire: an atomic operand tree still has no representation, and errors
+now go through interception while a direct continuation application still does not.
 
 ## Baseline to hold
 


### PR DESCRIPTION
Phase 3 was meant to be the payoffs — `dynamic-wind` cleaning up after a failure, and the report's own `$binds?` derivation (6.7.1) becoming expressible. **Neither worked when the phase began.**

## What was wrong

Phases 1 and 2 had missed **47 signalling sites**, so whether an error could be intercepted depended on which primitive raised it. A guard caught `(car 5)` and missed an unbound variable.

**39 `fail` sites** in `Eval`, `Runtime` and `Interop`. Phase 1 recorded that 8 remained and that they were "exactly the ones with no continuation to signal from" — a miscount. Almost all 39 are the `| Choice1Of2 error -> fail error` conversions this ADR had already identified as *where the pass begins*: the inventory named them, and the migration then skipped them. 8 sites do genuinely stay `fail` — the malformed-continuation and internal-error cases.

**8 sites in the compiled and dispatch paths** — `Compiler.fs`, `RuntimeDispatch.fs`, and the source text `StaticCompiler.fs` emits — which called `Done(throwError ...)` and never reached `signal` at all. The ADR's site inventory counted `fail` and `throwError` in the runtime and never considered compiled code, which is what a lambda body becomes. That is exactly why the gap presented as "catches an error from a primitive, misses one from evaluating a symbol".

Two of the 47 sit inside CPS callbacks that bind their own continuation, and take that one rather than the enclosing primitive's — the trap phase 1 documented, which the compiler cannot catch because both names are in scope.

## The payoffs

`dynamic-wind`, derived exactly as in 7.2.5's rationale, now runs `after` when the body *signals* — previously it ran on a normal return and on an abnormal pass but not on a failure, which is most of what one wants it for.

The report's `$binds?` derivation works, and agrees with the primitive (which stays).

A third test covers the error kinds that were escaping: symbol lookup, arithmetic, vector indexing, arity.

## On the `$binds?` transcription

The report diverts with `(apply divert #f)`, passing `#f` as an *atomic* operand tree. IronKernel's `apply` is the report's derivation verbatim, so that is not where the difference lies: a combination's operand tree is represented as a list, so a non-list tree has no spelling and `(divert #f)` delivers `(#f)`. That is the **7.2.5 divergence already on record**. The test has the body return `(list #t)` and takes the car of either path — a transcription difference, not a semantic one, since what decides the predicate is still whether looking the symbol up signals.

## Verification

- clean `--no-incremental` rebuild, 0 warnings
- 390 tests pass
- all 12 examples run (`yingyang.ikr` skipped, non-terminating by design)
- CLR fault sweep: 0 faults, 172 signalled, 47 returned

| | phase 2 | this branch |
|---|---:|---:|
| ColdCompile | 144.57 ns / 808 B | 147.23 ns / 808 B |
| Interpreted | 411.44 ns / 2048 B | 414.56 ns / 2048 B |
| CompiledGeneric | 176.80 ns / 808 B | 180.52 ns / 808 B |
| CompiledFolded | 51.84 ns / 304 B | 52.03 ns / 304 B |

Flat, allocation unchanged — routing the compiled path through `signal` costs nothing on the ordinary path.

## Not in this PR

Phase 4: retire the 7.2.7 divergence, check whether 15.1.3's successor can narrow now that ports can close on error, re-validate the matrix. The 7.2.5 divergence does **not** retire — an atomic operand tree still has no representation, and errors now go through interception while a direct continuation application still does not.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789658592&installation_model_id=427656&pr_number=70&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F70&signature=45c0c3ea1f2c0dc708a3971f25205ecfc1b438ff0508e74cfa97c0cfd085b31c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->