### PR TITLE
Make $sequence a primitive and lower it to CSeq (ADR 0007)

### DIFF
--- a/IronKernel.Runtime/Ast.fs
+++ b/IronKernel.Runtime/Ast.fs
@@ -202,6 +202,7 @@ module Ast =
     and PrimitiveIdentity =
         | PrimitiveIf
         | PrimitiveDefine
+        | PrimitiveSequence
     and PrimitiveOperativeRecord = {
         identity : PrimitiveIdentity option
         invoke : LispVal -> LispVal -> LispVal list -> Step

--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -526,6 +526,27 @@
                 bounceEval env (makeCPS env cont cps) cond
             |_ -> signal cont (NumArgs(3,args))
 
+        /// R-1RK 5.1.1. Evaluates its operands left to right in the dynamic
+        /// environment; the last is a tail context, and no operands gives inert.
+        ///
+        /// Primitive rather than derived (ADR 0007). The report's derivation builds
+        /// this from `seq2` and an `aux` operative that recurses on
+        /// `(eval (cons aux tail) env)`, so each element costs a `null?`, two `eval`s
+        /// and a `cons` beyond the work itself. 1.3.2 says the derivation "is not
+        /// considered part of the definition of the feature", so a primitive conforms;
+        /// the derivation is kept as a test rather than as the implementation.
+        ///
+        /// The last operand is evaluated against the caller's own continuation, which
+        /// is what makes it a tail context -- the same shape `Helpers.Seq` uses for a
+        /// compiled `CSeq`.
+        let rec sequenceForms env cont args =
+            match args with
+            | [] -> More(fun () -> continueEvalStep env cont Inert)
+            | [final] -> bounceEval env cont final
+            | head :: rest ->
+                let next e c _ _ = sequenceForms e c rest
+                bounceEval env (makeCPS env cont next) head
+
         let loadAndEval env cont = function
             | _ when not (has SourceLoading env) ->
                 signal cont (CapabilityDenied "source loading requires SourceLoading")
@@ -734,6 +755,7 @@
         let primitiveOperatives : (string * (LispVal -> LispVal -> LispVal list -> Step)) list =
             [
                   ("vau"    , vau);
+                  ("sequence", sequenceForms);
                   ("$binds?", bindsPredicate);
                   ("define" , define);
                   ("if"     , if_then_else);
@@ -2525,6 +2547,7 @@
             let operativeIdentity = function
                 | "if" -> Some PrimitiveIf
                 | "define" -> Some PrimitiveDefine
+                | "sequence" -> Some PrimitiveSequence
                 | _ -> None
             let makeOperative (name, func) =
                 name,

--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -754,3 +754,30 @@ let ``operative bodies are compiled on first application`` () =
         let compiled = (operativeOf "twice").compiledBody
         assertEval env "(twice 1)" (Obj (2 :> obj))
         Assert.Same(Option.get compiled, Option.get (operativeOf "twice").compiledBody))
+
+[<Fact>]
+let ``the last form of a compiled sequence is a tail context`` () =
+    // R-1RK 5.1.1 requires the last element of $sequence to be evaluated as a tail
+    // context. The derivation got that from `aux`'s structure; the primitive and the
+    // `CSeq` lowering (ADR 0007) each have to preserve it deliberately, and the
+    // trampoline hides a mistake -- the answer is still right and the CLR stack still
+    // flat, so only the continuation captured at the deepest point shows the leak.
+    withKernel (fun env ->
+        ignore (evalIn env "(define captured (vector 0))")
+        defineCompiledProcedure
+            env
+            "countdown"
+            "(n)"
+            [ "(if (eqv? n 0)
+                   (sequence 1 (vector-set! captured 0 (call/cc (lambda (k) k))))
+                   (sequence 1 (countdown (- n 1))))" ]
+
+        let depthAfter iterations =
+            ignore (evalIn env (sprintf "(countdown %d)" iterations))
+            match evalIn env "(vector-ref captured 0)" with
+            | Continuation _ as continuation -> continuationDepth continuation
+            | other -> failwithf "expected a captured continuation, got %A" other
+
+        let shallow = depthAfter 10
+        let deep = depthAfter 1000
+        Assert.Equal(shallow, deep))

--- a/IronKernel.Tests/KernelConformanceTests.fs
+++ b/IronKernel.Tests/KernelConformanceTests.fs
@@ -266,7 +266,17 @@ let private behaviouralChecks () : (string * string list) list = [
                 "(eqv? (car ((vau xs _ xs) foo)) 'foo)" ]
     "4.10.4", [ "(eqv? ((wrap (vau (x) _ x)) (+ 1 2)) 3)" ]
     "4.10.5", [ "(eqv? ((unwrap (lambda (x) x)) bar) 'bar)" ]
-    "5.1.1", [ "(eqv? (sequence 1 2 3) 3)" ]
+    // Primitive here rather than derived (ADR 0007); 1.3.2 permits that, since "the
+    // derivation code is not considered part of the definition of the feature".
+    "5.1.1", [ "(eqv? (sequence 1 2 3) 3)"
+               // "If (objects) is the empty list, the result is inert."
+               "(inert? (sequence))"
+               // Left to right, and an operative, so a later element sees what an
+               // earlier one defined.
+               "(let ((v (vector 0 0)))"
+               + " (sequence (sequence (vector-set! v 0 1) (vector-set! v 1 2))"
+               + " (and? (=? (vector-ref v 0) 1) (=? (vector-ref v 1) 2))))"
+               "(=? ((lambda () (sequence (define local 5) local))) 5)" ]
     "5.2.1", [ "(eqv? (car (list 7 8)) 7)"; "(eqv? (length (list 7 8)) 2)" ]
     "5.2.2", [ "(eqv? (cdr (list* 1 2)) 2)" ]
     "5.3.1", [ "(eqv? (car ((vau xs _ xs) foo)) 'foo)" ]

--- a/IronKernel.Tests/StdlibTests.fs
+++ b/IronKernel.Tests/StdlibTests.fs
@@ -84,3 +84,72 @@ let ``$and? and $or? stop as soon as the result is decided`` () =
         "($or? #t (sequence (vector-set! trace 1 1) #f))", Bool true
         "(vector-ref trace 1)", Obj 0
     ]
