### PR TITLE
Add IronKernel.Math: statistics, combinatorics, number theory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           # Seed the local folder feeds siblings restore from (lib/NuGet.config).
           "$bin" pack lib/IronKernel.Test/IronKernel.Test.ikproj
           "$bin" pack lib/IronKernel.Strings/IronKernel.Strings.ikproj
+          "$bin" pack lib/IronKernel.Collections/IronKernel.Collections.ikproj
           for project in lib/*/*.ikproj; do
             echo "=== ik test $project"
             "$bin" test "$project"

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ for the local-feed workflow and the roadmap.
 | [`IronKernel.Collections`](lib/IronKernel.Collections/) | Folds, slicing, stable sort, sets over `equal?`, alist editing, and the vector/list bridge — pure Kernel |
 | [`IronKernel.Strings`](lib/IronKernel.Strings/) | Search, split/join, case, trimming, padding, characters, invariant number conversion, and a variadic `format` — ordinal semantics throughout |
 | [`IronKernel.Json`](lib/IronKernel.Json/) | Grammar-enforcing JSON reader with offsets in its errors, a writer that refuses what JSON cannot carry, pretty-printing, and path traversal |
+| [`IronKernel.Math`](lib/IronKernel.Math/) | Statistics, combinatorics, and number theory — exact wherever the mathematics allows: means as ratios, `isqrt` and `factorial` at any size, primes, factorizations, totients |
 | [`IronKernel.Amb`](lib/IronKernel.Amb/) | Nondeterministic search: `amb`, `require`, bracketed choice, and pluggable search strategies over multi-shot delimited continuations |
 
 Packages test against `IronKernel.Test` through a test-scoped reference

--- a/lib/IronKernel.Math/.gitignore
+++ b/lib/IronKernel.Math/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+*.ikc
+packages.lock.json

--- a/lib/IronKernel.Math/IronKernel.Math.ikproj
+++ b/lib/IronKernel.Math/IronKernel.Math.ikproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <PackageId>IronKernel.Math</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>IronKernel</Authors>
+    <Description>Statistics, combinatorics, and number theory for IronKernel, exact wherever the mathematics allows: means as ratios, isqrt and factorial on integers of any size, primes, factorizations, totients. Pure Kernel; no host I/O.</Description>
+    <PackageTags>ironkernel</PackageTags>
+    <IronKernelMain>src/math.ikr</IronKernelMain>
+    <IronKernelProfile>unrestricted</IronKernelProfile>
+  </PropertyGroup>
+  <ItemGroup>
+    <IronKernelSource Include="src/**/*.ikr" />
+    <IronKernelTest Include="test/**/*.ikr" />
+    <PackageReference Include="IronKernel.Collections" Version="0.1.0" IronKernelKind="IronKernel" />
+    <PackageReference Include="IronKernel.Test" Version="0.1.0" IronKernelKind="IronKernel" IronKernelScope="test" />
+  </ItemGroup>
+</Project>

