### PR TITLE
Give the equivalence rules one definition and stop allocating for scalars

### DIFF
--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -87,58 +87,75 @@
         /// Everything else is judged the same way by both. Two equal exact integers,
         /// or two equal symbols, are interchangeable in every way a program can
         /// observe, and the report leaves eq? on such objects to the implementation.
+        /// One comparison. `ValueNone` means "these are two distinct pairs and the
+        /// caller asked for a structural comparison", which is the only case that has
+        /// to descend -- so it is the only case that needs a work list.
+        ///
+        /// An object is the same object as itself, whatever its type. Without that
+        /// first case an environment, a vector or a primitive combiner was not equal to
+        /// itself, because the cases below cover only the types with a structural
+        /// comparison and everything else fell through to false -- which breaks the
+        /// reflexivity 4.2.1 and 4.3.1 both require.
+        let private compareStep pairsByIdentity first second =
+            match first, second with
+            | a, b when obj.ReferenceEquals(a, b) -> ValueSome true
+            | Inert, Inert -> ValueSome true
+            | Obj arg1, Obj arg2 -> ValueSome(arg1.Equals(arg2))
+            | Bool arg1, Bool arg2 -> ValueSome(arg1 = arg2)
+            | Atom arg1, Atom arg2 -> ValueSome(arg1 = arg2)
+            | PromptTag arg1, PromptTag arg2 -> ValueSome(arg1 = arg2)
+            // Compared cell by cell rather than through the list patterns, which
+            // materialised both chains before comparing them and walked each value
+            // twice over -- once failing DottedList, once matching List.
+            //
+            // Reference-equal cells were settled above; for eq? distinct cells are
+            // distinct pairs however alike they look, so it never descends.
+            | Pair _, Pair _ -> if pairsByIdentity then ValueSome false else ValueNone
+            | Nil, Nil -> ValueSome true
+            | _ -> ValueSome false
+
+        /// The work list and the visited set are built only once a comparison actually
+        /// descends. `eq?` never does, and neither does any comparison of scalars, so
+        /// the common case allocates nothing -- comparing two integers cost 232 bytes
+        /// when both were built up front.
         let private compareValues pairsByIdentity left right =
-            let pending = System.Collections.Generic.Stack<LispVal * LispVal>()
-            pending.Push(left, right)
-            let visited =
-                System.Collections.Generic.HashSet<struct (PairCell * PairCell)>(
-                    HashIdentity.Structural)
-            let mutable equal = true
+            match compareStep pairsByIdentity left right with
+            | ValueSome result -> result
+            | ValueNone ->
+                let pending = System.Collections.Generic.Stack<LispVal * LispVal>()
+                let visited =
+                    System.Collections.Generic.HashSet<struct (PairCell * PairCell)>(
+                        HashIdentity.Structural)
+                pending.Push(left, right)
+                let mutable equal = true
 
-            let pushLists leftValues rightValues =
-                let rec loop leftRemaining rightRemaining =
-                    match leftRemaining, rightRemaining with
-                    | [], [] -> ()
-                    | leftValue :: leftTail, rightValue :: rightTail ->
-                        pending.Push(leftValue, rightValue)
-                        loop leftTail rightTail
-                    | _ -> equal <- false
-                loop leftValues rightValues
+                // Only a structural comparison reaches here, so two distinct cells
+                // always descend. Taking that case directly rather than through
+                // `compareStep` matters: it is every cons cell of every list compared.
+                //
+                // A pair of cells already under comparison is assumed equal. That is
+                // what makes equal? terminate on cyclic structure, which R-1RK 4.3.1
+                // requires and set-cdr! now makes reachable: if following the cycle
+                // round ever disagreed, the disagreement is found before the cells
+                // recur.
+                while equal && pending.Count > 0 do
+                    let first, second = pending.Pop()
+                    match first, second with
+                    | Pair leftCell, Pair rightCell when
+                        not (obj.ReferenceEquals(first, second)) ->
+                        if not (visited.Add(struct (leftCell, rightCell))) then ()
+                        else
+                            pending.Push(leftCell.cdr, rightCell.cdr)
+                            pending.Push(leftCell.car, rightCell.car)
+                    | _ ->
+                        match compareStep pairsByIdentity first second with
+                        | ValueSome true -> ()
+                        | ValueSome false -> equal <- false
+                        // Unreachable: the only ValueNone is two distinct pairs, taken
+                        // by the case above.
+                        | ValueNone -> equal <- false
 
