### PR TITLE
ik check: structured diagnostics for editors (ADR 0009 phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,8 @@ row as a conformance claim.
 0001 source/project/package conventions · 0002 AOT artifacts · 0003 portable core
 package format · 0004 compiling procedure bodies · 0005 mutable pairs · 0006 errors
 as abnormal passes · 0007 identity for derived combiners · 0008 caching compiled
-bodies (proposed, deliberately not built).
+bodies (proposed, deliberately not built) · 0009 editor tooling from the runtime
+outward (`ik check --json` is its phase 1).
 
 They record measurements and rejected options, not just decisions. When a prediction
 in one turns out wrong, correct it in place rather than leaving it — several carry

--- a/IronKernel.Runtime/Errors.fs
+++ b/IronKernel.Runtime/Errors.fs
@@ -13,20 +13,18 @@ module Errors =
         |Choice1Of2(error) -> f error
         |Choice2Of2(result) -> action
 
-    let showError error =
-        let mutable current = error
-        let mutable locations = []
-        let mutable collecting = true
-
-        while collecting do
+    /// The location wrappers around an error, outermost first, and the unwrapped core.
+    let errorLocations error =
+        let rec strip acc current =
             match current with
-            | LocatedError(span, sourceLine, inner) ->
-                locations <- (span, sourceLine) :: locations
-                current <- inner
-            | _ -> collecting <- false
+            | LocatedError(span, sourceLine, inner) -> strip ((span, sourceLine) :: acc) inner
+            | core -> List.rev acc, core
+        strip [] error
 
+    /// The diagnostic text of a core error, without location prefixes or caret art.
+    let errorMessage core =
         let message =
-            match current with
+            match core with
             | UnboundVar(msg,varname) -> msg + ": '" + varname + "' "
             | BadSpecialForm(msg,form) -> msg + ": " + showVal form
             | NotFunction(msg,func) -> msg + ": " + func
@@ -43,9 +41,14 @@ module Errors =
             // a diagnostic says what it is.
             | SessionExit value -> "session exited with " + showVal value
             | LocatedError _ -> invalidOp "Located error traversal is incomplete"
+        message
+
+    let showError error =
+        let locations, core = errorLocations error
+        let message = errorMessage core
 
         let output = Text.StringBuilder()
-        for span, _ in List.rev locations do
+        for span, _ in locations do
             let source =
                 if String.IsNullOrWhiteSpace span.sourceName then "<input>"
                 else span.sourceName
@@ -53,7 +56,8 @@ module Errors =
             output.AppendFormat("{0}:{1}:{2}: ", source, position.line, position.column) |> ignore
 
         output.Append(message) |> ignore
-        for span, sourceLine in locations do
+        // Prefixes read outermost first; caret blocks print innermost first.
+        for span, sourceLine in List.rev locations do
             let position = span.startPosition
             match sourceLine with
             | None -> ()

--- a/IronKernel.Tests/CheckTests.fs
+++ b/IronKernel.Tests/CheckTests.fs
@@ -1,0 +1,100 @@
+module IronKernel.Tests.CheckTests
+
+open System
+open System.IO
+open System.Text.Json
+open Xunit
+
+open IronKernel.Ast
+open IronKernel.Check
+
+let private tempPath extension =
+    Path.Combine(Path.GetTempPath(), "ironkernel-check-" + Guid.NewGuid().ToString("N") + extension)
+
+let private withSource (contents: string) body =
+    let path = tempPath ".ikr"
+    try
+        File.WriteAllText(path, contents)
+        body path
+    finally
+        File.Delete path
+
+let private parseReport (json: string) =
+    use document = JsonDocument.Parse json
+    let root = document.RootElement
+    Assert.Equal(1, root.GetProperty("version").GetInt32())
+    root.GetProperty("diagnostics").EnumerateArray()
+    |> Seq.map (fun d -> d.Clone())
+    |> Seq.toList
+
+[<Fact>]
+let ``check reports nothing for a clean file`` () =
+    withSource "(define f (lambda (x) (+ x 1)))\n" (fun path ->
+        Assert.Empty(checkFile Unrestricted path))
+
+[<Fact>]
+let ``check reports a parse error with its span`` () =
+    withSource "(define f\n  (lambda (x)\n    (+ x 1))\n" (fun path ->
+        match checkFile Unrestricted path with
+        | [ finding ] ->
+            Assert.Equal(path, finding.path)
+            match IronKernel.Errors.errorLocations finding.error with
+            | [ span, _ ], IronKernel.Ast.Parser _ ->
+                Assert.Equal(path, span.sourceName)
+                Assert.Equal(4L, span.startPosition.line)
+                Assert.Equal(1L, span.startPosition.column)
+            | locations, core -> failwithf "unexpected shape: %A / %A" locations core
+        | findings -> failwithf "expected one finding, got %A" findings)
+
+[<Fact>]
+let ``check json carries file range and message`` () =
+    withSource "(foo))\n" (fun path ->
+        let diagnostics = parseReport (toJson (checkFile Unrestricted path))
+        let diagnostic = Assert.Single diagnostics
+        Assert.Equal("error", diagnostic.GetProperty("severity").GetString())
+        Assert.Contains("Parse error", diagnostic.GetProperty("message").GetString())
+        Assert.Equal(path, diagnostic.GetProperty("file").GetString())
+        let start = diagnostic.GetProperty("range").GetProperty("start")
+        Assert.Equal(1L, start.GetProperty("line").GetInt64())
+        Assert.Equal(6L, start.GetProperty("column").GetInt64()))
+
+[<Fact>]
+let ``check json for a clean file is an empty diagnostics array`` () =
+    withSource "(define x 1)\n" (fun path ->
+        Assert.Empty(parseReport (toJson (checkFile Unrestricted path))))
+
+[<Fact>]
+let ``a finding without a span carries the checked path and no range`` () =
+    let path = tempPath ".ikr"
+    let diagnostics = parseReport (toJson (checkFile Unrestricted path))
+    let diagnostic = Assert.Single diagnostics
+    Assert.Equal(path, diagnostic.GetProperty("file").GetString())
+    let mutable range = Unchecked.defaultof<JsonElement>
+    Assert.False(diagnostic.TryGetProperty("range", &range))
+
+let private withProject body =
+    let root = Path.Combine(Path.GetTempPath(), "ironkernel-check-project-" + Guid.NewGuid().ToString("N"))
+    Directory.CreateDirectory root |> ignore
+    try
+        Assert.Equal(0, IronKernel.Project.create "app" "demo" root)
+        let directory = Path.Combine(root, "demo")
+        body directory (Path.Combine(directory, "demo.ikproj"))
+    finally
+        Directory.Delete(root, true)
+
+[<Fact>]
+let ``project check walks sources main and tests`` () =
+    withProject (fun directory projectPath ->
+        let load () =
+            match IronKernel.Project.load projectPath with
+            | Choice2Of2 project -> project
+            | Choice1Of2 error -> failwithf "project load failed: %A" error
+        Assert.Empty(checkProject (load ()))
+        let brokenSource = Path.Combine(directory, "src", "extra.ikr")
+        File.WriteAllText(brokenSource, "(define broken\n")
+        let brokenTest = Path.Combine(directory, "test", "extra_test.ikr")
+        File.WriteAllText(brokenTest, "(assert-true\n")
+        let findings = checkProject (load ())
+        Assert.Equal(2, List.length findings)
+        Assert.Contains(findings, fun finding -> finding.path = brokenSource)
+        Assert.Contains(findings, fun finding -> finding.path = brokenTest))

--- a/IronKernel.Tests/CliTests.fs
+++ b/IronKernel.Tests/CliTests.fs
@@ -629,3 +629,23 @@ let ``runtime diagnostics keep the enclosing span for errors after an if conditi
             let diagnostic = showError error
             Assert.Contains("if-condition.ikr:1:1", diagnostic)
             Assert.Contains("^^^^^^^^^^", diagnostic)
+
+[<Fact>]
+let ``check emits JSON diagnostics and distinguishes exit codes`` () =
+    let script = tempPath ".ikr"
+    try
+        File.WriteAllText(script, "(define broken\n")
+        let exitCode, stdout, _ = runCli [ "check"; script; "--json" ]
+        Assert.Equal(1, exitCode)
+        use report = System.Text.Json.JsonDocument.Parse stdout
+        let diagnostics = report.RootElement.GetProperty("diagnostics")
+        Assert.Equal(1, diagnostics.GetArrayLength())
+        Assert.Equal(script, diagnostics.[0].GetProperty("file").GetString())
+
+        File.WriteAllText(script, "(define whole 1)\n")
+        let exitCode, stdout, _ = runCli [ "check"; script; "--json" ]
+        Assert.Equal(0, exitCode)
+        use report = System.Text.Json.JsonDocument.Parse stdout
+        Assert.Equal(0, report.RootElement.GetProperty("diagnostics").GetArrayLength())
+    finally
+        File.Delete script

--- a/IronKernel.Tests/IronKernel.Tests.fsproj
+++ b/IronKernel.Tests/IronKernel.Tests.fsproj
@@ -26,6 +26,7 @@
     <Compile Include="ContractTests.fs" />
     <Compile Include="ConformanceTests.fs" />
     <Compile Include="CliTests.fs" />
+    <Compile Include="CheckTests.fs" />
     <Compile Include="ProjectTests.fs" />
     <Compile Include="ContinuationTests.fs" />
     <Compile Include="EffectTests.fs" />

--- a/IronKernel/Check.fs
+++ b/IronKernel/Check.fs
@@ -1,0 +1,90 @@
+namespace IronKernel
+
+/// `ik check`: parse and analyze source without evaluating it or writing output.
+/// Findings keep the location chain the runtime already attaches; `--json` emits
+/// them in the stable machine format editors consume (ADR 0009).
+module Check =
+
+    open System
+    open System.IO
+    open System.Text
+    open System.Text.Json
+    open Ast
+    open Errors
+
+    /// One reported problem: the file the check was asked about -- spans inside
+    /// the error may name other files -- and the error, locations intact.
+    type Finding = {
+        path : string
+        error : LispError
+    }
+
+    let checkFile profile (path: string) : Finding list =
+        match Emit.checkSourceFileForProfile profile path with
+        | Choice1Of2 error -> [ { path = path; error = error } ]
+        | Choice2Of2 () -> []
+
+    /// The files the project's author edits: sources, main, tests. Dependency
+    /// sources are published artifacts and are not this project's to fix.
+    let private projectFiles (project: Project.IkProject) =
+        project.sources @ [ project.main ] @ project.tests
+        |> List.distinctBy (fun (path: string) -> path.ToUpperInvariant())
+
+    let checkProject (project: Project.IkProject) : Finding list =
+        projectFiles project |> List.collect (checkFile project.profile)
+
+    let private writeLocation (writer: Utf8JsonWriter) fallbackPath (span: SourceSpan) =
+        let file =
+            if String.IsNullOrWhiteSpace span.sourceName then fallbackPath
+            else span.sourceName
+        writer.WriteString("file", (file: string))
+        writer.WritePropertyName "range"
+        writer.WriteStartObject()
+        for name, position in [ "start", span.startPosition; "end", span.endPosition ] do
+            writer.WritePropertyName (name: string)
+            writer.WriteStartObject()
+            writer.WriteNumber("line", position.line)
+            writer.WriteNumber("column", position.column)
+            writer.WriteEndObject()
+        writer.WriteEndObject()
+
+    /// Lines and columns are 1-based, matching the human diagnostics; `end` is
+    /// exclusive. A finding without a span carries only `file`, no `range`.
+    let toJson (findings: Finding list) : string =
+        use stream = new MemoryStream()
+        use writer = new Utf8JsonWriter(stream)
+        writer.WriteStartObject()
+        writer.WriteNumber("version", 1)
+        writer.WritePropertyName "diagnostics"
+        writer.WriteStartArray()
+        for finding in findings do
+            let locations, core = errorLocations finding.error
+            writer.WriteStartObject()
+            writer.WriteString("severity", "error")
+            writer.WriteString("message", errorMessage core)
+            match List.rev locations with
+            | [] -> writer.WriteString("file", finding.path)
+            | (innermost, _) :: enclosing ->
+                writeLocation writer finding.path innermost
+                if not (List.isEmpty enclosing) then
+                    writer.WritePropertyName "related"
+                    writer.WriteStartArray()
+                    for span, _ in enclosing do
+                        writer.WriteStartObject()
+                        writeLocation writer finding.path span
+                        writer.WriteEndObject()
+                    writer.WriteEndArray()
+            writer.WriteEndObject()
+        writer.WriteEndArray()
+        writer.WriteEndObject()
+        writer.Flush()
+        Encoding.UTF8.GetString(stream.ToArray())
+
+    /// Print findings -- JSON to stdout or human text to stderr -- and return
+    /// the exit code: 0 clean, 1 findings.
+    let report json (findings: Finding list) =
+        if json then printfn "%s" (toJson findings)
+        else
+            for finding in findings do
+                eprintfn "Check error: %s" (showError finding.error)
+        if List.isEmpty findings then 0 else 1

--- a/IronKernel/Emit.fs
+++ b/IronKernel/Emit.fs
@@ -165,6 +165,16 @@ module Emit =
                 | Choice1Of2 e -> throwError e
                 | Choice2Of2 expressions -> writeIkcPackage outputPath expressions
 
+    /// Everything `compile` checks -- read, parse, analyze -- with nothing written.
+    let checkSourceFileForProfile profile (inputPath: string) : ThrowsError<unit> =
+        match readSource inputPath with
+        | Choice1Of2 e -> throwError e
+        | Choice2Of2 source ->
+            let env = makePrimitiveBindingsForProfile profile
+            match analyzePackage env inputPath source with
+            | Choice1Of2 e -> throwError e
+            | Choice2Of2 _ -> returnM ()
+
     [<Obsolete("Use compileFileToPackage; IKC files are packages, not CLR assemblies.")>]
     let compileFileToAssembly inputPath outputPath =
         compileFileToPackage inputPath outputPath

--- a/IronKernel/IronKernel.fsproj
+++ b/IronKernel/IronKernel.fsproj
@@ -43,6 +43,7 @@
     <Compile Include="Emit.fs" />
     <Compile Include="Repl.fs" />
     <Compile Include="Project.fs" />
+    <Compile Include="Check.fs" />
     <Compile Include="Program.fs" />
     <!-- Pack=false: keep stdlib in the tool output (tools/net*/any) only, not as package contentFiles. -->
     <Content Include="kernel.ikr" CopyToOutputDirectory="PreserveNewest" Pack="false" />

--- a/IronKernel/Program.fs
+++ b/IronKernel/Program.fs
@@ -7,12 +7,14 @@ open IronKernel.Ast
 open IronKernel.Errors
 
 module ProjectTool = IronKernel.Project
+module CheckTool = IronKernel.Check
 
 let private usage =
     """Usage:
   ironkernel [--profile <profile>]                         Start the REPL
   ironkernel [--profile <profile>] <file.ikr> [args...]    Run a source script
   ironkernel [--profile <profile>] run <file> [args...]    Run a .ikr script or .ikc package
+  ironkernel [--profile <profile>] check [--json] [<file.ikr> | project.ikproj]
     ironkernel [--profile <profile>] compile <file.ikr> [-o <file.ikc>]
     ironkernel [--profile <profile>] compile <file.ikr> --managed [-o <directory>]
     ironkernel --profile <minimal|safe> compile <file.ikr> --native <rid> [-o <directory>]
@@ -26,6 +28,7 @@ Project commands:
   ik restore [--locked] [project.ikproj]
   ik run [project.ikproj] [args...]
   ik build|test|tree|pack [project.ikproj]
+  ik check [--json] [project.ikproj]
   ik add <package> <version> [--clr] [--test]
   ik remove <package>
   ik publish <source> [api-key]
@@ -157,6 +160,19 @@ let private dispatch (profileOverride: CapabilityProfile option) args =
     | "run" :: scriptArgs ->
         // Non-source tokens (including flags) are project program args, not scripts.
         withProject profileOverride None (fun project -> ProjectTool.run project scriptArgs)
+    | "check" :: rest ->
+        let json = List.contains "--json" rest
+        let arguments = rest |> List.filter (fun argument -> argument <> "--json")
+        match arguments with
+        | [] ->
+            withProject profileOverride None (fun project ->
+                CheckTool.report json (CheckTool.checkProject project))
+        | [path] when isProjectPath path ->
+            withProject profileOverride (Some path) (fun project ->
+                CheckTool.report json (CheckTool.checkProject project))
+        | [path] when Path.GetExtension(path).Equals(".ikr", StringComparison.OrdinalIgnoreCase) ->
+            CheckTool.report json (CheckTool.checkFile profile path)
+        | _ -> usageError "Expected 'ik check [--json] [<file.ikr> | project.ikproj]'."
     | ["compile"] -> usageError "Missing source file for 'compile'."
     | "compile" :: input :: "--native" :: rid :: rest ->
         let outputResult =

--- a/IronKernel/Project.fs
+++ b/IronKernel/Project.fs
@@ -630,7 +630,7 @@ module Project =
                 else
                     match bootstrapEnvForProfile project.profile with
                     | Choice1Of2 error ->
-                        eprintfn "Project startup error: %s" (showError error)
+                        eprintfn "Startup error: %s" (showError error)
                         1
                     | Choice2Of2 standardEnv ->
                         let env =

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ ik new app hello
 cd hello
 ik run
 ik test
+ik check
 ik restore
 ik add Acme.IronKernel.Http 1.2.0
 ik add Npgsql 9.0.0 --clr
@@ -187,6 +188,7 @@ for the local-feed workflow and the roadmap.
 | [`IronKernel.Collections`](lib/IronKernel.Collections/) | Folds, slicing, stable sort, sets over `equal?`, alist editing, and the vector/list bridge — pure Kernel |
 | [`IronKernel.Strings`](lib/IronKernel.Strings/) | Search, split/join, case, trimming, padding, characters, invariant number conversion, and a variadic `format` — ordinal semantics throughout |
 | [`IronKernel.Json`](lib/IronKernel.Json/) | Grammar-enforcing JSON reader with offsets in its errors, a writer that refuses what JSON cannot carry, pretty-printing, and path traversal |
+| [`IronKernel.Math`](lib/IronKernel.Math/) | Statistics, combinatorics, and number theory — exact wherever the mathematics allows: means as ratios, `isqrt` and `factorial` at any size, primes, factorizations, totients |
 | [`IronKernel.Amb`](lib/IronKernel.Amb/) | Nondeterministic search: `amb`, `require`, bracketed choice, and pluggable search strategies over multi-shot delimited continuations |
 
 Packages test against `IronKernel.Test` through a test-scoped reference
@@ -368,8 +370,9 @@ See [`Examples/contracts.ikr`](Examples/contracts.ikr).
 ## VS Code extension and playground
 
 The extension in [`editors/vscode/`](editors/vscode/) provides IronKernel syntax
-highlighting, snippets, run/compile commands, Problems diagnostics, and a
-playground backed by the real CLI. Build a local VSIX with:
+highlighting, snippets, run/compile commands, check-on-save diagnostics fed by
+`ik check --json`, and a playground backed by the real CLI. Build a local VSIX
+with:
 
 ```bash
 cd editors/vscode

--- a/docs/adr/0009-editor-tooling-from-the-runtime-outward.md
+++ b/docs/adr/0009-editor-tooling-from-the-runtime-outward.md
@@ -1,0 +1,166 @@
+# ADR 0009: Editor tooling grows from the runtime outward
+
+Status: Accepted — phase 1 implemented
+
+## Decision
+
+Deepen the existing VS Code extension into runtime-backed tooling, in a fixed
+order: structured diagnostics from the CLI first, environment enumeration
+primitives second, an in-process language server third, parser error recovery
+fourth, and the visible surfaces — environment inspector, profile status,
+debug adapter — only on top of those. No separate IDE, and no language server
+that shells out to the current text-scraping contract.
+
+Phase 1 ships with this ADR: `ik check [--json]`, a machine-readable
+diagnostics format, and the extension consuming it on save.
+
+## Problem
+
+The language has several concepts a generic editor cannot show — operatives vs
+applicatives, first-class environments, capability profiles, compiled vs
+residual paths — and the extension that exists is thinner than it looks:
+
+- **Diagnostics are stderr scraping.** The extension regex-matches
+  `Prefix error: file:line:col: message` and infers the end column by counting
+  `^` characters two lines below (`editors/vscode/src/diagnostics.ts`) — it
+  re-parses the caret art `showError` draws for humans. It fires only after an
+  explicit run or compile; nothing analyzes a buffer on open, edit, or save.
+  One emitter (`Project startup error:` in `Project.fs`) did not even match
+  the regex; `Build error:` and `Test startup error:` did not either.
+- **Operative/applicative coloring is a name list, maintained twice** — one
+  regex alternation in `syntaxes/ironkernel.tmLanguage.json`, a second copy in
+  `website/assets/site.js`. A user-defined operative gets no color; a shadowed
+  `if` keeps one. The distinction is the language's primary mental model,
+  rendered lexically.
+- **`compile` catches parse errors only.** `Analyze.analyzeLocatedGuarded`
+  returns a `CoreExpr`, not a `ThrowsError`; unbound variables and arity
+  errors surface at run time. `ik build` on a typo'd name exits 0.
+- **Environments are opaque to Kernel.** The host record is a plain
+  `Dictionary` plus a parent list and a capability set (`Ast.fs`,
+  `EnvironmentRecord`), but the only probe is `$binds?` and `showVal` prints
+  `<environment>`. No frame enumeration, no parent walk, no capability read.
+- **No session protocol.** The REPL is bare stdin/stdout; `trapError` folds
+  errors into stdout as `error : …` text, so a consumer cannot separate
+  results from failures without string-matching.
+- **The parser is fail-fast.** FParsec reports the first failure with no
+  partial tree, so a half-typed buffer yields one error and nothing to
+  complete against.
+
+## What already exists to build on
+
+These are the reasons the plan starts at the runtime rather than at the
+protocol:
+
+- `IronKernel/IronKernel.fsproj` is deliberately exe-and-library, so a server
+  can call `Parser`, `Analyze`, `Emit`, and `Project.load` in-process — no
+  process spawn per keystroke, no output parsing.
+- Span data is real end-to-end for errors: `Parser.readLocatedExprList`
+  returns a fully-spanned tree, `CLocated` carries spans through the IR, and
+  `LocatedError` carries them out. What was missing was a machine format, not
+  the data.
+- `contract-of` returns `(mode operands result effect trust)` for primitives
+  and contracted combiners — hover, signature help, and *semantic*
+  operative/applicative classification, nearly for free.
+- The `.ikproj` model plus `orderedSources`/`orderedTestSources` already
+  defines a workspace and its load order.
+- `Mono.Terminal`'s completion hook (`AutoCompleteEvent`) exists and is
+  unused; REPL tab-completion is wiring, once bindings are enumerable.
+
+## Plan
+
+**Phase 1 — structured diagnostics.** *Done.* `ik check [--json]
+[<file.ikr> | project.ikproj]` parses and analyzes without evaluating or
+writing anything — by construction it is `compile` minus the write
+(`Emit.checkSourceFileForProfile`), so any semantic checking later added to
+the analyze path flows into editors with no further work. Exit codes: 0
+clean, 1 findings, 2 usage. The JSON is a versioned contract:
+
+```json
+{"version": 1, "diagnostics": [{
+  "severity": "error", "message": "…", "file": "…",
+  "range": {"start": {"line": 1, "column": 5}, "end": {"line": 1, "column": 9}},
+  "related": [{"file": "…", "range": {…}}]
+}]}
+```
+
+Lines and columns are 1-based to match the human diagnostics; `end` is
+exclusive; a finding without a span (an unreadable file) carries `file` and no
+`range`; nested `LocatedError` wrappers become the innermost span as the
+primary location with the enclosing spans under `related`. `showError` was
+split into `errorLocations`/`errorMessage` so both renderings share one
+traversal — its human output is unchanged. Project check walks sources, main,
+and tests (not dependency sources, which are published artifacts and not this
+project's to fix), and does not require a restore.
+
+The extension now runs `check --json` on save (`ironkernel.checkOnSave`,
+default on, trusted workspaces only) and via **Check Current File**,
+publishing span-accurate diagnostics instead of scraping. The caret-art regex
+remains only for what `run` prints — runtime errors have no JSON channel yet —
+and the three mismatched prefixes are fixed or matched.
+
+**Phase 2 — environment enumeration.** Primitives to list a frame's bindings,
+walk `parents`, and read the capability set, over the existing `SymbolTable`
+machinery. This one gap blocks completion, the environment inspector, and
+REPL tab-completion all at once, which is why it precedes the server.
+
+**Phase 3 — the language server.** F#, referencing IronKernel in-process.
+Semantic tokens from actual binding resolution and `contract-of` — retiring
+both hand-maintained name lists — hover and signature help from contracts,
+completion from phase 2, diagnostics from phase 1's pipeline. Ships with
+marketplace publishing, which CI has already reduced to a decision
+(`vsce package` runs on every push; the `.vsix` is an artifact nobody
+publishes).
+
+**Phase 4 — parser error recovery.** A first failure with no partial tree is
+acceptable for check-on-save and fatal for as-you-type diagnostics and
+mid-edit completion. This is the largest single piece and nothing above
+depends on it, which is why it is fourth and not first.
+
+**Phase 5 — the visible surfaces.** Environment inspector (a UI over phase
+2), a profile status-bar item that also reads the project's own `<Profile>`,
+compiled-vs-residual highlighting (the IR's `CLocated` forms already mark
+what the analyzer touched).
+
+**Phase 6 — debug adapter.** Requires a persistent session protocol that does
+not exist — the REPL cannot even separate errors from values today — so the
+protocol is the prerequisite, and it should serve the inspector and
+remote-eval too, not just the DAP.
+
+## Alternatives
+
+**A separate IDE.** What Racket, Elixir, and Gleam did instead — deepen the
+extension/LSP surface — worked, and this project's size makes a second binary
+a distraction. Rejected.
+
+**LSP first, wrapping the CLI.** An LSP speaking to `ik` over stdout would
+inherit the caret-scraping contract and pay a process spawn per request. The
+enablers are in the runtime; the protocol layer is the easy part. Rejected as
+an ordering, not as a goal.
+
+**Growing the TextMate name lists (or tree-sitter).** Any lexical approach
+keeps the two hand-maintained operative/applicative lists and still cannot
+color a user-defined operative, because operative-ness is a property of the
+bound value, not the text. Semantic tokens from the server obsolete both
+lists. Rejected.
+
+**Debug adapter early.** "Harder, high value" understates the gap: there is
+no session protocol at all. Building the DAP first would force one into
+existence in DAP's shape rather than a shape the inspector and playground can
+share. Deferred, not rejected.
+
+**A single unversioned JSON blob.** The `version` field costs one property
+and makes the day the format changes a negotiation instead of a breakage.
+
+## Consequences
+
+The JSON format is now a contract with an external consumer; changes go
+through the version field. `check` is defined as `compile` minus the write,
+so the two cannot drift — and when the analyzer learns to reject unbound
+variables at compile time, every editor gets it the same day. The stderr
+regex is demoted to a fallback for runtime errors and can retire when a
+structured channel exists for `run`.
+
+The phases after 1 are ordered by what they unblock, not by visibility: the
+flashy items (inspector, DAP) are deliberately last because each is a thin
+view over a capability the runtime does not yet expose. The temptation to
+reorder toward visibility is the failure mode this ADR exists to record.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -11,6 +11,8 @@ The extension never implements a second evaluator in JavaScript.
 - Bracket matching, comments, indentation, and IronKernel snippets
 - **Run Current File** and **Compile Current File to IKC** commands
 - **Run Project** and **Build Project** for `.ikproj` (nearest project, picker, or explorer context menu)
+- Check on save: `ik check --json` runs on saved `.ikr` files and publishes
+  span-accurate diagnostics (disable with `ironkernel.checkOnSave`)
 - Source-range diagnostics in VS Code's Problems view
 - A playground with runnable examples, validation, cancellation, output limits, and timeouts
 
@@ -54,6 +56,7 @@ host authority available to editor commands and playground runs.
 ## Commands
 
 - `IronKernel: Run Current File`
+- `IronKernel: Check Current File` — `check <file.ikr> --json`, also run on save
 - `IronKernel: Compile Current File to IKC`
 - `IronKernel: Run Project` — `run <project.ikproj>` (plus `ironkernel.runArgs`)
 - `IronKernel: Build Project` — `build <project.ikproj>` → `bin/*.ikc`

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -32,6 +32,7 @@
   "activationEvents": [
     "onLanguage:ironkernel",
     "onCommand:ironkernel.runFile",
+    "onCommand:ironkernel.checkFile",
     "onCommand:ironkernel.compileFile",
     "onCommand:ironkernel.runProject",
     "onCommand:ironkernel.buildProject",
@@ -90,6 +91,11 @@
       {
         "command": "ironkernel.runFile",
         "title": "IronKernel: Run Current File",
+        "category": "IronKernel"
+      },
+      {
+        "command": "ironkernel.checkFile",
+        "title": "IronKernel: Check Current File",
         "category": "IronKernel"
       },
       {
@@ -210,6 +216,11 @@
           "default": "unrestricted",
           "description": "Capability profile used for scripts, packages, and playground execution."
         },
+        "ironkernel.checkOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "Run 'ik check' on saved IronKernel files and show its diagnostics inline. Requires a trusted workspace."
+        },
         "ironkernel.playground.timeoutMs": {
           "type": "number",
           "default": 10000,
@@ -229,7 +240,7 @@
     "problemPatterns": [
       {
         "name": "ironkernel",
-        "regexp": "^(?:Script error|Compile error|Package error|Project error|Startup error):\\s+(.+):(\\d+):(\\d+):\\s+(.*)$",
+        "regexp": "^(?:Script error|Compile error|Package error|Project error|Startup error|Test startup error|Build error|Check error):\\s+(.+):(\\d+):(\\d+):\\s+(.*)$",
         "file": 1,
         "line": 2,
         "column": 3,

--- a/editors/vscode/src/diagnostics.ts
+++ b/editors/vscode/src/diagnostics.ts
@@ -7,7 +7,102 @@ export interface ParsedDiagnostic {
 }
 
 const headerPattern =
-  /^(?:Script error|Compile error|Package error|Project error|Startup error):\s+(.+):(\d+):(\d+):\s+(.*)$/;
+  /^(?:Script error|Compile error|Package error|Project error|Startup error|Test startup error|Build error|Check error):\s+(.+):(\d+):(\d+):\s+(.*)$/;
+
+export interface CheckPosition {
+  line: number;
+  column: number;
+}
+
+export interface CheckRange {
+  start: CheckPosition;
+  end: CheckPosition;
+}
+
+export interface CheckLocation {
+  file: string;
+  range?: CheckRange;
+}
+
+export interface CheckDiagnostic extends CheckLocation {
+  severity: string;
+  message: string;
+  related?: CheckLocation[];
+}
+
+function readPosition(value: unknown): CheckPosition | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  const { line, column } = value as { line?: unknown; column?: unknown };
+  if (typeof line !== "number" || typeof column !== "number" || line < 1 || column < 1) {
+    return undefined;
+  }
+  return { line, column };
+}
+
+function readLocation(value: unknown): CheckLocation | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  const entry = value as { file?: unknown; range?: unknown };
+  if (typeof entry.file !== "string" || entry.file === "") {
+    return undefined;
+  }
+  if (entry.range === undefined) {
+    return { file: entry.file };
+  }
+  const range = entry.range as { start?: unknown; end?: unknown };
+  const start = readPosition(range.start);
+  const end = readPosition(range.end);
+  if (!start || !end) {
+    return undefined;
+  }
+  return { file: entry.file, range: { start, end } };
+}
+
+/**
+ * Parses `ik check --json` output (a version-1 check report). Returns
+ * undefined when stdout is not such a report, so callers can tell "clean"
+ * from "the CLI never produced one".
+ */
+export function parseCheckReport(stdout: string): CheckDiagnostic[] | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return undefined;
+  }
+  const report = parsed as { version?: unknown; diagnostics?: unknown };
+  if (report.version !== 1 || !Array.isArray(report.diagnostics)) {
+    return undefined;
+  }
+
+  const diagnostics: CheckDiagnostic[] = [];
+  for (const entry of report.diagnostics) {
+    const location = readLocation(entry);
+    if (!location) {
+      continue;
+    }
+    const { severity, message, related } = entry as {
+      severity?: unknown;
+      message?: unknown;
+      related?: unknown;
+    };
+    diagnostics.push({
+      ...location,
+      severity: typeof severity === "string" ? severity : "error",
+      message: typeof message === "string" ? message : "IronKernel error",
+      related: Array.isArray(related)
+        ? related.map(readLocation).filter((value): value is CheckLocation => value !== undefined)
+        : undefined
+    });
+  }
+  return diagnostics;
+}
 
 export function parseDiagnostics(stderr: string): ParsedDiagnostic[] {
   const lines = stderr.replace(/\r\n/g, "\n").split("\n");

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,7 +1,12 @@
 import * as path from "node:path";
 import * as vscode from "vscode";
 import { resolveRuntime, runProcess, type RuntimeCommand } from "./cli.js";
-import { parseDiagnostics } from "./diagnostics.js";
+import {
+  parseCheckReport,
+  parseDiagnostics,
+  type CheckDiagnostic,
+  type CheckLocation
+} from "./diagnostics.js";
 import { PlaygroundPanel } from "./playgroundPanel.js";
 import { findIkprojWalkingUp, isIkprojPath, rankIkProjects } from "./projects.js";
 
@@ -16,6 +21,23 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("ironkernel.showOutput", () => output.show()),
     vscode.commands.registerCommand("ironkernel.openPlayground", () => {
       PlaygroundPanel.createOrShow(context, output);
+    }),
+    vscode.commands.registerCommand("ironkernel.checkFile", async () => {
+      const document = await activeIronKernelDocument();
+      if (document) {
+        await runCheck(document, output, diagnostics);
+      }
+    }),
+    vscode.workspace.onDidSaveTextDocument((document) => {
+      if (
+        document.languageId === "ironkernel" &&
+        vscode.workspace.isTrusted &&
+        vscode.workspace
+          .getConfiguration("ironkernel", document.uri)
+          .get<boolean>("checkOnSave", true)
+      ) {
+        void runCheck(document, output, diagnostics);
+      }
     }),
     vscode.commands.registerCommand("ironkernel.runFile", async () => {
       const document = await activeIronKernelDocument();
@@ -191,13 +213,10 @@ async function saveIronKernelDocumentsNear(projectPath: string): Promise<void> {
   }
 }
 
-async function executeCli(
+async function resolveConfiguredRuntime(
   scopeUri: vscode.Uri,
-  args: string[],
-  title: string,
-  output: vscode.OutputChannel,
-  collection: vscode.DiagnosticCollection
-): Promise<void> {
+  output: vscode.OutputChannel
+): Promise<{ runtime: RuntimeCommand; maxOutputBytes: number } | undefined> {
   const folder = vscode.workspace.getWorkspaceFolder(scopeUri);
   const configuration = vscode.workspace.getConfiguration("ironkernel", scopeUri);
   let runtime: RuntimeCommand;
@@ -211,14 +230,127 @@ async function executeCli(
     const message = error instanceof Error ? error.message : String(error);
     output.appendLine(`[launch failed] ${message}`);
     void vscode.window.showErrorMessage(`Unable to resolve IronKernel: ${message}`);
-    return;
+    return undefined;
   }
   const profile = configuration.get<string>("profile", "unrestricted");
-  runtime = {
-    ...runtime,
-    prefixArgs: [...runtime.prefixArgs, "--profile", profile]
+  return {
+    runtime: {
+      ...runtime,
+      prefixArgs: [...runtime.prefixArgs, "--profile", profile]
+    },
+    maxOutputBytes: configuration.get<number>("maxOutputBytes", 1024 * 1024)
   };
-  const maxOutputBytes = configuration.get<number>("maxOutputBytes", 1024 * 1024);
+}
+
+const checksInFlight = new Map<string, AbortController>();
+
+async function runCheck(
+  document: vscode.TextDocument,
+  output: vscode.OutputChannel,
+  collection: vscode.DiagnosticCollection
+): Promise<void> {
+  const resolved = await resolveConfiguredRuntime(document.uri, output);
+  if (!resolved) {
+    return;
+  }
+  const key = document.uri.toString();
+  checksInFlight.get(key)?.abort();
+  const controller = new AbortController();
+  checksInFlight.set(key, controller);
+  try {
+    const result = await runProcess(
+      resolved.runtime,
+      ["check", document.uri.fsPath, "--json"],
+      {
+        timeoutMs,
+        maxOutputBytes: resolved.maxOutputBytes,
+        signal: controller.signal
+      }
+    );
+    if (result.cancelled) {
+      return;
+    }
+    const report = parseCheckReport(result.stdout);
+    if (report === undefined) {
+      output.appendLine(`[check produced no report; exit ${result.exitCode ?? "unknown"}]`);
+      if (result.stderr) {
+        output.append(result.stderr);
+      }
+      return;
+    }
+    publishCheckDiagnostics(document.uri, report, collection);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    output.appendLine(`[check failed] ${message}`);
+  } finally {
+    if (checksInFlight.get(key) === controller) {
+      checksInFlight.delete(key);
+    }
+  }
+}
+
+function toRange(location: CheckLocation): vscode.Range {
+  if (!location.range) {
+    return new vscode.Range(0, 0, 0, 1);
+  }
+  const startLine = location.range.start.line - 1;
+  const startColumn = location.range.start.column - 1;
+  let endLine = location.range.end.line - 1;
+  let endColumn = location.range.end.column - 1;
+  if (endLine < startLine || (endLine === startLine && endColumn <= startColumn)) {
+    endLine = startLine;
+    endColumn = startColumn + 1;
+  }
+  return new vscode.Range(startLine, startColumn, endLine, endColumn);
+}
+
+function publishCheckDiagnostics(
+  checkedUri: vscode.Uri,
+  report: CheckDiagnostic[],
+  collection: vscode.DiagnosticCollection
+): void {
+  const byDocument = new Map<string, vscode.Diagnostic[]>();
+  // A clean report must still overwrite the checked file's stale entries.
+  byDocument.set(checkedUri.toString(), []);
+  for (const entry of report) {
+    const uri = vscode.Uri.file(entry.file);
+    const diagnostic = new vscode.Diagnostic(
+      toRange(entry),
+      entry.message,
+      vscode.DiagnosticSeverity.Error
+    );
+    diagnostic.source = "IronKernel";
+    if (entry.related && entry.related.length > 0) {
+      diagnostic.relatedInformation = entry.related.map(
+        (location) =>
+          new vscode.DiagnosticRelatedInformation(
+            new vscode.Location(vscode.Uri.file(location.file), toRange(location)),
+            "in this enclosing form"
+          )
+      );
+    }
+    const key = uri.toString();
+    const values = byDocument.get(key) ?? [];
+    values.push(diagnostic);
+    byDocument.set(key, values);
+  }
+  for (const [key, values] of byDocument) {
+    collection.set(vscode.Uri.parse(key), values);
+  }
+}
+
+async function executeCli(
+  scopeUri: vscode.Uri,
+  args: string[],
+  title: string,
+  output: vscode.OutputChannel,
+  collection: vscode.DiagnosticCollection
+): Promise<void> {
+  const resolved = await resolveConfiguredRuntime(scopeUri, output);
+  if (!resolved) {
+    return;
+  }
+  const { runtime, maxOutputBytes } = resolved;
   collection.clear();
   output.show(true);
   output.appendLine(`> ${runtime.command} ${[...runtime.prefixArgs, ...args].join(" ")}`);

--- a/editors/vscode/test/diagnostics.test.ts
+++ b/editors/vscode/test/diagnostics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseDiagnostics } from "../src/diagnostics.js";
+import { parseCheckReport, parseDiagnostics } from "../src/diagnostics.js";
 
 describe("parseDiagnostics", () => {
   it("parses a ranged Unix diagnostic", () => {
@@ -41,5 +41,79 @@ describe("parseDiagnostics", () => {
 
   it("ignores unrelated output", () => {
     expect(parseDiagnostics("Hello,world!\n")).toEqual([]);
+  });
+});
+
+describe("parseCheckReport", () => {
+  it("parses a version-1 report with ranges and related locations", () => {
+    const report = parseCheckReport(
+      JSON.stringify({
+        version: 1,
+        diagnostics: [
+          {
+            severity: "error",
+            message: "Parse error: Expecting ')'",
+            file: "/work/demo.ikr",
+            range: { start: { line: 4, column: 1 }, end: { line: 4, column: 1 } },
+            related: [
+              {
+                file: "/work/demo.ikr",
+                range: { start: { line: 1, column: 1 }, end: { line: 4, column: 1 } }
+              }
+            ]
+          }
+        ]
+      })
+    );
+
+    expect(report).toEqual([
+      {
+        severity: "error",
+        message: "Parse error: Expecting ')'",
+        file: "/work/demo.ikr",
+        range: { start: { line: 4, column: 1 }, end: { line: 4, column: 1 } },
+        related: [
+          {
+            file: "/work/demo.ikr",
+            range: { start: { line: 1, column: 1 }, end: { line: 4, column: 1 } }
+          }
+        ]
+      }
+    ]);
+  });
+
+  it("keeps a rangeless diagnostic and distinguishes a clean report from garbage", () => {
+    const clean = parseCheckReport('{"version":1,"diagnostics":[]}');
+    expect(clean).toEqual([]);
+
+    const rangeless = parseCheckReport(
+      '{"version":1,"diagnostics":[{"severity":"error","message":"Failed to read","file":"/gone.ikr"}]}'
+    );
+    expect(rangeless).toEqual([
+      { severity: "error", message: "Failed to read", file: "/gone.ikr", related: undefined }
+    ]);
+
+    expect(parseCheckReport("")).toBeUndefined();
+    expect(parseCheckReport("Wrote demo.ikc\n")).toBeUndefined();
+    expect(parseCheckReport('{"version":2,"diagnostics":[]}')).toBeUndefined();
+  });
+
+  it("drops malformed entries instead of failing the report", () => {
+    const report = parseCheckReport(
+      JSON.stringify({
+        version: 1,
+        diagnostics: [
+          { severity: "error", message: "no file here" },
+          {
+            severity: "error",
+            message: "bad range",
+            file: "/work/demo.ikr",
+            range: { start: { line: 0, column: 1 }, end: { line: 1, column: 1 } }
+          },
+          { severity: "error", message: "kept", file: "/work/demo.ikr" }
+        ]
+      })
+    );
+    expect(report?.map((entry) => entry.message)).toEqual(["kept"]);
   });
 });


### PR DESCRIPTION
## What

Phase 1 of [ADR 0009](docs/adr/0009-editor-tooling-from-the-runtime-outward.md), which records the editor-tooling direction: grow tooling from the runtime outward — structured diagnostics first, environment enumeration next, then an in-process language server — rather than an IDE or an LSP wrapping the CLI's text output.

### CLI

- `ik check [--json] [<file.ikr> | project.ikproj]` — parse + analyze with nothing evaluated or written. Defined as `compile` minus the write (`Emit.checkSourceFileForProfile` reuses the same pipeline), so semantic checks later added to analysis reach editors with no further work.
- Exit codes: 0 clean, 1 findings, 2 usage. `--json` emits a versioned report on stdout: `file`, 1-based end-exclusive `range`, nested `LocatedError` wrappers as `related` locations; spanless errors carry `file` only.
- Project check walks sources, main, and tests (not dependency sources), needs no restore, and continues past a broken file to report all findings.
- `showError` splits into `errorLocations`/`errorMessage` so both renderings share one traversal — human output is byte-identical (existing exact-output error tests unchanged and passing).
- The `Project startup error:` prefix becomes `Startup error:`, which the extension's regex actually matches.

### VS Code extension

- Checks `.ikr` files on save (`ironkernel.checkOnSave`, default on, trusted workspaces only) plus a **Check Current File** command — span-accurate diagnostics from the JSON instead of regex-scraping caret art from stderr. Per-file, quiet, abortable; a clean report clears stale squiggles.
- The stderr regex remains as the fallback for `run` output and now also matches the `Build error` / `Test startup error` / `Check error` prefixes it previously dropped.

## Verification

- Clean `--no-incremental` rebuild: zero warnings. Full suite: 422/422 (415 on master + 7 new).
- All examples run (yingyang skipped); CLR fault sweep: `faulted (process aborted): 0`.
- Extension: `tsc --noEmit` clean, vitest 21/21 (3 new `parseCheckReport` tests).
- Benchmarks skipped deliberately: nothing added to the ordinary evaluation path — the refactored helpers run only when an error is rendered, and `check` is a new cold path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790009282&installation_model_id=427656&pr_number=85&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F85&signature=64fa8d208a6236d6a621e7267cbfe0e870fc9487bd09c3bb12a0ce493aa89ccc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->