### PR TITLE
Decide CLR call sugar at run time, not at analysis time (ADR 0008 step 2)

### DIFF
--- a/IronKernel.Runtime/RuntimeDispatch.fs
+++ b/IronKernel.Runtime/RuntimeDispatch.fs
@@ -14,10 +14,20 @@ module RuntimeDispatch =
     /// instead of starting a nested one. Nesting would cost CLR stack on every
     /// Kernel tail call, trap escaping continuations behind a collapsed result,
     /// and turn `Await` into a blocking wait. See ADR 0004.
-    let appNamed env cont name (operands: LispVal[]) : Step =
+    /// A name that resolves to nothing may still be CLR call sugar. The interpreter
+    /// has always tried the binding first and the rewrite second; since ADR 0008
+    /// step 2 the compiled paths do the same, instead of the analyzer deciding it
+    /// from the environment it happened to compile against.
+    let private operateNamed env cont name operands =
         match getVar env name with
-        | Choice1Of2 error -> signal cont error
-        | Choice2Of2 combiner -> bounceOperate env cont combiner (Array.toList operands)
+        | Choice2Of2 combiner -> bounceOperate env cont combiner operands
+        | Choice1Of2 error ->
+            match ClrSugar.tryRewrite name operands with
+            | Some rewritten -> bounceEval env cont rewritten
+            | None -> signal cont error
+
+    let appNamed env cont name (operands: LispVal[]) : Step =
+        operateNamed env cont name (Array.toList operands)
 
     /// One call site's resolved binding, immutable once constructed so that it can
     /// be published to other threads with a single reference write.
@@ -120,10 +130,7 @@ module RuntimeDispatch =
                     dispatch resolved env cont
                 // Not a simple chain: dispatch without caching rather than storing a
                 // snapshot that could never be revalidated.
-                | ValueNone ->
-                    match getVar env name with
-                    | Choice1Of2 error -> signal cont error
-                    | Choice2Of2 combiner -> bounceOperate env cont combiner operands
+                | ValueNone -> operateNamed env cont name operands
 
     type GeneratedFunc = Func<LispVal, LispVal, Step>
 

--- a/IronKernel.Tests/CompilerTests.fs
+++ b/IronKernel.Tests/CompilerTests.fs
@@ -805,3 +805,24 @@ let ``the last form of a let body is a tail context`` () =
             | other -> failwithf "expected a captured continuation, got %A" other
 
         Assert.Equal(depthAfter 10, depthAfter 1000))