+
+[<Fact>]
+let ``sequence follows 5.1.1`` () =
+    // Primitive since ADR 0007. The behaviour the report specifies is unchanged by
+    // that: left to right in the dynamic environment, last value returned, inert for
+    // no operands. (The tail-context half of 5.1.1 is not observable from a result,
+    // and is checked structurally in CompilerTests.)
+    evalSessionKernel [
+        "(sequence 1 2 3)", Obj 3
+        "(sequence 7)", Obj 7
+        "(sequence)", Inert
+        "($sequence 1 2 3)", Obj 3
+        // Left to right, and every element really is evaluated.
+        "(define trace (vector 0 0 0))", Inert
+        "(sequence (vector-set! trace 0 1) (vector-set! trace 1 2) (vector-set! trace 2 3))", Inert
+        "(vector-ref trace 0)", Obj 1
+        "(vector-ref trace 2)", Obj 3
+        // It is an operative: operands arrive unevaluated, so a later element can
+        // depend on a definition an earlier one made.
+        "(operative? sequence)", Bool true
+        "((lambda () (sequence (define local 5) local)))", Obj 5
+    ]
+
+[<Fact>]
+let ``a redefined sequence is used instead of the primitive`` () =
+    // The compiled form is guarded on the binding still holding the primitive, so a
+    // program that rebinds the name must get its own combiner rather than the
+    // lowered `CSeq`. Without the guard the lowering would silently win.
+    evalSessionKernel [
+        "((lambda () (define sequence (lambda xs 99)) (sequence 1 2 3)))", Obj 99
+        // The shadowing is local: the outer binding still means the primitive.
+        "(sequence 1 2 3)", Obj 3
+    ]
+
+[<Fact>]
+let ``the report's derivation of $sequence still behaves like the primitive`` () =
+    // ADR 0007 replaced this derivation with a primitive, so nothing exercises it any
+    // more and it could rot unnoticed. R-1RK 5.1.1's derivation, transcribed, and
+    // checked against the primitive on the cases that distinguish sequencing:
+    // ordering, the returned value, and the empty case.
+    evalSessionKernel [
+        """(define derived-sequence
+              ((wrap
+                 (vau (seq2) _
+                      (seq2
+                        (define aux
+                          (vau (head & tail) env
+                               (if (null? tail)
+                                 (eval head env)
+                                 (seq2
+                                   (eval head env)
+                                   (eval (cons aux tail) env)))))
+                        (vau body env
+                             (if (null? body)
+                               #inert
+                               (eval (cons aux body) env))))))
+               (vau (first second) env
+                    ((wrap (vau _ _ (eval second env)))
+                     (eval first env)))))""", Inert
+        "(derived-sequence 1 2 3)", Obj 3
+        "(derived-sequence 7)", Obj 7
+        "(inert? (derived-sequence))", Bool true
+        "(define trace (vector 0 0))", Inert
+        "(derived-sequence (vector-set! trace 0 1) (vector-set! trace 1 2))", Inert
+        "(vector-ref trace 0)", Obj 1
+        "(vector-ref trace 1)", Obj 2
+        // Unevaluated operands, as for the primitive.
+        "((lambda () (derived-sequence (define local 5) local)))", Obj 5
+    ]

