### PR TITLE
Make `let` a primitive (ADR 0007)

### DIFF
--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -547,6 +547,54 @@
                 let next e c _ _ = sequenceForms e c rest
                 bounceEval env (makeCPS env cont next) head
 
+        /// R-1RK 5.10.1. Evaluates each binding's expression in the dynamic
+        /// environment, left to right, then evaluates the body in a fresh child of
+        /// that environment with the definiends bound.
+        ///
+        /// Primitive rather than derived (ADR 0007). The derivation builds
+        /// `((lambda (formals) . body) . expressions)` and evaluates it, so every
+        /// `let` constructs a fresh operative -- and a fresh operative has no
+        /// compiled body, so ADR 0004 phase 3's memo never hits and the body is
+        /// compiled again on the single application it will ever receive. On the
+        /// heaviest example that was 90,583 of 339,599 body compilations in one run.
+        ///
+        /// Binding reuses `bindArgsStep`, so a definiend tree destructures exactly as
+        /// it does for an operative's formals, and the body runs through
+        /// `sequenceForms`, so its last form keeps the tail context 5.10.1 inherits
+        /// from the lambda it used to expand into.
+        let letForms env cont args =
+            match args with
+            | bindings :: body ->
+                match bindings with
+                | List binds ->
+                    let split =
+                        binds
+                        |> List.map (function
+                            // `(formal expression)`, read exactly as the derivation's
+                            // `car`/`cadr` read it.
+                            | List (formal :: expression :: _) -> Some(formal, expression)
+                            | _ -> None)
+                    if List.exists Option.isNone split then
+                        signal cont (BadSpecialForm("invalid let bindings", bindings))
+                    else
+                        let pairs = List.map Option.get split
+                        let formals = ofList (List.map fst pairs)
+                        let rec evaluateRemaining c evaluatedRev remaining =
+                            match remaining with
+                            | [] ->
+                                let child = newEnv [env]
+                                match run (bindArgsStep child (newContinuation env) formals
+                                                         (List.rev evaluatedRev)) with
+                                | Choice1Of2 error -> signal c error
+                                | Choice2Of2 _ -> sequenceForms child c body
+                            | expression :: rest ->
+                                let collect _ nextCont value _ =
+                                    evaluateRemaining nextCont (value :: evaluatedRev) rest
+                                More(fun () -> bounceEval env (makeCPS env c collect) expression)
+                        evaluateRemaining cont [] (List.map snd pairs)
+                | found -> signal cont (TypeMismatch("list", found))
+            | [] -> signal cont (NumArgs(1, args))
+
         let loadAndEval env cont = function
             | _ when not (has SourceLoading env) ->
                 signal cont (CapabilityDenied "source loading requires SourceLoading")
@@ -756,6 +804,7 @@
             [
                   ("vau"    , vau);
                   ("sequence", sequenceForms);
+                  ("let"    , letForms);
                   ("$binds?", bindsPredicate);
                   ("define" , define);
                   ("if"     , if_then_else);

--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -781,3 +781,27 @@ let ``the last form of a compiled sequence is a tail context`` () =
         let shallow = depthAfter 10
         let deep = depthAfter 1000
         Assert.Equal(shallow, deep))
+
+[<Fact>]
+let ``the last form of a let body is a tail context`` () =
+    // `let` used to expand into a lambda application, which gave it a tail context
+    // for free. The primitive (ADR 0007) has to keep it, and as for `sequence` the
+    // trampoline hides a mistake: the answer stays right and the stack flat, so only
+    // the captured continuation's depth shows a retained frame per iteration.
+    withKernel (fun env ->
+        ignore (evalIn env "(define captured (vector 0))")
+        defineCompiledProcedure
+            env
+            "countdown"
+            "(n)"
+            [ "(if (eqv? n 0)
+                   (let ((x 1)) (vector-set! captured 0 (call/cc (lambda (k) k))))
+                   (let ((x 1)) (countdown (- n 1))))" ]
+
+        let depthAfter iterations =
+            ignore (evalIn env (sprintf "(countdown %d)" iterations))
+            match evalIn env "(vector-ref captured 0)" with
+            | Continuation _ as continuation -> continuationDepth continuation
+            | other -> failwithf "expected a captured continuation, got %A" other
+
+        Assert.Equal(depthAfter 10, depthAfter 1000))

--- a/IronKernel.Tests/StdlibTests.fs
+++ b/IronKernel.Tests/StdlibTests.fs
@@ -153,3 +153,48 @@ let ``the report's derivation of $sequence still behaves like the primitive`` ()
         // Unevaluated operands, as for the primitive.
         "((lambda () (derived-sequence (define local 5) local)))", Obj 5
     ]