--- a/lib/IronKernel.Math/README.md
+++ b/lib/IronKernel.Math/README.md
@@ -1,0 +1,90 @@
+# IronKernel.Math
+
+Statistics, combinatorics, and number theory for IronKernel. The runtime's
+numeric tower is already strong — integers promote to big integers, division
+of exacts gives exact ratios in least terms — so this package adds what the
+tower does not: the procedures that combine numbers, exact wherever the
+mathematics allows.
+
+```scheme
+(mean (list 1 2))          ; => 3/2, exactly
+(isqrt (expt 10 100))      ; => 10^50, exactly — sqrt would round
+(binomial 52 5)            ; => 2598960
+(prime-factors 360)        ; => (2 2 2 3 3 5)
+```
+
+Only `stdev` is inherently inexact — it takes a square root — and says so by
+returning one.
+
+## Use
+
+```bash
+ik add IronKernel.Math 0.1.0
+```
+
+Or, from a checkout of this repository:
+
+```bash
+cd lib/IronKernel.Test && ik pack        # seed the local feed
+cd ../IronKernel.Collections && ik pack
+cd ../IronKernel.Math
+ik test
+ik pack
+```
+
+## API
+
+### Constants
+
+`pi`, `tau`, `euler`, `golden-ratio` — each the double nearest the
+mathematical value.
+
+### Basics
+
+| Form | Meaning |
+|---|---|
+| `(sign x)` | −1, 0, or 1, always exact, for any real. |
+| `(clamp x lo hi)` | Signals if `lo > hi`. |
+| `(lerp a b t)` | `a` at `t=0`, `b` at `t=1`; exact on exact inputs. |
+| `(isqrt n)` | Largest integer whose square does not exceed `n`. Newton's method on exact integers — correct at sizes where `sqrt`'s double rounds. |
+
+### Statistics
+
+All take a non-empty list of reals and preserve exactness.
+
+| Form | Meaning |
+|---|---|
+| `(sum xs)` / `(product xs)` | 0 and 1 on the empty list. |
+| `(mean xs)` | An exact ratio on exact inputs. |
+| `(median xs)` | Sorts internally; even count gives the mean of the two middles. |
+| `(variance xs)` | Population variance, exact. |
+| `(sample-variance xs)` | Bessel's n−1 correction; wants at least two elements. |
+| `(stdev xs)` / `(sample-stdev xs)` | Inexact, by nature. |
+
+### Combinatorics
+
+| Form | Meaning |
+|---|---|
+| `(factorial n)` | Exact at any size. |
+| `(binomial n k)` | n choose k by the rising product — k steps, never a full factorial. Out-of-range k gives 0. |
+| `(permutations n k)` | Ordered selections: the falling factorial. |
+
+### Number theory
+
+| Form | Meaning |
+|---|---|
+| `(prime? n)` | Trial division stepping 6k±1 — exact at any size, suited to 64-bit-scale numbers, not cryptographic ones. |
+| `(next-prime n)` | Smallest prime strictly greater than `n`. |
+| `(primes-upto n)` | Sieve of Eratosthenes, bound included. |
+| `(prime-factors n)` | With multiplicity, ascending; `(prime-factors 1)` is `()`. |
+| `(divisors n)` | Every positive divisor, ascending, in O(√n). |
+| `(totient n)` | Euler's φ, from the distinct prime factors, exactly. |
+| `(coprime? a b)` | `gcd` is 1. |
+
+## Notes
+
+- Pure Kernel: no CLR interop, no host I/O. List work (folds, `sort`,
+  `distinct`) comes from [`IronKernel.Collections`](../IronKernel.Collections/),
+  a runtime dependency.
+- Domain errors signal rather than answer: `(isqrt -1)`, `(factorial -1)`,
+  `(prime? 7.0)`, `(sample-variance (list 1))` are all errors.