--- a/IronKernel/Analyze.fs
+++ b/IronKernel/Analyze.fs
@@ -27,12 +27,14 @@ module Analyze =
         | AnalyzeGuardedForm of LispVal
         | BuildGuardedIf of BindingGuard * CoreExpr
         | BuildGuardedDefine of BindingGuard * string * CoreExpr
+        | BuildGuardedSequence of BindingGuard * int * CoreExpr
         | BuildGuardedOperate of LispVal list
 
     type private LocatedAnalysisWork =
         | AnalyzeLocated of Source.LocatedValue
         | BuildLocatedIf of SourceSpan * string option * BindingGuard * CoreExpr
         | BuildLocatedDefine of SourceSpan * string option * BindingGuard * string * CoreExpr
+        | BuildLocatedSequence of SourceSpan * string option * BindingGuard * int * CoreExpr
         | BuildLocatedOperate of SourceSpan * string option * LispVal list
 
     let analyze (value: LispVal) : CoreExpr =
@@ -142,6 +144,19 @@ module Analyze =
                             :: BuildGuardedDefine(guard, name, fallback)
                             :: pending
                     | None -> completed <- fallback :: completed
+                  // R-1RK 5.1.1, primitive since ADR 0007. Lowering it compiles the
+                  // elements instead of handing them to the runtime as raw syntax,
+                  // which is the same reason `if` is lowered. `CSeq` gives the last
+                  // element the caller's own continuation, so the tail context 5.1.1
+                  // requires survives compilation.
+                  | (Atom ("sequence" | "$sequence" as name) :: forms) ->
+                    let fallback = COperate(CVar name, forms)
+                    match tryCreateBindingGuard env name PrimitiveSequence with
+                    | Some guard ->
+                        pending <-
+                            (forms |> List.map AnalyzeGuardedForm)
+                            @ (BuildGuardedSequence(guard, List.length forms, fallback) :: pending)
+                    | None -> completed <- fallback :: completed
                   | Atom name :: operands ->
                     // Prefer a real binding over CLR call sugar (same rule as Eval).
                     match getVar' env name with
@@ -166,6 +181,8 @@ module Analyze =
                 | [rhs] ->
                     completed <- CGuarded(guard, CDefine(CVar name, rhs), fallback) :: completed
                 | _ -> invalidOp "Guarded definition analysis is incomplete"