+
+[<Fact>]
+let ``analysis of a sugar-shaped name does not depend on the environment`` () =
+    // ADR 0008 step 2. "Prefer a real binding over CLR call sugar" is a question about
+    // the environment the code *runs* in, and the analyzer used to answer it from the
+    // environment it happened to compile against: the same source produced a plain
+    // combination where the name was bound and a desugared one where it was not.
+    // That is wrong if the two environments disagree, and it is the reason a compiled
+    // body cannot be reused across closures. Both now analyse identically, and
+    // `operateNamed` decides at run time.
+    let bound = freshEnv ()
+    // freshEnv is primitives only, so bind something that needs no library.
+    ignore (evalIn bound "(define a/b 5)")
+    let unbound = freshEnv ()
+    Assert.True((getVar' bound "a/b").IsSome)
+    Assert.True((getVar' unbound "a/b").IsNone)
+
+    let core env = showCore (analyzeGuarded env (parseOk "(a/b 1)"))
+    Assert.Equal(core bound, core unbound)
+    // And it is the plain combination, not the desugared shape, in both.
+    Assert.Contains("var:a/b", core unbound)

--- a/IronKernel.Tests/InteropTests.fs
+++ b/IronKernel.Tests/InteropTests.fs
@@ -186,3 +186,33 @@ let ``clr-open denied without RawClrInterop`` () =
     | Choice1Of2 (UnboundVar _)
     | Choice1Of2 (CapabilityDenied _) -> ()
     | other -> failwithf "expected denial, got %A" other
+
+[<Fact>]
+let ``a binding wins over a CLR sugar name shape`` () =
+    // R-1RK has no syntactically privileged operator names, so a binding whose name
+    // happens to look like CLR sugar is still just a binding. Since ADR 0008 step 2
+    // the compiled path decides this the same way the interpreter always has, at the
+    // point of call, rather than when the form was analysed.
+    evalSessionKernel [
+        "(define a/b (lambda (x) (* x 10)))", Inert
+        "(a/b 4)", Obj 40
+        // Inside a procedure body, which is the compiled path.
+        "((lambda () (a/b 4)))", Obj 40
+        // A body that is applied more than once, so the second call goes through the
+        // call site's cache rather than a fresh resolution.
+        "(define twice (lambda () (+ (a/b 1) (a/b 2))))", Inert
+        "(twice)", Obj 30
+        "(twice)", Obj 30
+    ]
+
+[<Fact>]
+let ``CLR sugar still resolves when the name is unbound`` () =
+    // The other half: with no binding to prefer, the rewrite happens at the call.
+    evalSessionKernel [
+        "(=? (System.Math/Abs -3) 3)", Bool true
+        """(=? (.-Length "hello") 5)""", Bool true
+        // In a compiled body, and on a repeated call.
+        """(define len (lambda (s) (.-Length s)))""", Inert
+        """(=? (len "hello") 5)""", Bool true
+        """(=? (len "worlds") 6)""", Bool true
+    ]

--- a/IronKernel/Analyze.fs
+++ b/IronKernel/Analyze.fs
@@ -158,13 +158,13 @@ module Analyze =
                             @ (BuildGuardedSequence(guard, List.length forms, fallback) :: pending)
                     | None -> completed <- fallback :: completed
                   | Atom name :: operands ->
-                    // Prefer a real binding over CLR call sugar (same rule as Eval).
-                    match getVar' env name with
-                    | Some _ -> completed <- COperate(CVar name, operands) :: completed
-                    | None ->
-                        match tryRewrite name operands with
-                        | Some rewritten -> pending <- AnalyzeGuardedForm rewritten :: pending
-                        | None -> completed <- COperate(CVar name, operands) :: completed
+                    // "Prefer a real binding over CLR call sugar" is a run-time
+                    // question, and since ADR 0008 step 2 it is answered at run time
+                    // by `operateNamed`. Deciding it here read the closure, which made
+                    // the compiled form depend on the environment it was compiled
+                    // against rather than the one it runs in -- wrong if the two
+                    // disagree, and the obstacle to reusing a compiled body at all.
+                    completed <- COperate(CVar name, operands) :: completed
                   | op :: operands ->
                     pending <- AnalyzeGuardedForm op :: BuildGuardedOperate operands :: pending
                   | [] -> completed <- analyze form :: completed
@@ -257,19 +257,15 @@ module Analyze =
                                 located.span, sourceLine, guard, List.length forms, fallback)
                                :: pending)
                     | Source.LList (operator :: operands), COperate (_, rawOperands) ->
-                        let isClrSugar =
-                            match operator.kind with
-                            | Source.LAtom name when getVar' env name |> Option.isNone ->
-                                tryRewrite name (List.map Source.toLispVal operands)
-                                |> Option.isSome
-                            | _ -> false
-                        if isClrSugar then
-                            completed <- CLocated(located.span, sourceLine, expression) :: completed
-                        else
-                            pending <-
-                                AnalyzeLocated operator
-                                :: BuildLocatedOperate(located.span, sourceLine, rawOperands)
-                                :: pending
+                        // The sugar test that used to sit here is gone with the one
+                        // above it: `analyzeGuarded` no longer returns a rewritten
+                        // form, so there is no desugared shape whose children would
+                        // not line up with the source.
+                        ignore operands
+                        pending <-
+                            AnalyzeLocated operator
+                            :: BuildLocatedOperate(located.span, sourceLine, rawOperands)
+                            :: pending
                     | _ -> completed <- CLocated(located.span, sourceLine, expression) :: completed
             | BuildLocatedIf (span, sourceLine, guard, fallback) ->
                 match takeCompleted 3 with

--- a/docs/adr/0008-caching-compiled-bodies.md
+++ b/docs/adr/0008-caching-compiled-bodies.md
@@ -109,11 +109,31 @@ Make compilation closure-independent, then the key is just the body cell:
    Benchmarks are unchanged -- the resolution, not the comparison, is what the check
    costs -- so this buys correctness of reach rather than speed.
 2. Decide the CLR-sugar question at run time rather than at analysis time, or record
-   the dependency in the key.
+   the dependency in the key. **Done, and it was smaller than expected.**
+   `tryRewrite` is a pure function of the name and operands -- it never consults an
+   environment -- so the only closure-dependent part was the *test* "is this name
+   bound", and the interpreter had always applied that at the point of call. The
+   compiled dispatch paths now do the same: a name that resolves to nothing is tried
+   as sugar before signalling, exactly as `evalValidStep` does, and the analyzer emits
+   the plain combination either way. `ColdCompile` improves from 149.6 ns / 808 B to
+   140.1 ns / 784 B, because analysis no longer resolves a binding per named
+   combination, and CLR sugar in a tight loop is unchanged -- the reflection call
+   dominates the rewrite.
 3. Only then add the cache, keyed on the first body form's `PairCell`, with the
    call-site sharing measured rather than assumed.
 
-Step 1 is a small change with its own justification. Step 2 is the real work.
+Step 1 was a small change with its own justification. Step 2 turned out to be one
+too. **Analysis is now closure-independent**, which was the blocker; what remains
+before step 3 is the shared-inline-cache question above, which is a performance
+matter rather than a correctness one.
+
+A third inconsistency turned up while doing this and is worth recording even though
+nothing reaches it today. The env-less `analyze` -- used by `compileLispVal` and
+`compileSource`, neither of which has a production caller -- rewrote sugar-shaped
+names *unconditionally*, so it would have preferred sugar over a binding, which is
+the opposite of the rule `Eval` and `analyzeGuarded` applied. Moving the decision to
+run time makes all three agree by construction rather than by three copies of one
+rule.
 
 ## Alternatives
 


### PR DESCRIPTION
The analyzer asked the closure whether a name was bound and rewrote the form as a CLR call when it was not. That made the compiled form depend on the environment it was **compiled against** rather than the one it **runs in** — wrong if the two disagree, and the reason a compiled body cannot be shared across closures.

## Smaller than the ADR expected

`tryRewrite` is a pure function of the name and its operands — it never consults an environment. The only closure-dependent part was the test *"is this name bound"*, and the interpreter had **always** applied that at the point of call:

```fsharp
// Eval.fs, unchanged for as long as it has existed
match getVar' env name with
| Some r -> operateStep env cont r args
| None   -> match tryRewrite name args with
            | Some rewritten -> evalStep env cont rewritten
            | None -> signal cont (UnboundVar ...)
```

So the fix is to make the compiled paths agree with the interpreter rather than to invent anything. Both compiled dispatch entry points now go through one `operateNamed` with that same rule, and the analyzer emits the plain combination either way.

The located analyzer's matching sugar test goes with it: `analyzeGuarded` no longer returns a rewritten form, so there is no desugared shape whose children would fail to line up with the source.

## A third copy of the rule, which disagreed

The env-less `analyze` — used by `compileLispVal` and `compileSource` — rewrote sugar-shaped names **unconditionally**, preferring sugar over a binding, the opposite of the rule `Eval` and `analyzeGuarded` applied. Neither entry point has a production caller, so nothing reached it. The three now agree by construction instead of by three copies of one rule.

## Measurements

| | before | after |
|---|---:|---:|
| `ColdCompile` | 149.6 ns / 808 B | **140.1 ns / 784 B** |
| CLR sugar, 200k calls in a loop | ~2.35 s | ~2.26 s |
| `Interpreted` / `CompiledGeneric` / `CompiledFolded` | 421.6 / 185.0 / 53.4 ns | 421.4 / 183.3 / 52.8 ns |

Analysis no longer resolves a binding per named combination, so compiling is slightly cheaper. Sugar in a tight loop is unchanged — the reflection call dominates the rewrite — and the CLR-heavy examples (`safe-clr`, `vau-dotnet`, `samples`) are within noise.

## The test that matters

Closure-independence is asserted directly: analyse the same source against an environment that binds the name and one that does not, and compare the Core. Checked against master, where they differ —

```
Expected: "(operate var:a/b ...)"
Actual:   "(operate var:. ...)"
```

— which is precisely the dependence this removes. Behavioural tests cover both halves: a binding wins over a sugar-shaped name (including on a repeated call, so through the call-site cache), and sugar still resolves when the name is unbound.

## Verification

- clean `--no-incremental` rebuild, 0 warnings
- 405 tests pass
- all 12 examples run (`yingyang.ikr` skipped, non-terminating by design)
- CLR fault sweep: 0 faults, 172 signalled, 47 returned

**Analysis is now closure-independent**, which was the blocker for ADR 0008 step 3. What remains before the cache is the shared-inline-cache question — a performance matter, not a correctness one — and the ADR's finding that the cache is worth 0.6–2.2% still stands, so step 3 remains deferred on its own evidence.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789676653&installation_model_id=427656&pr_number=80&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F80&signature=3763e701e890447764241ffd7f9ec6b3d8a077d8c180fca05932e7e9a5da9658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->