### PR TITLE
ADR 0007: identity for derived combiners — measured, and recommended against

### DIFF
--- a/docs/adr/0004-compiling-procedure-bodies.md
+++ b/docs/adr/0004-compiling-procedure-bodies.md
@@ -242,6 +242,13 @@ on the table for a *different* mechanism.
 from `PrimitiveIdentity` and should get its own ADR rather than being grown into
 this one.
 
+> [ADR 0007](0007-identity-for-derived-combiners.md) took that up and recommends
+> against building it. A dynamic census puts derived operatives at 7.2% of dispatches,
+> and 84% of that is sequencing rather than the `let`/`letrec` this paragraph guessed
+> at -- `letrec` is 0.09%. The static census above ranked it first, which is the
+> hazard of counting source sites. The cheaper route is to make the hot derived
+> operatives primitive and reuse the guard that already exists.
+
 ## Baseline
 
 Taken on an idle machine alongside phase 5's measurement, as the reference for any

--- a/docs/adr/0007-identity-for-derived-combiners.md
+++ b/docs/adr/0007-identity-for-derived-combiners.md
@@ -1,0 +1,165 @@
+# ADR 0007: Identity for derived combiners
+
+Status: Proposed
+
+## Decision
+
+Do not build it. ADR 0004 phase 5 ended by naming identity for derived combiners as
+the lever its own mechanism could not reach; measuring that lever shows it is worth
+about 1% of dispatches beyond what a much smaller change already gets. Instead,
+promote the hot standard-library operatives to primitives and lower them through the
+`PrimitiveIdentity` guard that already exists, starting with `$sequence`.
+
+## Problem
+
+`PrimitiveIdentity` is a field on `PrimitiveOperativeRecord`. A compound operative --
+anything `kernel.ikr` builds with `vau` -- cannot carry one, so `analyzeGuarded`
+cannot recognise it and every call goes through generic `COperate` dispatch. Phase 5
+measured that guards are 11.7% faster on a fresh frame where they apply, and found
+that the operators with structure worth lowering are all derived and therefore out of
+reach.
+
+The obvious repair is to give derived combiners an identity too: stamp the standard
+library's combiners at bootstrap, generalise `BindingGuard.expectedIdentity` to cover
+them, and lower `(let ...)`, `(sequence ...)` and friends the way `if` is lowered
+today.
+
+Before building that, it is worth asking what it would buy.
+
+## What the dispatches actually are
+
+Phase 5's census counted *static* occurrences in compiled bodies and ranked `letrec`
+first among derived operatives. That ranking is an artifact of counting source sites.
+Instrumenting the compiled dispatch path (`NamedCallSite.Invoke`) and running eight
+example programs -- 9.0M dispatches in total, from 2.5k to 8.2M per program -- gives
+the frequency instead:
+
+| Combiner kind | Share of dispatches |
+|---|---:|
+| primitive applicative | 78.4% |
+| derived applicative | 12.3% |
+| **derived operative** | **7.2%** |
+| other applicative | 2.0% |
+| primitive operative | 0.0% |
+
+The derived-operative share is the ceiling on what this ADR's mechanism could ever
+address, and it is remarkably stable: 6.8% to 7.6% across all eight programs.
+
+Inside that 7.2% slice:
+
+| | Share of slice | Share of all dispatches |
+|---|---:|---:|
+| `seq2` | 46.3% | 3.4% |
+| `sequence` | 37.9% | 2.7% |
+| `let` | 14.1% | 1.0% |
+| `letrec` | 1.3% | 0.09% |
+| `cond`, `let*`, rest | 0.4% | 0.03% |
+
+So 84% of the target is one feature, sequencing. `letrec`, which the static census
+ranked first, is 0.09% of dispatches -- three orders of magnitude below where
+counting source sites placed it. Anyone sizing this work from the static census would
+have built the general mechanism to speed up the wrong thing.
+
+## Sequencing costs more than its own dispatches
+
+`$sequence` is the report's derivation (5.1.1): `seq2` plus an `aux` operative that
+evaluates the head and recurses on `(eval (cons aux tail) env)`. Each element
+therefore costs roughly a `null?`, two `eval`s and a `cons` on top of the dispatch
+itself -- and those are the top of the overall table:
+
+| Site | Share of all dispatches |
+|---|---:|
+| `null?` | 26.0% |
+| `eval` | 18.7% |
+| `cons` | 9.4% |
+| `zero?` | 8.9% |
+| `car` | 7.9% |
+
+This is an inference, not an attribution: the census keys on the dispatched name and
+does not record the caller, so it cannot say how much of that `eval` traffic is
+sequencing. Two things make the inference worth acting on anyway. The arithmetic is
+the right order -- 549k sequencing dispatches against 1.68M `eval` and 845k `cons` --
+and the census *undercounts* sequencing, because `aux` recurses through
+`(cons aux tail)`, a computed operator that never reaches the name-keyed call site at
+all. Lowering `$sequence` removes the generated traffic, not just the 6.1%.
+
+## Why the general mechanism is the wrong shape
+
+The case for identity on derived combiners is that it generalises. It does not.
+
+A guard only pays if the compiler knows what to lower the combiner *into*. `CIf`
+wins by compiling the branches; `CSeq` would win by compiling the elements. That
+knowledge is hardcoded per feature, so the mechanism can only ever recognise
+combiners the compiler already understands -- which is the standard library, and
+nothing else. It does not extend to user-defined combiners: speeding those up means
+inlining an arbitrary vau body, with the hygiene and dynamic-environment questions
+that entails, and that is a different technique that would not use this machinery.
+
+So the general mechanism's reach is exactly the set of combiners we could instead
+make primitive. Both routes end at the same lowered `CSeq`; one adds an identity
+scheme for compound operatives, a bootstrap stamping pass and a wider
+`BindingGuard`, and the other adds a primitive and one `PrimitiveIdentity` case.
+
+The report settles whether making them primitive is allowed. R-1RK 1.3.2:
+
+> The derivation code is not considered part of the definition of the feature, so
+> implementations are not expected to duplicate the exact behavior of the code.
+
+Library features may be implemented primitively. Conformance is unaffected, and the
+matrix records module completeness rather than how a feature was built.
+
+## What to do instead
+
+**Promote `$sequence` to a primitive operative** with a `PrimitiveSequence` identity,
+and lower `(sequence . forms)` to `CSeq` in `analyzeGuarded` under the existing
+binding guard, with the current `COperate` path as the fallback.
+
+`CSeq` already exists in `Ir.fs` and `compileToFunc` already compiles it -- it is
+produced today only by the package decoder and the partial evaluator, never by the
+analyzer. So the compiler side is a lowering rule, not a new node.
+
+`let` is the only other candidate above 1%, and it is a further decision to take on
+its own evidence once sequencing is done, because removing the sequencing traffic
+changes the profile everything else is measured against.
+
+## Risks
+
+**Sequencing is load-bearing.** Every operative body is a sequence, so a wrong
+primitive breaks everything at once. That is also the mitigation: the 394-test suite
+and the twelve examples exercise it on every path, and a mistake cannot hide.
+
+**Tail position.** 5.1.1 requires the last element to be evaluated as a tail context.
+The derivation gets this from `aux`'s structure; a primitive and a `CSeq` lowering
+each have to preserve it deliberately. ADR 0004 phase 2 already found that the
+equivalent property is invisible to a test that only checks results, and has to be
+measured structurally -- capture a continuation at the deepest point and assert its
+`nextCont` depth stays bounded. The same test shape applies here.
+
+**The derivation stops being exercised.** `kernel.ikr`'s version is presently
+executed by everything; as a fallback it would be executed by almost nothing, so it
+can rot unnoticed. It should keep a test that drives it directly.
+
+**The profile is one corpus.** Eight example programs are not a workload survey, and
+they lean on the standard library more than user code would. The 7.2% ceiling is the
+number to distrust first if the result disappoints.
+
+## Cost
+
+One primitive, one `PrimitiveIdentity` case, one lowering rule, and the tests above.
+No new mechanism. Against that, the rejected design needs identity on
+`OperativeRecord`, a bootstrap pass to stamp the standard library, a generalised
+`BindingGuard`, and a decision about what happens when a program redefines a stamped
+name -- for at most one point of additional reach.
+
+## Consequences
+
+`$sequence` moves from derived to primitive. The report permits it, but it is a real
+change in character: IronKernel has preferred to derive what the report derives, and
+this is the first place where measurement argues the other way. It is worth being
+explicit that the reason is evidence rather than convenience, and that the derivation
+stays in the tree as the fallback and as documentation of the semantics.
+
+If sequencing is lowered and the gain does not appear, the conclusion is not "now
+build the general mechanism". It is that dispatch is not where the time goes, and the
+remaining 78.4% -- primitive applicative calls in hot loops -- is the thing to profile
+next.