+            | BuildGuardedSequence (guard, count, fallback) ->
+                completed <- CGuarded(guard, CSeq(takeCompleted count), fallback) :: completed
             | BuildGuardedOperate operands ->
                 match takeCompleted 1 with
                 | [operator] -> completed <- COperate(operator, operands) :: completed
@@ -233,6 +250,12 @@ module Analyze =
                             AnalyzeLocated rhs
                             :: BuildLocatedDefine(located.span, sourceLine, guard, name, fallback)
                             :: pending
+                    | Source.LList (_ :: forms), CGuarded (guard, CSeq _, fallback) ->
+                        pending <-
+                            (forms |> List.map AnalyzeLocated)
+                            @ (BuildLocatedSequence(
+                                located.span, sourceLine, guard, List.length forms, fallback)
+                               :: pending)
                     | Source.LList (operator :: operands), COperate (_, rawOperands) ->
                         let isClrSugar =
                             match operator.kind with
@@ -265,6 +288,10 @@ module Analyze =
                         CLocated(span, sourceLine, CGuarded(guard, CDefine(CVar name, rhs), fallback))
                         :: completed
                 | _ -> invalidOp "Located definition analysis is incomplete"
+            | BuildLocatedSequence (span, sourceLine, guard, count, fallback) ->
+                completed <-
+                    CLocated(span, sourceLine, CGuarded(guard, CSeq(takeCompleted count), fallback))
+                    :: completed
             | BuildLocatedOperate (span, sourceLine, operands) ->
                 match takeCompleted 1 with
                 | [operator] ->
@@ -327,6 +354,8 @@ module Analyze =
                     completed <- ofList (Atom "if" :: operands) :: completed
                 | CIntrinsicOperate(PrimitiveDefine, operands) ->
                     completed <- ofList (Atom "define" :: operands) :: completed
+                | CIntrinsicOperate(PrimitiveSequence, operands) ->
+                    completed <- ofList (Atom "sequence" :: operands) :: completed
                 | CGuarded(_, _, fallback)
                 | CContractFold(_, _, fallback) ->
                     pending <- Reify fallback :: pending

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -173,7 +173,8 @@ module Compiler =
                         KernelFunc(fun env cont ->
                             match identity with
                             | PrimitiveIf -> Runtime.if_then_else env cont operands
-                            | PrimitiveDefine -> Runtime.define env cont operands)
+                            | PrimitiveDefine -> Runtime.define env cont operands
+                            | PrimitiveSequence -> Runtime.sequenceForms env cont operands)
                         :: completed
                 | CGuarded (guard, specialized, fallback) ->
                     pending <-

--- a/IronKernel/CorePackage.fs
+++ b/IronKernel/CorePackage.fs
@@ -101,11 +101,13 @@ module CorePackage =
     let private writeIdentity (writer: BinaryWriter) = function
         | PrimitiveIf -> writer.Write 0uy
         | PrimitiveDefine -> writer.Write 1uy
+        | PrimitiveSequence -> writer.Write 2uy
 
     let private readIdentity (reader: BinaryReader) =
         match reader.ReadByte() with
         | 0uy -> PrimitiveIf
         | 1uy -> PrimitiveDefine
+        | 2uy -> PrimitiveSequence
         | tag -> raise (InvalidDataException(sprintf "Unknown IKC primitive identity: %d" tag))
 
     let private writePosition (writer: BinaryWriter) position =

--- a/IronKernel/StaticCompiler.fs
+++ b/IronKernel/StaticCompiler.fs
@@ -160,6 +160,7 @@ module StaticCompiler =
                         match guard.expectedIdentity with
                         | PrimitiveIf -> "PrimitiveIf"
                         | PrimitiveDefine -> "PrimitiveDefine"