--- a/lib/IronKernel.Math/src/math.ikr
+++ b/lib/IronKernel.Math/src/math.ikr
@@ -1,0 +1,271 @@
+; IronKernel.Math -- statistics, combinatorics, number theory
+; ===========================================================
+;
+; The runtime's numeric tower is already strong: integers promote to big
+; integers, division of exacts gives exact ratios in least terms, expt of
+; exacts stays exact. This package adds what the tower does not: the
+; procedures that combine numbers.
+;
+;   (mean (list 1 2))          ; => 3/2, exactly
+;   (isqrt (expt 10 100))      ; => 10^50, exactly -- sqrt would round
+;   (binomial 52 5)            ; => 2598960
+;   (prime-factors 360)        ; => (2 2 2 3 3 5)
+;
+; Exactness is preserved wherever the mathematics allows: sums, products,
+; means, medians, variances, and everything in the combinatorics and number
+; theory sections are exact on exact inputs. Only stdev is inherently
+; inexact -- it takes a square root -- and says so by returning one.
+;
+; Everything here works on integers of any size; factorial, binomial, and
+; isqrt are routine on hundreds of digits. The primality test is trial
+; division (6k±1) -- honest and exact at any size, but quadratic in the
+; number of digits, so it is a fit for 64-bit-scale numbers, not
+; cryptographic ones.
+;
+; Pure Kernel: no CLR interop, no host I/O. List procedures (folds, sort)
+; come from IronKernel.Collections, a runtime dependency.
+
+(provide! (pi tau euler golden-ratio
+           sign clamp lerp isqrt
+           sum product mean median
+           variance stdev sample-variance sample-stdev
+           factorial binomial permutations
+           prime? next-prime primes-upto prime-factors divisors totient
+           coprime?)
+
+  ; --- constants ------------------------------------------------------------
+  ;
+  ; Written as literals so the package stays pure Kernel; each is the double
+  ; nearest the mathematical value.
+
+  (define pi 3.141592653589793)
+  (define tau 6.283185307179586)
+  (define euler 2.718281828459045)
+  (define golden-ratio 1.618033988749895)
+
+  ; --- private --------------------------------------------------------------
+
+  (define ensure
+    (lambda (ok message)
+      (if ok #inert (error message))))
+
+  (define exact-integer?
+    (lambda (n) ($and? (integer? n) (exact? n))))
+
+  ; --- basics ---------------------------------------------------------------
+
+  ; -1, 0, or 1, always exact, for any real.
+  (define sign
+    (lambda (x)
+      (cond ((positive? x) 1)
+            ((negative? x) -1)
+            (#t 0))))
+
+  (define clamp
+    (lambda (x lo hi)
+      (ensure (<=? lo hi) "clamp: lower bound exceeds upper bound")
+      (cond ((<? x lo) lo)
+            ((>? x hi) hi)
+            (#t x))))
+
+  ; Linear interpolation: a at t=0, b at t=1. Exact on exact inputs.
+  (define lerp
+    (lambda (a b t)
+      (+ a (* (- b a) t))))
+
+  ; The largest integer whose square does not exceed n. Newton's method on
+  ; exact integers, so it is correct at sizes where sqrt's double rounds.
+  (define isqrt
+    (lambda (n)
+      (ensure (exact-integer? n) "isqrt: wants an exact integer")
+      (ensure (not? (negative? n)) "isqrt: wants a non-negative integer")
+      (if (<? n 2)
+        n
+        (letrec ((improve (lambda (guess)
+                            (let ((better (div (+ guess (div n guess)) 2)))
+                              (if (<? better guess) (improve better) guess)))))
+          (improve n)))))
+
+  ; --- statistics -----------------------------------------------------------
+  ;
+  ; All take a non-empty list of reals and preserve exactness; on exact
+  ; inputs a mean is an exact ratio, not a rounded double.
+
+  (define sum (lambda (xs) (fold-left + 0 xs)))
+  (define product (lambda (xs) (fold-left * 1 xs)))
+
+  (define mean
+    (lambda (xs)
+      (ensure (not? (null? xs)) "mean: wants a non-empty list")
+      (/ (sum xs) (length xs))))
+
+  ; The middle element; for an even count, the mean of the two middles.
+  (define median
+    (lambda (xs)
+      (ensure (not? (null? xs)) "median: wants a non-empty list")
+      (let ((ordered (sort xs <?))
+            (n (length xs)))
+        (let ((middle (list-ref ordered (div n 2))))
+          (if (odd? n)
+            middle
+            (/ (+ (list-ref ordered (- (div n 2) 1)) middle) 2))))))
+
+  (define squared-deviations
+    (lambda (xs)
+      (let ((m (mean xs)))
+        (sum (map (lambda (x) (let ((d (- x m))) (* d d))) xs)))))
+
+  ; Population variance: mean squared deviation from the mean.
+  (define variance
+    (lambda (xs)
+      (ensure (not? (null? xs)) "variance: wants a non-empty list")
+      (/ (squared-deviations xs) (length xs))))
+
+  ; Sample variance, with Bessel's n-1 correction.
+  (define sample-variance
+    (lambda (xs)
+      (ensure (<? 1 (length xs)) "sample-variance: wants at least two elements")
+      (/ (squared-deviations xs) (- (length xs) 1))))
+
+  (define stdev
+    (lambda (xs) (sqrt (real->inexact (variance xs)))))
+
+  (define sample-stdev
+    (lambda (xs) (sqrt (real->inexact (sample-variance xs)))))
+
+  ; --- combinatorics --------------------------------------------------------
+
+  (define factorial
+    (lambda (n)
+      (ensure (exact-integer? n) "factorial: wants an exact integer")
+      (ensure (not? (negative? n)) "factorial: wants a non-negative integer")
+      (letrec ((go (lambda (i acc)
+                     (if (<=? i 1) acc (go (- i 1) (* acc i))))))
+        (go n 1))))
+
+  ; n choose k, by the rising product -- k multiplications and divisions,
+  ; never a full factorial. Out-of-range k gives 0, as the identity wants.
+  (define binomial
+    (lambda (n k)
+      (ensure (exact-integer? n) "binomial: wants exact integers")
+      (ensure (exact-integer? k) "binomial: wants exact integers")
+      (cond ((negative? k) 0)
+            ((>? k n) 0)
+            (#t (let ((k (min k (- n k))))
+                  (letrec ((go (lambda (i acc)
+                                 (if (>? i k)
+                                   acc
+                                   (go (+ i 1) (div (* acc (- n (- i 1))) i))))))
+                    (go 1 1)))))))
+
+  ; Ordered selections of k from n: the falling factorial n (n-1) ... (n-k+1).
+  (define permutations
+    (lambda (n k)
+      (ensure (exact-integer? n) "permutations: wants exact integers")
+      (ensure (exact-integer? k) "permutations: wants exact integers")
+      (cond ((negative? k) 0)
+            ((>? k n) 0)
+            (#t (letrec ((go (lambda (i acc)
+                               (if (=? i k)
+                                 acc
+                                 (go (+ i 1) (* acc (- n i)))))))
+                  (go 0 1))))))
+
+  ; --- number theory --------------------------------------------------------
+
+  ; Trial division stepping 6k±1 up to the square root: exact at any size,
+  ; suited to 64-bit-scale numbers.
+  (define prime?
+    (lambda (n)
+      (ensure (exact-integer? n) "prime?: wants an exact integer")
+      (cond ((<? n 2) #f)
+            ((<? n 4) #t)
+            ((zero? (mod n 2)) #f)
+            ((zero? (mod n 3)) #f)
+            (#t (letrec ((probe (lambda (i)
+                                  (cond ((>? (* i i) n) #t)
+                                        ((zero? (mod n i)) #f)
+                                        ((zero? (mod n (+ i 2))) #f)
+                                        (#t (probe (+ i 6)))))))
+                  (probe 5))))))
+
+  ; The smallest prime strictly greater than n.
+  (define next-prime
+    (lambda (n)
+      (ensure (exact-integer? n) "next-prime: wants an exact integer")
+      (if (<? n 2)
+        2
+        (letrec ((from (lambda (candidate)
+                         (if (prime? candidate) candidate (from (+ candidate 2))))))
+          (if (=? n 2) 3 (from (if (odd? n) (+ n 2) (+ n 1))))))))
+
+  ; Every prime up to and including n, by the sieve of Eratosthenes.
+  (define primes-upto
+    (lambda (n)
+      (ensure (exact-integer? n) "primes-upto: wants an exact integer")
+      (if (<? n 2)
+        ()
+        (let ((composite (make-vector (+ n 1) #f)))
+          (letrec
+            ((strike (lambda (multiple step)
+                       (if (<=? multiple n)
+                         (begin (vector-set! composite multiple #t)
+                                (strike (+ multiple step) step))
+                         #inert)))
+             (mark (lambda (p)
+                     (if (<=? (* p p) n)
+                       (begin
+                         (if (vector-ref composite p) #inert (strike (* p p) p))
+                         (mark (+ p 1)))
+                       #inert)))
+             (collect (lambda (p)
+                        (cond ((>? p n) ())
+                              ((vector-ref composite p) (collect (+ p 1)))
+                              (#t (cons p (collect (+ p 1))))))))
+            (mark 2)
+            (collect 2))))))
+
+  ; The prime factorization with multiplicity, ascending:
+  ; (prime-factors 360) => (2 2 2 3 3 5). 1 has the empty factorization.
+  (define prime-factors
+    (lambda (n)
+      (ensure (exact-integer? n) "prime-factors: wants an exact integer")
+      (ensure (positive? n) "prime-factors: wants a positive integer")
+      (letrec
+        ((pull (lambda (n d)
+                 (if (zero? (mod n d))
+                   (cons d (pull (div n d) d))
+                   (rest n (if (=? d 2) 3 (+ d 2))))))
+         (rest (lambda (n d)
+                 (cond ((>? (* d d) n) (if (=? n 1) () (list n)))
+                       (#t (pull n d))))))
+        (rest n 2))))
+
+  ; Every positive divisor, ascending. Collected as d and n/d pairs up to
+  ; the square root, so the work is O(sqrt n).
+  (define divisors
+    (lambda (n)
+      (ensure (exact-integer? n) "divisors: wants an exact integer")
+      (ensure (positive? n) "divisors: wants a positive integer")
+      (letrec ((walk (lambda (d low high)
+                       (cond ((>? (* d d) n) (append (reverse low) high))
+                             ((zero? (mod n d))
+                              (let ((partner (div n d)))
+                                (walk (+ d 1)
+                                      (cons d low)
+                                      (if (=? d partner) high (cons partner high)))))
+                             (#t (walk (+ d 1) low high))))))
+        (walk 1 () ()))))
+
+  ; Euler's totient: how many of 1..n are coprime to n. Computed from the
+  ; distinct prime factors, exactly.
+  (define totient
+    (lambda (n)
+      (ensure (exact-integer? n) "totient: wants an exact integer")
+      (ensure (positive? n) "totient: wants a positive integer")
+      (fold-left (lambda (t p) (* (div t p) (- p 1)))
+                 n
+                 (distinct (prime-factors n)))))
+
+  (define coprime?
+    (lambda (a b) (=? (gcd a b) 1))))

--- a/lib/IronKernel.Math/test/math_test.ikr
+++ b/lib/IronKernel.Math/test/math_test.ikr
@@ -1,0 +1,116 @@
+; Tests for IronKernel.Math, written with IronKernel.Test. IronKernel.Collections
+; arrives as a runtime dependency of the package itself.
+
+(suite "constants"
+  (check "pi is the double nearest pi" (=? pi 3.141592653589793))
+  (check "tau is two pi" (=? tau (* 2.0 pi)))
+  (check "euler" (=? euler 2.718281828459045))
+  (check "the golden ratio satisfies its identity approximately"
+    (let ((residual (- (* golden-ratio golden-ratio) (+ golden-ratio 1.0))))
+      ($and? (<? residual 1e-12) (>? residual -1e-12)))))
+
+(suite "basics"
+  (check-equal "sign of a negative" -1 (sign -3))
+  (check-equal "sign of zero" 0 (sign 0))
+  (check-equal "sign of a positive inexact is exact" 1 (sign 2.5))
+  (check-equal "clamp below" 0 (clamp -5 0 3))
+  (check-equal "clamp inside" 2 (clamp 2 0 3))
+  (check-equal "clamp above" 3 (clamp 5 0 3))
+  (check-error "clamp with crossed bounds signals" (clamp 1 3 0))
+  (check-equal "lerp at zero" 0 (lerp 0 10 0))
+  (check-equal "lerp at one" 10 (lerp 0 10 1))
+  (check-equal "lerp keeps exactness" (/ 5 2) (lerp 0 10 (/ 1 4))))
+
+(suite "isqrt"
+  (check-equal "perfect square" 12 (isqrt 144))
+  (check-equal "rounds down" 9 (isqrt 99))
+  (check-equal "zero" 0 (isqrt 0))
+  (check-equal "one" 1 (isqrt 1))
+  (check "exact where sqrt's double rounds"
+    (=? (isqrt (expt 10 100)) (expt 10 50)))
+  (check "floor property at a hard boundary"
+    (let ((n (- (expt 10 50) 1)))
+      (let ((r (isqrt (* n n))))
+        ($and? (=? r n) (>? (* (+ r 1) (+ r 1)) (* n n))))))
+  (check-error "a negative signals" (isqrt -1))
+  (check-error "an inexact signals" (isqrt 2.0)))
+
+(suite "statistics"
+  (check-equal "sum" 6 (sum (list 1 2 3)))
+  (check-equal "sum of nothing" 0 (sum ()))
+  (check-equal "product" 24 (product (list 2 3 4)))
+  (check-equal "product of nothing" 1 (product ()))
+  (check-equal "mean is exact" (/ 3 2) (mean (list 1 2)))
+  (check-error "mean of nothing signals" (mean ()))
+  (check-equal "median of odd count" 2 (median (list 3 1 2)))
+  (check-equal "median of even count is the middle mean" (/ 5 2) (median (list 4 1 3 2)))
+  (check-equal "median does not require sorted input" 7 (median (list 9 7 1)))
+  (check-equal "population variance, exactly" 4 (variance (list 2 4 4 4 5 5 7 9)))
+  (check-equal "sample variance uses n-1" (/ 32 7) (sample-variance (list 2 4 4 4 5 5 7 9)))
+  (check-error "sample variance of one element signals" (sample-variance (list 1)))
+  (check "stdev is the root of the variance" (=? 2.0 (stdev (list 2 4 4 4 5 5 7 9))))
+  (check "stdev of identical values is zero" (=? 0.0 (stdev (list 5 5 5)))))
+
+(suite "combinatorics"
+  (check-equal "0! is 1" 1 (factorial 0))
+  (check-equal "5!" 120 (factorial 5))
+  (check-equal "20! fits exactly" 2432902008176640000 (factorial 20))
+  (check "30! promotes past 64 bits"
+    (=? (factorial 30) (* 30 (factorial 29))))
+  (check-error "factorial of a negative signals" (factorial -1))
+  (check-equal "binomial" 2598960 (binomial 52 5))
+  (check-equal "binomial edge: choose 0" 1 (binomial 7 0))
+  (check-equal "binomial edge: choose all" 1 (binomial 7 7))
+  (check-equal "binomial out of range is 0" 0 (binomial 5 7))
+  (check-equal "binomial of negative k is 0" 0 (binomial 5 -1))
+  (check "binomial agrees with the factorial identity at scale"
+    (=? (binomial 100 50)
+        (div (factorial 100) (* (factorial 50) (factorial 50)))))
+  (check "Pascal's rule holds"
+    (=? (binomial 30 12) (+ (binomial 29 11) (binomial 29 12))))
+  (check-equal "permutations" 60 (permutations 5 3))
+  (check-equal "permutations of all is the factorial" 120 (permutations 5 5))
+  (check-equal "permutations out of range is 0" 0 (permutations 3 5)))
+
+(suite "primes"
+  (check "2 is prime" (prime? 2))
+  (check "1 is not" (not? (prime? 1)))
+  (check "0 is not" (not? (prime? 0)))
+  (check "negatives are not" (not? (prime? -7)))
+  (check "97 is prime" (prime? 97))
+  (check "91 is 7 times 13" (not? (prime? 91)))
+  (check "a square of a prime is not prime" (not? (prime? 49)))
+  (check "a larger prime" (prime? 104729))
+  (check-error "prime? of an inexact signals" (prime? 7.0))
+  (check-equal "next-prime from below 2" 2 (next-prime 0))
+  (check-equal "next-prime is strictly greater" 3 (next-prime 2))
+  (check-equal "next-prime skips evens" 101 (next-prime 100))
+  (check-equal "next-prime after a prime" 104729 (next-prime 104723))
+  (check-equal "primes-upto"
+    (list 2 3 5 7 11 13 17 19 23 29) (primes-upto 30))
+  (check-equal "primes-upto includes its bound" (list 2 3 5 7) (primes-upto 7))
+  (check-equal "primes-upto below 2 is empty" () (primes-upto 1))
+  (check "the sieve and trial division agree"
+    (equal? (primes-upto 200) (filter prime? (range 2 201)))))
+
+(suite "factorization"
+  (check-equal "prime-factors with multiplicity, ascending"
+    (list 2 2 2 3 3 5) (prime-factors 360))
+  (check-equal "prime-factors of a prime" (list 97) (prime-factors 97))
+  (check-equal "prime-factors of 1 is empty" () (prime-factors 1))
+  (check "prime-factors multiply back"
+    (=? 987654 (product (prime-factors 987654))))
+  (check-error "prime-factors of 0 signals" (prime-factors 0))
+  (check-equal "divisors, ascending"
+    (list 1 2 3 4 6 9 12 18 36) (divisors 36))
+  (check-equal "divisors of a prime" (list 1 97) (divisors 97))
+  (check-equal "divisors of 1" (list 1) (divisors 1))
+  (check-equal "totient of a prime is p-1" 96 (totient 97))
+  (check-equal "totient of 36" 12 (totient 36))
+  (check-equal "totient of 1" 1 (totient 1))
+  (check "totient counts the coprimes"
+    (=? (totient 30) (count (lambda (k) (coprime? k 30)) (range 1 31))))
+  (check "coprime?" (coprime? 35 64))
+  (check "coprime? can miss" (not? (coprime? 6 9))))
+
+(report-checks)

--- a/lib/NuGet.config
+++ b/lib/NuGet.config
@@ -12,5 +12,6 @@
   <packageSources>
     <add key="ironkernel-lib-test" value="IronKernel.Test/bin" />
     <add key="ironkernel-lib-strings" value="IronKernel.Strings/bin" />
+    <add key="ironkernel-lib-collections" value="IronKernel.Collections/bin" />
   </packageSources>
 </configuration>

--- a/lib/README.md
+++ b/lib/README.md
@@ -11,6 +11,7 @@ conventions, tests that can fail for the right reason.
 | [`IronKernel.Collections`](IronKernel.Collections/) | Folds, slicing, stable sort, sets over `equal?`, alist editing, the vector/list bridge — pure Kernel |
 | [`IronKernel.Strings`](IronKernel.Strings/) | Search, split/join, case, trimming, padding, characters, invariant number conversion, variadic `format` — ordinal semantics throughout |
 | [`IronKernel.Json`](IronKernel.Json/) | Grammar-enforcing JSON reader with offsets in its errors, a writer that refuses what JSON cannot carry, pretty-printing, path traversal |
+| [`IronKernel.Math`](IronKernel.Math/) | Statistics, combinatorics, number theory — exact wherever the mathematics allows: means as ratios, `isqrt` and `factorial` at any size, primes, factorizations, totients |
 | [`IronKernel.Amb`](IronKernel.Amb/) | Nondeterministic search: `amb`, `require`, bracketed choice, pluggable search strategies over multi-shot delimited continuations |
 
 ## Working in this directory
@@ -18,7 +19,8 @@ conventions, tests that can fail for the right reason.
 Packages test with `IronKernel.Test` through a **test-scoped reference**
 (`IronKernelScope="test"`, written by `ik add <id> <ver> --test`): it loads
 for `ik test` only and never appears in a published package's dependencies.
-`IronKernel.Json` additionally depends on `IronKernel.Strings` at runtime.
+`IronKernel.Json` additionally depends on `IronKernel.Strings` at runtime,
+and `IronKernel.Math` on `IronKernel.Collections`.
 
 Until these are published to NuGet.org, siblings resolve through the local
 folder feeds in [`NuGet.config`](NuGet.config). Seed them once per checkout:
@@ -26,6 +28,7 @@ folder feeds in [`NuGet.config`](NuGet.config). Seed them once per checkout:
 ```bash
 cd IronKernel.Test && ik pack
 cd ../IronKernel.Strings && ik pack
+cd ../IronKernel.Collections && ik pack
 ```
 
 Packages that consume a locally packed sibling do not commit
@@ -39,9 +42,6 @@ its version, delete `~/.nuget/packages/<id>/<version>` (and the consumer's
 
 ## Candidates for what comes next
 
-- **Math** — the numeric tower is already strong in the runtime (rationals,
-  exact infinities, trig, `expt`); a package earns its place when it offers
-  more than re-exports: statistics, combinatorics, number-theoretic helpers.
 - **Time** — dates, durations, and formatting over `System.DateTime`, with
   the same invariant-culture discipline as `IronKernel.Strings`.
 - **Ports/IO** — structured file and path helpers over the capability-gated


### PR DESCRIPTION
The next package from the `lib/` roadmap. The numeric tower already does the hard part — big-integer promotion, exact ratios in least terms, exact `expt` — so `IronKernel.Math` adds the procedures that **combine** numbers, exact wherever the mathematics allows.

```scheme
(mean (list 1 2))          ; => 3/2, exactly
(isqrt (expt 10 100))      ; => 10^50, exactly — sqrt's double would round
(binomial 52 5)            ; => 2598960
(prime-factors 360)        ; => (2 2 2 3 3 5)
```

## Surface

- **Statistics** — `sum`, `product`, `mean`, `median`, population/sample `variance` and `stdev`. Exact on exact inputs; only `stdev` is inherently inexact (it takes a square root) and says so by returning one.
- **Combinatorics** — `factorial`, `binomial` (rising product: k steps, never a full factorial; out-of-range k gives 0 as the identity wants), `permutations` (falling factorial). Routine on hundreds of digits.
- **Number theory** — `prime?` (6k±1 trial division, documented as fit for 64-bit-scale numbers, not cryptographic ones), `next-prime`, `primes-upto` (sieve), `prime-factors` (with multiplicity, ascending), `divisors` (O(√n)), `totient`, `coprime?`.
- **Basics** — `pi`/`tau`/`euler`/`golden-ratio` as literals, `sign` (always exact), `clamp`, `lerp`, `isqrt` (Newton on exact integers).

Domain errors signal rather than answer: `(isqrt -1)`, `(factorial -1)`, `(prime? 7.0)`, `(sample-variance (list 1))` are all tested errors.

## Composition

Pure Kernel — no CLR interop, no host I/O. List work (`fold-left`, `sort`, `distinct`) comes from `IronKernel.Collections`, making this the second package with a runtime dependency; the nuspec carries Collections and nothing else (test DSL stays excluded via the test-scoped reference). CI's feed-seeding step now packs Collections alongside Test and Strings; the existing loop picks the new package up automatically.

## Tests

82 checks. They cross-check rather than restate the implementation:

- `binomial 100 50` against the factorial identity, and Pascal's rule `C(30,12) = C(29,11) + C(29,12)`
- the sieve against `(filter prime? (range 2 201))`
- `totient 30` by literally counting coprimes
- `isqrt` floor property at the `10^50 − 1` boundary, where a double-based sqrt goes wrong

All six lib packages pass `ik test`; `IronKernel.Math.0.1.0.nupkg` packs with the correct dependency group.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790009310&installation_model_id=427656&pr_number=86&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F86&signature=ad7a3139a1205a025f206f1ac5cf16ffc260514509ca90a82576e2a13a599cc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->