### PR DESCRIPTION
ADR 0004 phase 5 ended by naming identity for derived combiners as the lever its own mechanism could not reach, and said it should get its own ADR. This is that ADR. It measures the lever before building it, and **the recommendation is not to build it.**

## The static census was misleading

Phase 5 counted *static* occurrences in compiled bodies and ranked `letrec` first among derived operatives. I instrumented the compiled dispatch path (`NamedCallSite.Invoke`) and ran eight example programs — 9.0M dispatches, 2.5k to 8.2M each — to get frequency instead.

| Combiner kind | Share of dispatches |
|---|---:|
| primitive applicative | 78.4% |
| derived applicative | 12.3% |
| **derived operative** | **7.2%** |
| other applicative | 2.0% |

7.2% is the ceiling on what this mechanism could ever address, and it is stable at 6.8–7.6% across all eight programs. Inside that slice:

| | Share of slice | Share of all dispatches |
|---|---:|---:|
| `seq2` | 46.3% | 3.4% |
| `sequence` | 37.9% | 2.7% |
| `let` | 14.1% | 1.0% |
| `letrec` | 1.3% | **0.09%** |

84% of the target is one feature — sequencing. `letrec`, which the static census ranked first, is 0.09% of dispatches: three orders of magnitude below where counting source sites placed it. **Sizing this work from the static census would have built a general mechanism to speed up the wrong thing.**