+
+[<Fact>]
+let ``let follows 5.10.1`` () =
+    // Primitive since ADR 0007, and the behaviour the report specifies is unchanged:
+    // each expression is evaluated in the dynamic environment, then the body runs in
+    // a fresh child with the definiends bound.
+    evalSessionKernel [
+        "(let ((x 2) (y 3)) (* x y))", Obj 6
+        "(let () 42)", Obj 42
+        // Several body forms, evaluated in order, last one returned.
+        "(let ((x 1)) (define y 2) (+ x y))", Obj 3
+        "(let ((v (vector 0))) (vector-set! v 0 7) (vector-ref v 0))", Obj 7
+        // The expressions see the *enclosing* scope, not the bindings being made --
+        // this is what separates let from let*.
+        "(let ((x 1)) (let ((x 2) (y x)) y))", Obj 1
+        "(let* ((x 3) (y x)) (+ x y))", Obj 6
+        // Left to right.
+        """(let ((v (vector 0)))
+              (let ((a (vector-set! v 0 1)) (b (vector-ref v 0))) b))""", Obj 1
+        // A definiend tree destructures, exactly as an operative's formals do.
+        "(let (((a b) (list 1 2))) (+ a b))", Obj 3
+        // The body is a child: a definition inside does not escape.
+        "((lambda () (define z 1) (let ((q 2)) (define z 5)) z))", Obj 1
+        // letrec still works, since it expands through let.
+        "(letrec ((f (lambda (n) (if (zero? n) 0 (f (- n 1)))))) (f 5))", Obj 0
+    ]
+
+[<Fact>]
+let ``the report's derivation of let still behaves like the primitive`` () =
+    // ADR 0007 replaced this with a primitive, so nothing exercises the derivation
+    // now. Transcribed and checked on the cases that distinguish let: scope of the
+    // expressions, several body forms, destructuring, and the empty binding list.
+    evalSessionKernel [
+        """(define derived-let
+              (vau (binds & body) env
+                (eval (cons
+                        (list* lambda (cons (map car binds) body))
+                        (map cadr binds))
+                    env)))""", Inert
+        "(derived-let ((x 2) (y 3)) (* x y))", Obj 6
+        "(derived-let () 42)", Obj 42
+        "(derived-let ((x 1)) (define y 2) (+ x y))", Obj 3
+        "(let ((x 1)) (derived-let ((x 2) (y x)) y))", Obj 1
+        "(derived-let (((a b) (list 1 2))) (+ a b))", Obj 3
+    ]

--- a/IronKernel/kernel.ikr
+++ b/IronKernel/kernel.ikr
@@ -97,11 +97,14 @@
 (define cadr (lambda ((_ & (x & _))) x))
 (define cddr (lambda ((_ & (_ & x))) x))	  
 
