### PR TITLE
Add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# IronKernel
+
+An implementation of the Kernel programming language (R⁻¹RK, WPI TR 05-07) on .NET,
+plus a compiler, a project/package tool (`ik`), and a CLR interop surface.
+
+The report is the specification. When behaviour is in question, quote the report
+section rather than reasoning from what the code does.
+
+## Build and test
+
+```
+dotnet build IronKernel.sln -c Release --nologo
+dotnet test  IronKernel.sln -c Release --nologo
+```
+
+The suite is currently 409 tests and takes roughly two minutes.
+
+## Verification ritual
+
+Run all of this before opening a PR. Each step has caught something the others did
+not.
+
+1. **Clean rebuild, zero warnings.** `dotnet build IronKernel.sln -c Release --no-incremental --nologo`
+2. **Full suite.**
+3. **Every example.** `Examples/*.ikr`, skipping `yingyang.ikr` — it is non-terminating
+   by design. Run the built binary directly (`IronKernel/bin/Release/net10.0/IronKernel`);
+   `dotnet run` in a loop has hung here.
+4. **CLR fault sweep.** `python3 tools/scan-clr-faults.py IronKernel/bin/Release/net10.0/IronKernel tools/clr-fault-cases.txt`
+   Expect `faulted (process aborted): 0`. A non-zero count means a CLR exception
+   escaped as a process abort instead of a Kernel error.
+5. **Benchmarks**, when the change could touch evaluation:
+   `dotnet run -c Release --project IronKernel.Benchmarks -- --filter '*CompilerBenchmarks*'`
+   Classes: `CompilerBenchmarks`, `ControlFlowBenchmarks`, `GuardSpecializationBenchmarks`,
+   `EqualityBenchmarks`, `SymbolLookupBenchmarks`, `ApplicationArityBenchmarks`,
+   `ClrResolutionBenchmarks`.
+
+## Conformance matrix
+
+`docs/kernel-conformance.md` is **generated**, by probing a real bootstrapped
+environment in `IronKernel.Tests/KernelConformanceTests.fs`. A test fails if the
+committed copy is stale, so it cannot drift from the implementation.
+
+```
+IRONKERNEL_UPDATE_CONFORMANCE=1 dotnet test IronKernel.sln -c Release --nologo --filter "conformance matrix"
+```
+
+The README quotes the matrix's headline counts and a separate test checks that too.
+Current state: 135/135 entries verified, 44/44 modules, 11 divergences.
+
+R⁻¹RK §1.3.2 makes the **module** the unit of conformance. `verified` means a
+behavioural check exercises the entry — not that every requirement in it is proven.
+Divergences are recorded in the same file and are worth reading before treating any
+row as a conformance claim.
+
+## Layout
+
+| | |
+|---|---|
+| `IronKernel.Runtime/` | AST, evaluator (CPS trampoline), symbol table, primitives, CLR interop |
+| `IronKernel/` | analyzer, compiler, package format, REPL, project tool (`ik`) |
+| `IronKernel/kernel.ikr` | the standard library, in Kernel |
+| `IronKernel.Tests/` | xunit; conformance matrix generator lives here |
+| `docs/adr/` | architecture decision records |
+| `Examples/` | runnable examples, including the `lantern` multi-file project |
+
+## ADRs
+
+0001 source/project/package conventions · 0002 AOT artifacts · 0003 portable core
+package format · 0004 compiling procedure bodies · 0005 mutable pairs · 0006 errors
+as abnormal passes · 0007 identity for derived combiners · 0008 caching compiled
+bodies (proposed, deliberately not built).
+
+They record measurements and rejected options, not just decisions. When a prediction
+in one turns out wrong, correct it in place rather than leaving it — several carry
+inline corrections for exactly that reason.
+
+## Conventions that earned their place
+
+**A test must be able to fail for the right reason.** Check it. Two real examples:
+"the file could be deleted" cannot detect an unclosed port, because deleting an open
+file succeeds on Unix; and a tail-context test only means something if moving the
+recursion out of tail position breaks it (it takes the captured continuation's depth
+from 23 to 2003). Negative controls are cheap and have repeatedly shown a test was
+vacuous.
+
+**Counts and profiles have not predicted cost here.** Three hypotheses — caching
+compiled bodies, pre-sizing the frame dictionary, the equality path — looked
+compelling by dispatch counts or a sampled profile and produced nothing on the clock.
+The two changes that worked (`$sequence` and `let` as primitives, together 16.2s →
+4.9s on the heaviest example) both removed work a *derivation* generated per call.
+Verify by timing a real program before believing a profile. `dotnet-trace` on this
+platform puts GC-poll frames at ~89%, so it is biased toward allocation sites.
+
+**Benchmark noise vs regression.** A uniform slowdown across every case with
+byte-identical allocation is the machine, not the code — usually a stray process from
+an earlier run holding a core. Check `ps` for leftover `IronKernel` processes before
+diagnosing. Killing a shell pipeline does not kill the `dotnet` child.
+
+**Editing large F# files.** Prefer line-indexed edits over slicing between two text
+anchors. Slicing has twice removed a function that happened to sit between the
+anchors; the compiler caught it both times, but it is avoidable.
+
+**Git.** Stage explicit paths. `git add -A` has swept unrelated untracked files into
+a commit.
+
+**The global `ik` tool can be stale.** It is installed separately from the repo
+(`dotnet tool`, packaged from `IronKernel/IronKernel.fsproj` as `IronKernel.Tool`).
+Check `ik --version` against `version` before investigating a reported bug — a
+lantern crash reported against 0.4.2 did not exist on the current tree.


### PR DESCRIPTION
The conventions this repository is worked under lived only in the ADRs and in whatever the last session happened to remember. This writes them down.

**What it covers:** build and test commands; the verification ritual with a note on what each step has actually caught; how the generated conformance matrix works and how to regenerate it; the layout; an index of the eight ADRs.

**The last section is the part worth having.** It records what was learned by getting it wrong rather than by deciding it:

- *A test must be able to fail for the right reason.* "The file could be deleted" cannot detect an unclosed port, because deleting an open file succeeds on Unix. A tail-context test only means something if moving the recursion out of tail position breaks it — 23 against 2003.
- *Counts and profiles have not predicted cost here.* Three hypotheses died on the clock; the two changes that worked removed work a derivation generated per call. `dotnet-trace` on this platform puts GC-poll frames at ~89%, so it is biased toward allocation sites.
- *Telling benchmark noise from a regression*: uniform slowdown with byte-identical allocation is the machine, usually a stray process holding a core.
- Editing and git habits that have caused avoidable damage — slicing between text anchors has twice deleted a function sitting between them, and `git add -A` has swept unrelated untracked files into a commit.
- The global `ik` tool is installed separately and can be stale. A lantern crash reported against 0.4.2 did not exist on the current tree.

Numbers are current at this commit: 409 tests, 135/135 entries verified, 44/44 modules, 11 divergences.

Docs only; the suite passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790001825&installation_model_id=427656&pr_number=83&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F83&signature=a7f15e8234a2b9ef2c8647f094853ab9bacdef98cefbb21fee8a22753811382e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->