## Sequencing costs more than its own dispatches

`$sequence` is the report's derivation — `seq2` plus an `aux` that evaluates the head and recurses on `(eval (cons aux tail) env)`. Each element costs roughly a `null?`, two `eval`s and a `cons`, and those are the top of the overall table (`null?` 26.0%, `eval` 18.7%, `cons` 9.4%).

I've labelled this an **inference, not an attribution** — the census keys on the dispatched name and doesn't record the caller. Two things make it worth acting on: the arithmetic is the right order (549k sequencing dispatches against 1.68M `eval`, 845k `cons`), and the census *undercounts* sequencing, because `aux` recurses through `(cons aux tail)` — a computed operator that never reaches a name-keyed call site.

## The decisive argument is shape, not size

The case for the general mechanism is that it generalises. It doesn't. A guard only pays if the compiler knows what to lower the combiner *into*, and that knowledge is hardcoded per feature — so it can only recognise combiners the compiler already understands, which is the standard library and nothing else. Speeding up user-defined combiners means inlining an arbitrary vau body: a different technique that wouldn't use this machinery.

So the general mechanism's reach is *exactly the set we could instead make primitive*, and R-1RK 1.3.2 permits that:

> The derivation code is not considered part of the definition of the feature, so implementations are not expected to duplicate the exact behavior of the code.

Both routes end at the same lowered `CSeq`. One adds an identity scheme for compound operatives, a bootstrap stamping pass, a wider `BindingGuard`, and a redefinition policy. The other adds a primitive and one `PrimitiveIdentity` case.

## What the ADR proposes instead

Promote `$sequence` to a primitive with a `PrimitiveSequence` identity and lower it to `CSeq` in `analyzeGuarded` under the existing guard. `CSeq` already exists and `compileToFunc` already compiles it — today it is emitted only by the package decoder and the partial evaluator, never by the analyzer.

`let` is the only other candidate above 1%, and should be decided on its own evidence *after* sequencing, since removing that traffic changes the profile everything else is measured against.

## Risks recorded

Sequencing is load-bearing (every operative body is one). 5.1.1's tail-context requirement needs the structural test ADR 0004 phase 2 established — continuation depth — not a result check. The derivation stops being exercised once it is only a fallback, so it needs a test that drives it directly. And eight examples are not a workload survey: the 7.2% ceiling is the number to distrust first if the result disappoints.

The ADR also states what a null result would mean: not "now build the general mechanism", but that dispatch isn't where the time goes and the remaining 78.4% is what to profile.

Status is `Proposed` — no code changes. Also cross-links phase 5's note in ADR 0004, which guessed at `let`/`letrec`, to what the measurement found. Docs only; 394 tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789671584&installation_model_id=427656&pr_number=75&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F75&signature=a52a9a84646f484ced2063620e4fb09b1260893032c44adc8d4803f129ab50e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->