-(define let (vau (binds & body) env
-    (eval (cons
-            (list* lambda (cons (map car binds) body))
-            (map cadr binds))
-        env)))
+; Primitive since ADR 0007, not derived. The derivation below built
+; ((lambda (formals) . body) . expressions) and evaluated it, so every `let`
+; constructed a fresh operative whose body was then compiled for its single
+; application -- 90,583 of 339,599 body compilations in one run of
+; constant-width-amb. Kept as a test in StdlibTests.
+;
+; (define let (vau (binds & body) env
+;     (eval (cons (list* lambda (cons (map car binds) body)) (map cadr binds)) env)))
 
 (define any?
   (lambda (f xs)

--- a/docs/adr/0007-identity-for-derived-combiners.md
+++ b/docs/adr/0007-identity-for-derived-combiners.md
@@ -1,6 +1,6 @@
 # ADR 0007: Identity for derived combiners
 
-Status: Accepted — sequencing implemented
+Status: Accepted — sequencing and `let` implemented
 
 ## Decision
 
@@ -150,6 +150,50 @@ evidence here -- 398 tests, and every example unchanged.
 
 The `let` question is now open on its own terms, and the profile it should be
 measured against is this one, not the one in this ADR.
+
+## Outcome, `let`
+
+Re-censused against the post-sequencing profile first, as that paragraph asked.
+Total dispatches over the same eight programs fell from 9.0M to 5.69M, `eval` fell
+70% -- confirming sequencing generated most of it -- and derived operatives fell from
+7.2% to 1.8% of a smaller total, with `let` now 89.8% of that slice.
+
+One prediction in this ADR was wrong and is worth recording. It attributed `cons`
+traffic to sequencing along with `eval`; `cons` is 844,535 both before and after,
+unchanged. The `eval` half of the inference held, the `cons` half did not.
+
+`let` at 1.62% of dispatches did not look worth much. The dispatch count was the
+wrong measure, and the reason is specific: the derivation builds
+`((lambda (formals) . body) . expressions)`, so every `let` constructs a fresh
+operative -- and a fresh operative's `compiledBody` is `None`, so ADR 0004 phase 3's
+memo never hits and the body is compiled again for the single application it will
+ever receive. Counting those directly:
+
+| | before | after |
+|---|---:|---:|
+| body compilations, `constant-width-amb` | 339,599 | **47,260 (-86%)** |
+| wall clock, median of 3 | 11.56 s | **4.88 s (-58%)** |
+
+Against master before either change, that example is 16.19 s to 4.88 s, a 70%
+reduction. `ControlFlowBenchmarks` and `CompilerBenchmarks` are unchanged, which is
+expected -- neither exercises `let` in a hot path, so the gain shows up in programs
+rather than microbenchmarks.
+
+`let` binds through `bindArgsStep`, the same code an operative's formals use, so a
+definiend tree destructures identically; the body runs through `sequenceForms`, which
+keeps the tail context it used to inherit from the lambda. Both have tests, and the
+tail-context test was validated against a negative control the same way sequencing's
+was: 23 against 2003.
+
+**The residual is larger than either change.** 47,260 body compilations remain in one
+run, and `let` accounted for only 90,583 of the original 339,599 dispatches' worth.
+The rest come from other operatives built and applied once -- a `lambda` literal
+inside a loop is the obvious case. The general fix is to memoise compilation across
+operatives sharing a body, since the body `LispVal` is the same object every time the
+same source form is evaluated. That is not free: `compileLispValGuarded` takes the
+closure environment, and analysis-time decisions such as CLR-call sugar depend on what
+is bound there, so a cache keyed on body identity alone is unsound. It needs its own
+ADR.
 
 ## Risks
 


### PR DESCRIPTION
ADR 0007 said the `let` question should be measured against the profile left by the sequencing change, not the one in the ADR. Doing that first mattered — and not in the direction the dispatch counts suggested.

## The re-census, and a wrong prediction

Total dispatches over the same eight programs: **9.0M → 5.69M**, with `eval` down 70% — sequencing did generate most of it, as ADR 0007 inferred. Derived operatives fell from 7.2% to 1.8%, with `let` now 89.8% of that slice.

One prediction in the ADR was **wrong**, and is recorded as such: it attributed `cons` traffic to sequencing alongside `eval`. `cons` is 844,535 both before and after — unchanged. The `eval` half of the inference held; the `cons` half did not.

## Why 1.62% of dispatches was the wrong measure

That left `let` at 1.62% of dispatches, which does not look worth much. But the derivation builds `((lambda (formals) . body) . expressions)`, so **every `let` constructs a fresh operative** — and a fresh operative's `compiledBody` is `None`, so ADR 0004 phase 3's memo never hits and the body is compiled again for the single application it will ever receive.

Counting those directly:

| | before | after |
|---|---:|---:|
| body compilations, `constant-width-amb` | 339,599 | **47,260 (-86%)** |
| wall clock, median of 3 | 11.56 s | **4.88 s (-58%)** |

Against master before either change, that example goes **16.19 s → 4.88 s (-70%)**.

`ControlFlowBenchmarks` (20,501 / 728 / 2676 ns) and `CompilerBenchmarks` (149.9 / 416.1 / 183.1 / 52.6 ns) are unchanged — expected, since neither exercises `let` in a hot path. The gain is in programs, not microbenchmarks.

## The implementation

`let` evaluates each binding expression in the dynamic environment, left to right, then binds through `bindArgsStep` — the same code an operative's formals use, so a definiend tree destructures identically — and runs the body through `sequenceForms`, which keeps the tail context it used to inherit from the lambda.

## Tests

5.10.1's behaviour, including the scope of the binding expressions (`(let ((x 1)) (let ((x 2) (y x)) y))` is 1 — they see the enclosing scope, which is what separates `let` from `let*`), left-to-right order, definiend trees, empty bindings, several body forms, and that the body is a child that does not leak definitions. The derivation is kept in `StdlibTests` so it cannot rot now that nothing runs it.

The tail-context test was validated against a negative control, as sequencing's was: moving the recursion out of tail position takes the captured continuation's depth from **23 to 2003**.

## The residual is bigger than either change

**47,260 body compilations remain** in one run, and `let` only ever accounted for 90,583 of the original dispatches' worth. The rest come from other operatives built and applied once — a `lambda` literal inside a loop being the obvious case.

The general fix is to memoise compilation across operatives sharing a body, since the body `LispVal` is the same object each time the same source form is evaluated. It is **not free**: `compileLispValGuarded` takes the closure environment, and analysis-time decisions such as CLR-call sugar depend on what is bound there, so a cache keyed on body identity alone is unsound. That needs its own ADR rather than being done here.

## Verification

- clean `--no-incremental` rebuild, 0 warnings
- 401 tests pass
- all 12 examples run (`yingyang.ikr` skipped, non-terminating by design)
- CLR fault sweep: 0 faults, 172 signalled, 47 returned

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789674054&installation_model_id=427656&pr_number=77&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F77&signature=5508f2be294d0ebebf89f47fd3c32a1a8b768fbd63b91ab087be682160dce434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->