### PR TITLE
Align the two guard checks (ADR 0008 step 1)

### DIFF
--- a/IronKernel.Runtime/SymbolTable.fs
+++ b/IronKernel.Runtime/SymbolTable.fs
@@ -7,10 +7,15 @@ module SymbolTable =
     open Ast
     open Errors
 
+    /// What a guarded specialization needs is that `name` still denotes a primitive
+    /// with `expectedIdentity` in the environment the code is *running* in. The
+    /// binding cell it denoted when the form was compiled is deliberately not part of
+    /// that (ADR 0008): pinning it rejected a binding that had been rebound and
+    /// restored, and rejected every environment except the compiling one -- and the
+    /// package format never carried it anyway, since a decoded guard is rebuilt
+    /// against the decoding environment.
     type BindingGuard = {
         name : string
-        cellId : int64
-        version : int64
         expectedIdentity : PrimitiveIdentity
     }
 
@@ -231,23 +236,12 @@ module SymbolTable =
         | Some cell ->
             let state = cell.state
             if primitiveIdentity state.value = Some expectedIdentity then
-                Some
-                    { name = name
-                      cellId = cell.id
-                      version = state.version
-                      expectedIdentity = expectedIdentity }
+                Some { name = name; expectedIdentity = expectedIdentity }
             else None
         | _ -> None
 
-    let bindingGuardMatches env guard =
-        match tryResolveBindingCell env guard.name with
-        | ValueSome cell ->
-            let state = cell.state
-            cell.id = guard.cellId
-            && state.version = guard.version
-            && primitiveIdentity state.value = Some guard.expectedIdentity
-        | ValueNone -> false
-
+    /// The live guard test: does `name` denote a primitive with this identity in the
+    /// environment we are running in? Both compiled paths use this.
     let bindingHasPrimitiveIdentity env name expectedIdentity =
         match tryResolveBindingCell env name with
         | ValueSome cell -> primitiveIdentity cell.state.value = Some expectedIdentity

--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -164,12 +164,12 @@ let ``environment-aware analysis guards primitive forms`` () =
     // not hand them back to the interpreter.
     match analyzeGuarded env (parseOk "(if #t 1 2)") with
     | CGuarded (guard, CIf (CLit (Bool true), CLit _, CLit _), COperate (CVar "if", _)) ->
-        Assert.True(bindingGuardMatches env guard)
+        Assert.True(bindingHasPrimitiveIdentity env guard.name guard.expectedIdentity)
     | other -> failwith (showCore other)
 
     match analyzeGuarded env (parseOk "(define answer 42)") with
     | CGuarded (guard, CDefine (CVar "answer", CLit _), COperate (CVar "define", _)) ->
-        Assert.True(bindingGuardMatches env guard)
+        Assert.True(bindingHasPrimitiveIdentity env guard.name guard.expectedIdentity)
     | other -> failwith (showCore other)
 
 [<Fact>]

--- a/IronKernel.Tests/EnvironmentTests.fs
+++ b/IronKernel.Tests/EnvironmentTests.fs
@@ -59,19 +59,44 @@ let ``eval with explicit environment`` () =
         "(eval 'x e)", Obj 99
     ]
 
+let private matches env (guard: BindingGuard) =
+    bindingHasPrimitiveIdentity env guard.name guard.expectedIdentity
+
 [<Fact>]
-let ``binding guards track identity and version`` () =
+let ``binding guards track identity`` () =
     let env = freshEnv ()
     let guard =
         tryCreateBindingGuard env "if" PrimitiveIf
         |> Option.defaultWith (fun () -> failwith "missing primitive if guard")
 
-    Assert.True(bindingGuardMatches env guard)
+    Assert.True(matches env guard)
     ignore (defineVar env "unrelated" (Obj (1 :> obj)))
-    Assert.True(bindingGuardMatches env guard)
+    Assert.True(matches env guard)
 
     ignore (evalIn env "(define if (vau operands caller operands))")
-    Assert.False(bindingGuardMatches env guard)
+    Assert.False(matches env guard)
+
+[<Fact>]
+let ``a binding guard survives a rebind and restore`` () =
+    // The behaviour ADR 0008 step 1 changes. The guard asks whether the name denotes
+    // the primitive *now*, so a binding that was replaced and then set back to the
+    // primitive is specialized again. Pinning the cell version rejected it forever
+    // after, because assigning the cell bumps the version even when the value
+    // returns to what it was.
+    let env = freshEnv ()
+    let original =
+        match getVar' env "if" with
+        | Some value -> value
+        | None -> failwith "missing if binding"
+    let guard =
+        tryCreateBindingGuard env "if" PrimitiveIf
+        |> Option.defaultWith (fun () -> failwith "missing primitive if guard")
+
+    Assert.True(matches env guard)
+    ignore (evalIn env "(define if (vau operands caller operands))")
+    Assert.False(matches env guard)
+    ignore (defineVar env "if" original)
+    Assert.True(matches env guard)
 
 [<Fact>]
 let ``binding guards reject applicative-wrapped primitives`` () =
@@ -92,7 +117,7 @@ let ``binding guards reject applicative-wrapped primitives`` () =
         match resolveBindingCell env2 "if" with
         | Some cell ->
             cell.state <- { cell.state with value = Applicative bare }
-            Assert.False(bindingGuardMatches env2 guard)
+            Assert.False(matches env2 guard)
         | None -> failwith "missing if binding"
     | None -> failwith "missing if binding"
 