+                        | PrimitiveSequence -> "PrimitiveSequence"
                     Some(
                         generated(
                             "runGuard env cont " + quote guard.name + " " + identity

--- a/IronKernel/kernel.ikr
+++ b/IronKernel/kernel.ikr
@@ -10,24 +10,11 @@
 ; If ⟨objects⟩ is a nonempty finite list, its last element is evaluated as a tail context. If ⟨objects⟩ is the empty list, the result is inert.
 ; Known in other schemes as `begin` or `block`.
 
-(define sequence
-  ((wrap
-     (vau (seq2) _
-          (seq2
-            (define aux
-              (vau (head & tail) env
-                   (if (null? tail)
-                     (eval head env)
-                     (seq2
-                       (eval head env)
-                       (eval (cons aux tail) env)))))
-            (vau body env
-                 (if (null? body)
-                   #inert
-                   (eval (cons aux body) env))))))
-   (vau (first second) env
-        ((wrap (vau _ _ (eval second env)))
-         (eval first env)))))
+; Primitive since ADR 0007, not derived. The report's derivation -- kept as a test
+; in StdlibTests rather than as the implementation -- costs a `null?`, two `eval`s
+; and a `cons` per element, and a dispatch census put sequencing at 84% of all
+; derived-operative dispatches. 1.3.2 permits this: "the derivation code is not
+; considered part of the definition of the feature".
 
 ; (list . objects)
 ; The list applicative returns objects.

--- a/docs/adr/0007-identity-for-derived-combiners.md
+++ b/docs/adr/0007-identity-for-derived-combiners.md
@@ -1,6 +1,6 @@
 # ADR 0007: Identity for derived combiners
 
-Status: Proposed
+Status: Accepted — sequencing implemented
 
 ## Decision
 
@@ -121,6 +121,35 @@ analyzer. So the compiler side is a lowering rule, not a new node.
 `let` is the only other candidate above 1%, and it is a further decision to take on
 its own evidence once sequencing is done, because removing the sequencing traffic
 changes the profile everything else is measured against.
+
+## Outcome
+
+Implemented for `$sequence`. The gain is much larger than the 6.1% dispatch share,
+which is what the inference above predicted: the derivation's cost was mostly the
+`eval`/`cons`/`null?` traffic it generated per element, not its own dispatches.
+
+| | master | primitive |
+|---|---:|---:|
+| `constant-width-amb.ikr`, median of 3 | 16.19 s | **11.56 s (-28.6%)** |
+| `LambdaLiteralCall` | 32,881 ns / 135.1 KB | **20,804 ns / 87.2 KB (-37% / -35%)** |
+| `NamedLambdaCall` | 744.7 ns | 739.2 ns |
+| `EffectHandlerResume` | 2695.4 ns | 2659.7 ns |
+
+`LambdaLiteralCall` builds and applies a combiner once, which is what every `let`
+expands to, so it is the most sequence-dense benchmark in the set; the rest are flat
+to 2% better. `CompilerBenchmarks` is unchanged (146.9 / 426.7 / 183.1 / 52.2 ns),
+which is the check that nothing was added to the ordinary path.
+
+The three risks named above were all real work rather than formalities. The tail
+context needed the structural test, and that test was checked against a negative
+control: moving the recursion out of tail position takes the captured continuation's
+depth from 23 to 2003, so it discriminates. The derivation is kept in
+`StdlibTests` and checked against the primitive, so it cannot rot silently. And
+`sequence` being load-bearing is why the suite and the twelve examples are the real
+evidence here -- 398 tests, and every example unchanged.
+
+The `let` question is now open on its own terms, and the profile it should be
+measured against is this one, not the one in this ADR.
 
 ## Risks
 

--- a/docs/kernel-conformance.md
+++ b/docs/kernel-conformance.md
@@ -142,7 +142,7 @@ divergences before taking any row as a claim of conformance.
 
 | Entry | Feature | Module | Status | Notes |
 |---|---|---|---|---|
-| 5.1.1 | `$sequence` | Control | `verified` | 1 behavioural check(s) |
+| 5.1.1 | `$sequence` | Control | `verified` | 4 behavioural check(s) |
 | 5.2.1 | `list` | Pairs and lists | `verified` | 2 behavioural check(s) |
 | 5.2.2 | `list*` | Pairs and lists | `verified` | 1 behavioural check(s) |
 | 5.3.1 | `$vau` | Combiners | `verified` | 1 behavioural check(s) |


### PR DESCRIPTION
[ADR 0007](docs/adr/0007-identity-for-derived-combiners.md) measured derived-operative dispatch at 7.2% and found 84% of it was sequencing — then argued the real cost was not those dispatches but the traffic the derivation *generates*. `$sequence` is built from `seq2` plus an `aux` that recurses on `(eval (cons aux tail) env)`, so each element costs a `null?`, two `eval`s and a `cons`.

**The prediction holds, and by a wide margin.**

| | master | primitive |
|---|---:|---:|
| `constant-width-amb.ikr`, median of 3 | 16.19 s | **11.56 s (-28.6%)** |
| `LambdaLiteralCall` | 32,881 ns / 135.1 KB | **20,804 ns / 87.2 KB (-37% / -35%)** |
| `NamedLambdaCall` | 744.7 ns | 739.2 ns |
| `EffectHandlerResume` | 2695.4 ns | 2659.7 ns |
| `CompilerBenchmarks` | 147.3 / 432.4 / 185.0 / 54.1 ns | 146.9 / 426.7 / 183.1 / 52.2 ns |

28.6% off the heaviest workload, against the 6.1% of dispatches sequencing accounted for — which is the point the ADR made about generated traffic. `LambdaLiteralCall` builds and applies a combiner once, which is what every `let` expands to, so it is the most sequence-dense benchmark in the set. The rest are flat to 2% better, and `CompilerBenchmarks` is unchanged — the check that nothing was added to the ordinary path.

## What changed

`$sequence` becomes a primitive operative carrying `PrimitiveSequence`, and `analyzeGuarded` lowers `(sequence . forms)` to `CSeq` under the existing binding guard, so the elements are compiled instead of handed to the runtime as raw syntax. `CSeq` already existed and `compileToFunc` already compiled it — the analyzer had simply never emitted it. Both analyzers lower it, as ADR 0004 phase 4 established they should agree.

R-1RK 1.3.2 permits the move: "the derivation code is not considered part of the definition of the feature, so implementations are not expected to duplicate the exact behavior of the code."

Adding the identity case made the type checker name every site that handles `PrimitiveIdentity` exhaustively — compiler, reifier, package codec, static emitter. That is how all four were found, rather than by grepping.

## The three risks the ADR named were all real work

- **Tail context (5.1.1).** A missed tail context still returns the right answer and keeps the CLR stack flat, so it is only visible structurally. The test captures a continuation at the deepest point and asserts its depth is unchanged between 10 and 1000 iterations — and I validated the test against a negative control: moving the recursion out of tail position takes the depth from **23 to 2003**. It discriminates.
- **The derivation stops being exercised.** Nothing runs it now, so it is kept in `StdlibTests`, transcribed from the report, and checked against the primitive on ordering, returned value, the empty case and unevaluated operands.
- **`sequence` is load-bearing.** Every operative body is one, which is why the suite and the twelve examples are the real evidence. A redefined `sequence` is also tested to beat the lowering, since without the guard it would silently lose.

## Verification

- clean `--no-incremental` rebuild, 0 warnings
- 398 tests pass
- all 12 examples run (`yingyang.ikr` skipped, non-terminating by design)
- CLR fault sweep: 0 faults, 172 signalled, 47 returned
- 5.1.1 goes from one behavioural check to four; 135/135 entries, 44/44 modules, eleven divergences

ADR 0007 is now `Accepted — sequencing implemented`, with the outcome recorded. The `let` question (1.0% of dispatches) is open on its own terms, and should be measured against *this* profile rather than the one in the ADR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789672883&installation_model_id=427656&pr_number=76&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F76&signature=3fab5881584457576d3fc986fdea35ee6ac093cd4049f2d28c2e126212642ce1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->