-            while equal && pending.Count > 0 do
-                match pending.Pop() with
-                // An object is the same object as itself, whatever its type. Without
-                // this an environment, a vector or a primitive combiner was not equal
-                // to itself, because the cases below cover only the types with a
-                // structural comparison and everything else fell through to false --
-                // which breaks the reflexivity 4.2.1 and 4.3.1 both require.
-                | first, second when obj.ReferenceEquals(first, second) -> ()
-                | Inert, Inert -> ()
-                | Obj arg1, Obj arg2 -> equal <- arg1.Equals(arg2)
-                | Bool arg1, Bool arg2 -> equal <- arg1 = arg2
-                | Atom arg1, Atom arg2 -> equal <- arg1 = arg2
-                | PromptTag arg1, PromptTag arg2 -> equal <- arg1 = arg2
-                // Compared cell by cell rather than through the list patterns, which
-                // materialised both chains before comparing them and walked each value
-                // twice over -- once failing DottedList, once matching List.
-                | Pair left, Pair right ->
-                    if pairsByIdentity then
-                        // Reference-equal cells were settled above; distinct cells are
-                        // distinct pairs however alike they look.
-                        equal <- false
-                    // A pair of cells already under comparison is assumed equal. That is
-                    // what makes equal? terminate on cyclic structure, which R-1RK 4.3.1
-                    // requires and set-cdr! now makes reachable: if following the cycle
-                    // round ever disagreed, the disagreement is found before the cells
-                    // recur. eq? cannot loop, because it never descends into a pair.
-                    elif not (visited.Add(struct (left, right))) then ()
-                    else
-                        pending.Push(left.cdr, right.cdr)
-                        pending.Push(left.car, right.car)
-                | Nil, Nil -> ()
-                | _ -> equal <- false
-
-            equal
+                equal
 
         /// R-1RK 4.7.1. The result is inert, and 3.8 requires an error when the pair is
         /// immutable -- which is what protects a captured algorithm from being rewritten


### PR DESCRIPTION
**Cleanup, not a performance change.** It was written as a probe to test whether the equality path is where real programs spend time. It isn't — that result is recorded in the commit message and below so nobody re-derives it hopefully.

## What it tidies

`compareValues` held the comparison rules inline in its walk loop, built a `Stack` **and** a `HashSet` on every call, and carried a `pushLists` closure that nothing had called since the cell-by-cell comparison replaced it.

The rules move into `compareStep`, which returns `ValueNone` for the single case that has to descend — two distinct pairs under a structural comparison. That is the whole reason the work list exists, so it and the visited set are built only when that case arises. `eq?` never descends (distinct cells are distinct pairs however alike they look), and no comparison of scalars descends either, so neither allocates now.

The descending loop takes the pair case directly rather than through `compareStep` — it is every cons cell of every list compared, and the extra dispatch showed up in the benchmark when it did not.

## Measurements

| | master | this branch |
|---|---:|---:|
| `ScalarEqual` | 31.5 ns / 232 B | **8.6 ns / 48 B** |
| `FlatListEqual` | 674.0 ns / 2104 B | 700.5 ns / 2104 B |
| `NestedListEqual` | 1439.7 ns / 4344 B | 1453.6 ns / 4344 B |
| `DottedListEqual` | 822.4 ns / 2104 B | 661.8 ns / 2104 B |

List allocation is byte-identical, which is the check that the descending path was left alone; `DottedListEqual`'s baseline had a StdDev of 41 ns, so read that row as noise rather than a win.

**On real programs: nothing measurable.** `constant-width-amb` 3.55 s against 3.48 s, inside run-to-run noise; `constant-width` and `zipper` identical. So equality is not where these programs spend their time, despite `null?`/`eq?`/`zero?` being 41% of dispatches and `compareValues` showing 48% inclusive in a sampled profile — a profile whose GC-poll frames sat at 89%, so it was biased toward allocation sites to begin with.

That makes three hypotheses (body-compilation caching, the frame dictionary, equality) that looked compelling by counts or profile and produced nothing on the clock. The two changes that did work — `$sequence` and `let` — both removed work a derivation generated per call.

## Verification

- clean `--no-incremental` rebuild, 0 warnings
- 405 tests pass
- all 12 examples run (`yingyang.ikr` skipped, non-terminating by design)
- CLR fault sweep: 0 faults, 172 signalled, 47 returned
- `CompilerBenchmarks` unchanged: 139.5 / 422.0 / 180.9 / 51.5 ns

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789681791&installation_model_id=427656&pr_number=81&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F81&signature=6f9526d758ea98a27e67d23c689a99485527a6eab3fa2a12330d4d587c892ef0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->