--- a/IronKernel/Compiler.fs
+++ b/IronKernel/Compiler.fs
@@ -234,8 +234,18 @@ module Compiler =
                 match takeCompleted 2 with
                 | [specialized; fallback] ->
                     completed <-
+                        // Name and identity, the same test `RuntimeDispatch.runGuard`
+                        // applies to generated code (ADR 0008 step 1). What the
+                        // specialization needs is that this name still denotes that
+                        // primitive here; the binding cell it happened to denote when
+                        // the form was compiled is not part of that. Pinning the cell
+                        // and version additionally rejected a binding that had been
+                        // rebound and restored, and would reject every environment but
+                        // the compiling one -- which is what a shared compiled body
+                        // would need to survive.
                         KernelFunc(fun env cont ->
-                            if bindingGuardMatches env guard then specialized.Invoke(env, cont)
+                            if bindingHasPrimitiveIdentity env guard.name guard.expectedIdentity
+                            then specialized.Invoke(env, cont)
                             else fallback.Invoke(env, cont))
                         :: completed
                 | _ -> invalidOp "Guarded compilation is incomplete"

--- a/IronKernel/Ir.fs
+++ b/IronKernel/Ir.fs
@@ -102,7 +102,7 @@ module Ir =
                     output.Append("(intrinsic ").Append(sprintf "%A" identity).Append(" ...)") |> ignore
                 | CGuarded(guard, specialized, _) ->
                     pending <-
-                        Append(sprintf "(guard %s@%d " guard.name guard.version)
+                        Append(sprintf "(guard %s " guard.name)
                         :: RenderCore specialized
                         :: Append ")"
                         :: pending

--- a/docs/adr/0008-caching-compiled-bodies.md
+++ b/docs/adr/0008-caching-compiled-bodies.md
@@ -101,7 +101,13 @@ Make compilation closure-independent, then the key is just the body cell:
 1. Align the compiled `CGuarded` with `runGuard`'s name-and-identity check, removing
    the `cellId`/`version` pinning. This is worth doing on its own terms -- it is the
    same conceptual guard implemented two ways, and the strict version also fails after
-   a rebind-and-restore that the permissive one survives.
+   a rebind-and-restore that the permissive one survives. **Done.** The two paths now
+   apply the same test, `BindingGuard` no longer carries the cell it was made against,
+   and `bindingGuardMatches` is gone. The pinning turned out to be vestigial in a
+   third place as well: the package format never wrote those fields, so a decoded
+   guard was already rebuilt against the decoding environment by name and identity.
+   Benchmarks are unchanged -- the resolution, not the comparison, is what the check
+   costs -- so this buys correctness of reach rather than speed.
 2. Decide the CLR-sugar question at run time rather than at analysis time, or record
    the dependency in the key.
 3. Only then add the cache, keyed on the first body form's `PairCell`, with the


### PR DESCRIPTION
The same conceptual guard was implemented twice:

- `RuntimeDispatch.runGuard` — used by generated and statically compiled code — re-resolves the name in the invoking environment and compares primitive identity.
- `Compiler.fs`'s `CGuarded` — used by the JIT path — called `bindingGuardMatches`, which *additionally* required the binding cell's `id` and `version` to equal what was seen at compile time.

## The strict half is stricter than the specialization needs

What `CIf`, `CDefine` or `CSeq` require is that the name denotes that primitive **in the environment the code is running in**. Which cell it denoted when the form was compiled is not part of that. Pinning it rejected two things it should not:

- **A binding rebound and then restored.** Assigning a cell bumps its version even when the value returns to what it was, so the guard failed permanently afterwards.
- **Any environment other than the compiling one** — which is exactly what a shared compiled body would need to survive, and so is the prerequisite for ADR 0008's cache.

It turned out to be vestigial in a third place too: the **package format never wrote those fields**. The decoder rebuilds the guard with `tryCreateBindingGuard` against the decoding environment, so a guard that crossed a package boundary already meant name-and-identity.

## What changed

`BindingGuard` loses `cellId` and `version`; `bindingGuardMatches` goes with them; `showCore` renders a guard without the version it no longer carries (it appears only in failure messages, nothing asserts on it).

`ContractGuard` is a separate type and keeps its own pinning — nothing here touches contract folding.

## Tests

They moved onto the check that actually runs, which is where the coverage belongs — they were asserting a function no longer reachable from production code. One test is added for the behaviour that changes:

```
guard created                    → matches
(define if (vau operands caller operands))  → does not match
restore the primitive            → matches again      ← previously false forever
```

The existing "compiled guard deoptimizes after primitive rebinding" test still passes, so rebinding to something else still falls back.

## Measurements

`GuardSpecializationBenchmarks`: 156.6 ns guarded against 184.7 unguarded; 192.8 against 217.1 on a fresh frame. `CompilerBenchmarks` flat (149.6 / 421.6 / 185.0 / 53.4 ns). Unchanged, as expected — the check costs the *resolution*, not the comparison. This buys reach, not speed.

## Verification

- clean `--no-incremental` rebuild, 0 warnings
- 402 tests pass
- all 12 examples run (`yingyang.ikr` skipped, non-terminating by design)
- CLR fault sweep: 0 faults, 172 signalled, 47 returned

ADR 0008 step 1 is marked done. Step 2 — the CLR-sugar decision, the actual soundness blocker — is untouched, and remains the real work before any body cache.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789675557&installation_model_id=427656&pr_number=79&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F79&signature=14166f6b83b07ac01908d581406ca12a7b9724be4d1588bfcda29253c3eaaaff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->