### PR TITLE
Add IronKernel.Time; close the datetime/timespan set under + and -

### DIFF
--- a/IronKernel.Runtime/Arithmetic.fs
+++ b/IronKernel.Runtime/Arithmetic.fs
@@ -391,6 +391,12 @@ namespace IronKernel
                 match b with
                 | :? TimeSpan as span -> returnM (Obj(date + span))
                 | _ -> throwError (ClrTypeMismatch("TimeSpan", b.GetType().Name))
+            | Obj (:? TimeSpan as span), Obj b ->
+                match b with
+                | :? TimeSpan as other -> returnM (Obj(span + other))
+                // Commutative with the case above: (+ span date) is (+ date span).
+                | :? DateTime as date -> returnM (Obj(date + span))
+                | _ -> throwError (ClrTypeMismatch("TimeSpan or DateTime", b.GetType().Name))
             | Obj a, Obj b ->
                 dispatchInfinities addCombine addMixed a b (fun () ->
                     numericBinaryOp addWidened a' b')
@@ -402,7 +408,12 @@ namespace IronKernel
             | Obj (:? DateTime as date), Obj b ->
                 match b with
                 | :? DateTime as other -> returnM (Obj(date - other))
-                | _ -> throwError (ClrTypeMismatch("DateTime", b.GetType().Name))
+                | :? TimeSpan as span -> returnM (Obj(date - span))
+                | _ -> throwError (ClrTypeMismatch("DateTime or TimeSpan", b.GetType().Name))
+            | Obj (:? TimeSpan as span), Obj b ->
+                match b with
+                | :? TimeSpan as other -> returnM (Obj(span - other))
+                | _ -> throwError (ClrTypeMismatch("TimeSpan", b.GetType().Name))
             | Obj a, Obj b ->
                 dispatchInfinities subtractCombine subtractMixed a b (fun () ->
                     numericBinaryOp subtractWidened a' b')

--- a/IronKernel.Runtime/Runtime.fs
+++ b/IronKernel.Runtime/Runtime.fs
@@ -2683,23 +2683,27 @@
                               invoke = func })
                 let contract =
                     match name with
-                    // `+` also accepts DateTime + TimeSpan and `-` DateTime - DateTime.
-                    // Results stay AnyShape: a non-any result wraps every dynamic call
-                    // in a validation continuation, which these hot paths avoid.
+                    // `+` also accepts DateTime + TimeSpan (either order) and
+                    // TimeSpan + TimeSpan; `-` accepts DateTime - DateTime,
+                    // DateTime - TimeSpan, and TimeSpan - TimeSpan. The shapes
+                    // over-approximate -- opAdd/opMinus reject the combinations the
+                    // CLR does not define. Results stay AnyShape: a non-any result
+                    // wraps every dynamic call in a validation continuation, which
+                    // these hot paths avoid.
                     | "+" ->
                         Some(
                             certifiedVariadicApplicative
                                 name
-                                [ OneOfShape [NumberShape; DateTimeShape]
-                                  OneOfShape [NumberShape; TimeSpanShape] ]
+                                [ OneOfShape [NumberShape; DateTimeShape; TimeSpanShape]
+                                  OneOfShape [NumberShape; TimeSpanShape; DateTimeShape] ]
                                 0
                                 AnyShape)
                     | "-" ->
                         Some(
                             certifiedVariadicApplicative
                                 name
-                                [ OneOfShape [NumberShape; DateTimeShape]
-                                  OneOfShape [NumberShape; DateTimeShape] ]
+                                [ OneOfShape [NumberShape; DateTimeShape; TimeSpanShape]
+                                  OneOfShape [NumberShape; DateTimeShape; TimeSpanShape] ]
                                 2
                                 AnyShape)
                     | "*" ->

--- a/IronKernel.Tests/ArithmeticTests.fs
+++ b/IronKernel.Tests/ArithmeticTests.fs
@@ -234,6 +234,24 @@ let ``variadic addition preserves the datetime extension`` () =
         assertEval env "(=? (.get (- (+ d ts ts) d) TotalHours) 48.0)" (Bool true))
 
 [<Fact>]
+let ``timespan arithmetic composes and subtracts from datetimes`` () =
+    // The full closed set: span+span and span-span are spans, date-span is a date,
+    // and (+ span date) commutes with (+ date span). Combinations the CLR does not
+    // define -- here span - date -- still signal.
+    withKernel (fun env ->
+        ignore (evalIn env "(define d (new System.DateTime 2020 1 1))")
+        ignore (evalIn env "(define h6 (new System.TimeSpan 6 0 0))")
+        ignore (evalIn env "(define h2 (new System.TimeSpan 2 0 0))")
+        assertEval env "(=? (.get (+ h6 h2) TotalHours) 8.0)" (Bool true)
+        assertEval env "(=? (.get (- h6 h2) TotalHours) 4.0)" (Bool true)
+        assertEval env "(equal? (- (+ d h6) h6) d)" (Bool true)
+        assertEval env "(equal? (+ h6 d) (+ d h6))" (Bool true)
+        assertEval env "(=? (.get (+ h6 h2 h2) TotalHours) 10.0)" (Bool true)
+        match evalIn env "(- h6 d)" with
+        | Status _ -> ()
+        | value -> failwithf "(- span date) should signal an error, got %s" (showVal value))
+
+[<Fact>]
 let ``division is not the truncating quotient`` () =
     // R-1RK 12.8.2: `/` is ordinary division. It stays integral only when it divides
     // evenly; the truncating quotient is `div` (12.5.8), a separate feature.

--- a/IronKernel.Tests/ContractTests.fs
+++ b/IronKernel.Tests/ContractTests.fs
@@ -91,8 +91,8 @@ let ``wrap preserves applicative contract metadata without nesting`` () =
             (ofList
                 [ Atom "applicative"
                   ofList
-                      [ ofList [Atom "number"; Atom "datetime"]
-                        ofList [Atom "number"; Atom "timespan"] ]
+                      [ ofList [Atom "number"; Atom "datetime"; Atom "timespan"]
+                        ofList [Atom "number"; Atom "timespan"; Atom "datetime"] ]
                   Atom "any"
                   Atom "pure"
                   Bool true

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ for the local-feed workflow and the roadmap.
 | [`IronKernel.Strings`](lib/IronKernel.Strings/) | Search, split/join, case, trimming, padding, characters, invariant number conversion, and a variadic `format` — ordinal semantics throughout |
 | [`IronKernel.Json`](lib/IronKernel.Json/) | Grammar-enforcing JSON reader with offsets in its errors, a writer that refuses what JSON cannot carry, pretty-printing, and path traversal |
 | [`IronKernel.Math`](lib/IronKernel.Math/) | Statistics, combinatorics, and number theory — exact wherever the mathematics allows: means as ratios, `isqrt` and `factorial` at any size, primes, factorizations, totients |
+| [`IronKernel.Time`](lib/IronKernel.Time/) | Dates and durations over `System.DateTime`/`System.TimeSpan` — UTC-disciplined instants the arithmetic tower adds and subtracts, calendar operations, unix time, and invariant ISO 8601 formatting and parsing |
 | [`IronKernel.Amb`](lib/IronKernel.Amb/) | Nondeterministic search: `amb`, `require`, bracketed choice, and pluggable search strategies over multi-shot delimited continuations |
 
 Packages test against `IronKernel.Test` through a test-scoped reference

--- a/lib/IronKernel.Time/.gitignore
+++ b/lib/IronKernel.Time/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+*.ikc
+packages.lock.json

--- a/lib/IronKernel.Time/IronKernel.Time.ikproj
+++ b/lib/IronKernel.Time/IronKernel.Time.ikproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <PackageId>IronKernel.Time</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>IronKernel</Authors>
+    <Description>Dates, durations, and formatting for IronKernel over System.DateTime and System.TimeSpan: UTC-disciplined instants the arithmetic tower already adds and subtracts, calendar operations, unix time, and invariant-culture ISO 8601 formatting and parsing.</Description>
+    <PackageTags>ironkernel</PackageTags>
+    <IronKernelMain>src/time.ikr</IronKernelMain>
+    <IronKernelProfile>unrestricted</IronKernelProfile>
+  </PropertyGroup>
+  <ItemGroup>
+    <IronKernelSource Include="src/**/*.ikr" />
+    <IronKernelTest Include="test/**/*.ikr" />
+    <PackageReference Include="IronKernel.Test" Version="0.1.0" IronKernelKind="IronKernel" IronKernelScope="test" />
+  </ItemGroup>
+</Project>

--- a/lib/IronKernel.Time/README.md
+++ b/lib/IronKernel.Time/README.md
@@ -1,0 +1,109 @@
+# IronKernel.Time
+
+Dates, durations, and formatting for IronKernel over `System.DateTime` and
+`System.TimeSpan`, with one discipline applied throughout: **instants are
+UTC**. Constructors build UTC instants, `now` is UTC, parsing assumes and
+adjusts to UTC, and crossing into local time only happens through the two
+conversions that say so by name.
+
+```scheme
+(date 2024 3 15)                     ; midnight UTC
+(+ (now) (hours 2))                  ; the tower already adds durations
+(- deadline (now))                   ; ... and subtracts to a duration
+(date->string (date 2024 3 15))      ; "2024-03-15T00:00:00.0000000Z"
+(date->unix (date 2024 3 15))        ; 1710460800
+```
+
+The runtime's arithmetic accepts these values directly: `date + duration`
+(either order), `duration + duration`, `date - date`, `date - duration`, and
+`duration - duration` are ordinary `+` and `-`. This package supplies what the
+tower does not — construction, accessors, ordering, calendar arithmetic,
+conversion, and invariant-culture formatting and parsing. Parsers return `#f`
+on malformed input, following `IronKernel.Strings`' discipline.
+
+## Use
+
+```bash
+ik add IronKernel.Time 0.1.0
+```
+
+Or, from a checkout of this repository:
+
+```bash
+cd lib/IronKernel.Test && ik pack     # seed the local feed for the test DSL
+cd ../IronKernel.Time
+ik test
+ik pack
+```
+
+## API
+
+### Construction
+
+| Form | Meaning |
+|---|---|
+| `(now)` | The current instant, UTC. |
+| `(today)` | Now's calendar day at midnight UTC. |
+| `(date y m d)` | Midnight UTC on that day. An impossible day signals. |
+| `(date-time y m d h mi s [ms])` | A UTC instant. |
+| `(date? x)` / `(duration? x)` / `(date-utc? t)` | |
+
+### Accessors
+
+`date-year`, `date-month`, `date-day`, `date-hour`, `date-minute`,
+`date-second`, `date-millisecond`, `date-day-of-year`;
+`(date-day-of-week t)` gives a lowercase symbol (`monday` … `sunday`);
+`(date-only t)` truncates to midnight, kind preserved.
+
+### Ordering
+
+`date<?`, `date<=?`, `date>?`, `date>=?`, `date=?`, and the same five for
+durations.
+
+### Calendar arithmetic
+
+Months and years have no fixed length, so these are calendar operations, not
+durations — the day clamps when the target month is shorter:
+
+| Form | Meaning |
+|---|---|
+| `(add-months t n)` / `(add-years t n)` | `(add-months (date 2024 1 31) 1)` is Feb 29. |
+| `(leap-year? y)` / `(days-in-month y m)` | |
+
+### Durations
+
+Constructors `(days n)`, `(hours n)`, `(minutes n)`, `(seconds n)`,
+`(milliseconds n)` accept exact or inexact numbers; combine them with `+` and
+`-`. `(duration-negate d)` flips sign.
+
+Component accessors wrap at their unit — `(duration-hours (hours 26))` is 2,
+with `(duration-days …)` carrying the 1 — while totals do not:
+`(duration-total-hours (hours 26))` is 26.0. Both families cover days, hours,
+minutes, seconds, and milliseconds.
+
+### Conversions
+
+| Form | Meaning |
+|---|---|
+| `(date->local t)` / `(date->utc t)` | The only crossings into machine-local time. |
+| `(date->unix t)` | Whole seconds since the epoch, floored, exact. |
+| `(unix->date n)` | The inverse; negative values reach before 1970. |
+
+### Formatting and parsing
+
+Always the invariant culture.
+
+| Form | Meaning |
+|---|---|
+| `(date->string t)` | ISO 8601 round-trip form (`"o"`). |
+| `(date->string t fmt)` | A .NET format spec. |
+| `(string->date s)` | Any ISO-ish form; a zoned string converts to UTC, an unzoned one is taken as already UTC — never as machine-local. `#f` on malformed input. |
+| `(string->date s fmt)` | Exact parse against a spec; `#f` on mismatch. |
+| `(duration->string d [fmt])` / `(string->duration s)` | `"1.02:30:00"` both ways; `#f` on malformed input. |
+
+## Notes
+
+- Nothing here performs host I/O beyond reading the clock and, in the two
+  local-time conversions, the machine's time zone.
+- `date=?` compares instants; two `DateTime`s with different kinds but equal
+  ticks compare equal, as the CLR defines.

--- a/lib/IronKernel.Time/src/time.ikr
+++ b/lib/IronKernel.Time/src/time.ikr
@@ -1,0 +1,222 @@
+; IronKernel.Time -- dates, durations, and formatting
+; ===================================================
+;
+; Calendar time over System.DateTime and System.TimeSpan, with one discipline
+; applied throughout: instants are UTC. Constructors build UTC instants, `now`
+; is UTC, parsing assumes and adjusts to UTC, and crossing into local time
+; only happens through the two conversions that say so by name.
+;
+;   (date 2024 3 15)                     ; midnight UTC
+;   (+ (now) (hours 2))                  ; the tower already adds durations
+;   (- deadline (now))                   ; ... and subtracts to a duration
+;   (date->string (date 2024 3 15))      ; "2024-03-15T00:00:00.0000000Z"
+;   (date->unix (date 2024 3 15))        ; 1710460800
+;
+; The runtime's arithmetic accepts these values directly: date + duration and
+; duration + duration are additions, date - date and date - duration are
+; subtractions. This package supplies what the tower does not -- construction,
+; accessors, ordering, calendar arithmetic (months and years do not have a
+; fixed length, so they are not durations), conversion, and invariant-culture
+; formatting and parsing, following IronKernel.Strings' discipline: parsers
+; return #f on malformed input rather than signalling.
+;
+; Nothing here performs host I/O beyond reading the clock and, in the two
+; local-time conversions, the machine's time zone.
+
+(provide! (now today date date-time date? date-utc?
+           date-year date-month date-day
+           date-hour date-minute date-second date-millisecond
+           date-day-of-week date-day-of-year date-only
+           date<? date<=? date>? date>=? date=?
+           add-years add-months
+           leap-year? days-in-month
+           days hours minutes seconds milliseconds duration?
+           duration-negate
+           duration-days duration-hours duration-minutes
+           duration-seconds duration-milliseconds
+           duration-total-days duration-total-hours duration-total-minutes
+           duration-total-seconds duration-total-milliseconds
+           duration<? duration<=? duration>? duration>=? duration=?
+           date->local date->utc
+           date->unix unix->date
+           date->string string->date
+           duration->string string->duration)
+
+  ; --- private --------------------------------------------------------------
+
+  (define invariant (.get System.Globalization.CultureInfo InvariantCulture))
+  (define utc-kind (.get System.DateTimeKind Utc))
+  ; AdjustToUniversal (16) | AssumeUniversal (64): a zoned string converts to
+  ; UTC, an unzoned one is taken as already UTC -- never as machine-local.
+  (define utc-styles
+    (. System.Enum ToObject (clr-type System.Globalization.DateTimeStyles) 80))
+  (define clr-datetime (clr-type System.DateTime))
+  (define clr-timespan (clr-type System.TimeSpan))
+
+  (define try-thunk
+    (lambda (thunk)
+      (call/cc (lambda (escape)
+        (guard-dynamic-extent
+          ()
+          (lambda () (list #t (thunk)))
+          (list (list error-continuation
+                      (lambda (obj divert) (escape (list #f obj))))))))))
+
+  ; #f instead of a signal, for the parsers.
+  (define try-or-false
+    (lambda (thunk)
+      (let ((outcome (try-thunk thunk)))
+        (if (car outcome) (cadr outcome) #f))))
+
+  (define clr-instance?
+    (lambda (t)
+      (lambda (x)
+        (let ((outcome (try-thunk (lambda () (eq? (. x GetType) t)))))
+          (if (car outcome) (cadr outcome) #f)))))
+
+  ; CompareTo gives a sign; the five predicates read it.
+  (define compare-with
+    (lambda (test) (lambda (a b) (test (. a CompareTo b) 0))))
+
+  ; --- construction ---------------------------------------------------------
+
+  (define now (lambda () (.get System.DateTime UtcNow)))
+
+  ; Today's date at midnight UTC.
+  (define today (lambda () (.get (now) Date)))
+
+  ; Midnight UTC on the given calendar day.
+  (define date
+    (lambda (year month day)
+      (new System.DateTime year month day 0 0 0 utc-kind)))
+
+  ; A UTC instant; milliseconds are optional.
+  (define date-time
+    (lambda (year month day hour minute second & opt)
+      (if (null? opt)
+        (new System.DateTime year month day hour minute second utc-kind)
+        (new System.DateTime year month day hour minute second (car opt) utc-kind))))
+
+  (define date? (clr-instance? clr-datetime))
+  (define duration? (clr-instance? clr-timespan))
+
+  (define date-utc?
+    (lambda (t) (equal? (.get t Kind) utc-kind)))
+
+  ; --- accessors ------------------------------------------------------------
+
+  (define date-year (lambda (t) (.get t Year)))
+  (define date-month (lambda (t) (.get t Month)))
+  (define date-day (lambda (t) (.get t Day)))
+  (define date-hour (lambda (t) (.get t Hour)))
+  (define date-minute (lambda (t) (.get t Minute)))
+  (define date-second (lambda (t) (.get t Second)))
+  (define date-millisecond (lambda (t) (.get t Millisecond)))
+  (define date-day-of-year (lambda (t) (.get t DayOfYear)))
+
+  ; The weekday as a lowercase symbol: monday, tuesday, ...
+  (define date-day-of-week
+    (lambda (t)
+      (string->symbol (. (. (.get t DayOfWeek) ToString) ToLowerInvariant))))
+
+  ; The instant's calendar day at midnight, kind preserved.
+  (define date-only (lambda (t) (.get t Date)))
+
+  ; --- ordering -------------------------------------------------------------
+
+  (define date<? (compare-with <?))
+  (define date<=? (compare-with <=?))
+  (define date>? (compare-with >?))
+  (define date>=? (compare-with >=?))
+  (define date=? (compare-with =?))
+
+  (define duration<? (compare-with <?))
+  (define duration<=? (compare-with <=?))
+  (define duration>? (compare-with >?))
+  (define duration>=? (compare-with >=?))
+  (define duration=? (compare-with =?))
+
+  ; --- calendar arithmetic ----------------------------------------------------
+  ;
+  ; Months and years have no fixed length, so these are calendar operations,
+  ; not durations: the day clamps when the target month is shorter, as
+  ; AddMonths defines.
+
+  (define add-years (lambda (t n) (. t AddYears n)))
+  (define add-months (lambda (t n) (. t AddMonths n)))
+
+  (define leap-year? (lambda (year) (. System.DateTime IsLeapYear year)))
+  (define days-in-month (lambda (year month) (. System.DateTime DaysInMonth year month)))
+
+  ; --- durations --------------------------------------------------------------
+
+  (define days (lambda (n) (. System.TimeSpan FromDays (real->inexact n))))
+  (define hours (lambda (n) (. System.TimeSpan FromHours (real->inexact n))))
+  (define minutes (lambda (n) (. System.TimeSpan FromMinutes (real->inexact n))))
+  (define seconds (lambda (n) (. System.TimeSpan FromSeconds (real->inexact n))))
+  (define milliseconds (lambda (n) (. System.TimeSpan FromMilliseconds (real->inexact n))))
+
+  (define duration-negate (lambda (d) (. d Negate)))
+
+  ; Components, as the clock would show them: (duration-hours (hours 26)) is 2.
+  (define duration-days (lambda (d) (.get d Days)))
+  (define duration-hours (lambda (d) (.get d Hours)))
+  (define duration-minutes (lambda (d) (.get d Minutes)))
+  (define duration-seconds (lambda (d) (.get d Seconds)))
+  (define duration-milliseconds (lambda (d) (.get d Milliseconds)))
+
+  ; Totals, as one inexact number: (duration-total-hours (hours 26)) is 26.0.
+  (define duration-total-days (lambda (d) (.get d TotalDays)))
+  (define duration-total-hours (lambda (d) (.get d TotalHours)))
+  (define duration-total-minutes (lambda (d) (.get d TotalMinutes)))
+  (define duration-total-seconds (lambda (d) (.get d TotalSeconds)))
+  (define duration-total-milliseconds (lambda (d) (.get d TotalMilliseconds)))
+
+  ; --- conversions ------------------------------------------------------------
+
+  (define date->local (lambda (t) (. t ToLocalTime)))
+  (define date->utc (lambda (t) (. t ToUniversalTime)))
+
+  (define epoch (date 1970 1 1))
+
+  ; Whole seconds since 1970-01-01T00:00:00Z, floored, as an exact integer --
+  ; narrowed to the language's native 32-bit width when it fits, like the
+  ; reader narrows literals.
+  (define date->unix
+    (lambda (t)
+      (let ((n (div (.get (- (date->utc t) epoch) Ticks) 10000000)))
+        (if ($and? (<=? -2147483648 n) (<=? n 2147483647))
+          (. System.Convert ToInt32 n)
+          n))))
+
+  (define unix->date
+    (lambda (n) (+ epoch (seconds n))))
+
+  ; --- formatting and parsing --------------------------------------------------
+  ;
+  ; Always the invariant culture. With no format, date->string writes ISO 8601
+  ; round-trip form ("o"); string->date reads any ISO-ish form, assuming and
+  ; adjusting to UTC. With a .NET format spec, both use it exactly. Parsers
+  ; return #f on malformed input.
+
+  (define date->string
+    (lambda (t & fmt)
+      (if (null? fmt)
+        (. t ToString "o" invariant)
+        (. t ToString (car fmt) invariant))))
+
+  (define string->date
+    (lambda (s & fmt)
+      (if (null? fmt)
+        (try-or-false (lambda () (. System.DateTime Parse s invariant utc-styles)))
+        (try-or-false (lambda () (. System.DateTime ParseExact s (car fmt) invariant utc-styles))))))
+
+  (define duration->string
+    (lambda (d & fmt)
+      (if (null? fmt)
+        (. d ToString)
+        (. d ToString (car fmt) invariant))))
+
+  (define string->duration
+    (lambda (s)
+      (try-or-false (lambda () (. System.TimeSpan Parse s invariant))))))

--- a/lib/IronKernel.Time/test/time_test.ikr
+++ b/lib/IronKernel.Time/test/time_test.ikr
@@ -1,0 +1,125 @@
+; Tests for IronKernel.Time, written with IronKernel.Test.
+
+(suite "construction"
+  (check "date builds midnight UTC"
+    (let ((t (date 2024 3 15)))
+      ($and? (date-utc? t)
+             (=? 0 (date-hour t))
+             (=? 0 (date-minute t)))))
+  (check "date-time carries the clock"
+    (let ((t (date-time 2024 3 15 10 30 45)))
+      ($and? (=? 10 (date-hour t)) (=? 30 (date-minute t)) (=? 45 (date-second t)))))
+  (check-equal "date-time takes optional milliseconds"
+    250 (date-millisecond (date-time 2024 3 15 10 30 45 250)))
+  (check "now is a UTC date" (let ((t (now))) ($and? (date? t) (date-utc? t))))
+  (check "today is now's calendar day at midnight"
+    (let ((t (today)))
+      ($and? (date-utc? t) (=? 0 (date-hour t)) (date<=? t (now)))))
+  (check-error "an impossible day signals" (date 2024 2 30))
+  (check "date? rejects non-dates"
+    ($and? (not? (date? 5)) (not? (date? (hours 1)))))
+  (check "duration? classifies"
+    ($and? (duration? (hours 1)) (not? (duration? (now))) (not? (duration? 5)))))
+
+(suite "accessors"
+  (check-equal "the calendar parts"
+    (list 2024 3 15) (let ((t (date 2024 3 15)))
+                       (list (date-year t) (date-month t) (date-day t))))
+  (check-equal "day of week is a lowercase symbol"
+    (string->symbol "friday") (date-day-of-week (date 2024 3 15)))
+  (check-equal "day of year" 75 (date-day-of-year (date 2024 3 15)))
+  (check "date-only truncates to midnight, kind preserved"
+    (let ((midnight (date-only (date-time 2024 3 15 10 30 0))))
+      ($and? (date=? midnight (date 2024 3 15)) (date-utc? midnight)))))
+
+(suite "the tower does the arithmetic"
+  (check "date plus duration"
+    (date=? (+ (date 2024 3 15) (hours 26)) (date-time 2024 3 16 2 0 0)))
+  (check "date minus duration"
+    (date=? (- (date-time 2024 3 15 10 30 0) (minutes 90))
+            (date-time 2024 3 15 9 0 0)))
+  (check "date minus date is a duration"
+    (=? 13.5 (duration-total-hours (- (date 2024 3 16) (date-time 2024 3 15 10 30 0)))))
+  (check "durations add"
+    (=? 90.0 (duration-total-minutes (+ (hours 1) (minutes 30)))))
+  (check "durations subtract"
+    (=? 30.0 (duration-total-minutes (- (hours 1) (minutes 30))))))
+
+(suite "ordering"
+  (check "date<?" (date<? (date 2024 3 15) (date 2024 3 16)))
+  (check "date<? can miss" (not? (date<? (date 2024 3 16) (date 2024 3 15))))
+  (check "date=?" (date=? (date-time 2024 3 15 10 30 0) (date-time 2024 3 15 10 30 0)))
+  (check "date<=? on equals" (date<=? (date 2024 3 15) (date 2024 3 15)))
+  (check "date>? and date>=?"
+    ($and? (date>? (date 2024 3 16) (date 2024 3 15))
+           (date>=? (date 2024 3 16) (date 2024 3 16))))
+  (check "duration ordering"
+    ($and? (duration<? (minutes 1) (hours 1))
+           (duration>? (hours 1) (minutes 59))
+           (duration=? (minutes 60) (hours 1))
+           (duration<=? (hours 1) (hours 1))
+           (duration>=? (hours 1) (minutes 60)))))
+
+(suite "calendar"
+  (check "add-months clamps at a short month"
+    (date=? (add-months (date 2024 1 31) 1) (date 2024 2 29)))
+  (check "add-years from a leap day clamps"
+    (date=? (add-years (date 2024 2 29) 1) (date 2025 2 28)))
+  (check "add-months goes backward" (date=? (add-months (date 2024 3 15) -1) (date 2024 2 15)))
+  (check "leap-year?" ($and? (leap-year? 2024) (not? (leap-year? 2023)) (not? (leap-year? 1900))))
+  (check-equal "days-in-month in a leap February" 29 (days-in-month 2024 2))
+  (check-equal "days-in-month otherwise" 28 (days-in-month 2023 2)))
+
+(suite "durations"
+  (check "constructors accept exact and inexact"
+    (=? (duration-total-hours (days (/ 1 2))) (duration-total-hours (hours 12))))
+  (check-equal "components wrap at their unit" 2 (duration-hours (hours 26)))
+  (check-equal "components: the day part" 1 (duration-days (hours 26)))
+  (check "totals do not wrap" (=? 26.0 (duration-total-hours (hours 26))))
+  (check "milliseconds round-trip"
+    (=? 1500.0 (duration-total-milliseconds (milliseconds 1500))))
+  (check "negate" (=? -2.0 (duration-total-hours (duration-negate (hours 2)))))
+  (check "seconds and minutes components"
+    (let ((d (+ (minutes 2) (seconds 30))))
+      ($and? (=? 2 (duration-minutes d)) (=? 30 (duration-seconds d))))))
+
+(suite "unix time"
+  (check-equal "the epoch is zero" 0 (date->unix (date 1970 1 1)))
+  (check-equal "a known instant" 1710460800 (date->unix (date 2024 3 15)))
+  (check "unix->date inverts" (date=? (unix->date 1710460800) (date 2024 3 15)))
+  (check-equal "negative times reach before the epoch" -86400 (date->unix (unix->date -86400)))
+  (check-equal "sub-second parts floor" 0 (date->unix (date-time 1970 1 1 0 0 0 900)))
+  (check "far futures stay exact past 32 bits"
+    (=? 7258118400 (date->unix (date 2200 1 1)))))
+
+(suite "local time"
+  (check "utc -> local -> utc round-trips"
+    (let ((t (date-time 2024 3 15 10 30 0)))
+      (date=? (date->utc (date->local t)) t)))
+  (check "date->local leaves UTC kind behind"
+    (not? (date-utc? (date->local (now))))))
+
+(suite "formatting and parsing"
+  (check-equal "ISO 8601 round-trip form"
+    "2024-03-15T10:30:00.0000000Z" (date->string (date-time 2024 3 15 10 30 0)))
+  (check-equal "a custom spec, invariantly"
+    "15/03/2024" (date->string (date 2024 3 15) "dd/MM/yyyy"))
+  (check "string->date reads what date->string writes"
+    (let ((t (date-time 2024 3 15 10 30 45 250)))
+      (date=? (string->date (date->string t)) t)))
+  (check "a zoned string converts to UTC"
+    (date=? (string->date "2024-03-15T12:30:00+02:00") (date-time 2024 3 15 10 30 0)))
+  (check "an unzoned string is taken as UTC, not machine-local"
+    (let ((t (string->date "2024-03-15T10:30:00")))
+      ($and? (date-utc? t) (date=? t (date-time 2024 3 15 10 30 0)))))
+  (check "an exact format parses"
+    (date=? (string->date "15/03/2024" "dd/MM/yyyy") (date 2024 3 15)))
+  (check "a malformed date is #f, not an error" (eq? #f (string->date "nope")))
+  (check "a string missing its exact format is #f"
+    (eq? #f (string->date "2024-03-15" "dd/MM/yyyy")))
+  (check-equal "duration->string" "1.02:30:00" (duration->string (+ (days 1) (hours 2) (minutes 30))))
+  (check "string->duration inverts"
+    (duration=? (string->duration "1.02:30:00") (+ (days 1) (hours 2) (minutes 30))))
+  (check "a malformed duration is #f" (eq? #f (string->duration "junk"))))
+
+(report-checks)

--- a/lib/README.md
+++ b/lib/README.md
@@ -12,6 +12,7 @@ conventions, tests that can fail for the right reason.
 | [`IronKernel.Strings`](IronKernel.Strings/) | Search, split/join, case, trimming, padding, characters, invariant number conversion, variadic `format` — ordinal semantics throughout |
 | [`IronKernel.Json`](IronKernel.Json/) | Grammar-enforcing JSON reader with offsets in its errors, a writer that refuses what JSON cannot carry, pretty-printing, path traversal |
 | [`IronKernel.Math`](IronKernel.Math/) | Statistics, combinatorics, number theory — exact wherever the mathematics allows: means as ratios, `isqrt` and `factorial` at any size, primes, factorizations, totients |
+| [`IronKernel.Time`](IronKernel.Time/) | Dates and durations over `System.DateTime`/`System.TimeSpan`: UTC-disciplined instants the arithmetic tower adds and subtracts, calendar operations, unix time, invariant ISO 8601 formatting and parsing |
 | [`IronKernel.Amb`](IronKernel.Amb/) | Nondeterministic search: `amb`, `require`, bracketed choice, pluggable search strategies over multi-shot delimited continuations |
 
 ## Working in this directory
@@ -42,8 +43,6 @@ its version, delete `~/.nuget/packages/<id>/<version>` (and the consumer's
 
 ## Candidates for what comes next
 
-- **Time** — dates, durations, and formatting over `System.DateTime`, with
-  the same invariant-culture discipline as `IronKernel.Strings`.
 - **Ports/IO** — structured file and path helpers over the capability-gated
   port primitives.
 - A **conformance-style docs page** per package, generated from its tests,


### PR DESCRIPTION
The next package from the `lib/` roadmap, in two commits: a small runtime extension it needs, then the package.

## Runtime: close the datetime/timespan set under `+` and `-`

The tower knew `(+ date span)` and `(- date date)` but nothing else — durations could not be combined, and a duration could not be taken back off a date. The set closes: `span + span`, `span - span`, `date - span`, and `(+ span date)` commuting with the case that already worked. `span - date` still signals. The certified contracts widen to match, `NumberShape` stays first in each `OneOf` so numeric validation order is unchanged, and the A/B on `GuardSpecializationBenchmarks` + `CompilerBenchmarks` shows byte-identical allocation with timings within noise.

## `IronKernel.Time`

One discipline throughout: **instants are UTC**. Constructors build UTC instants, `now` is UTC, parsing assumes and adjusts to UTC (`AdjustToUniversal | AssumeUniversal` — an unzoned string is taken as already UTC, never machine-local), and local time is reachable only through `date->local` / `date->utc`.

```scheme
(+ (now) (hours 2))              ; the tower does the arithmetic
(- deadline (now))               ; date - date is a duration
(add-months (date 2024 1 31) 1)  ; Feb 29 — calendar ops clamp
(date->unix (date 2024 3 15))    ; 1710460800, exact, floored
(string->date "2024-03-15T12:30:00+02:00")  ; converts to UTC
```

- Accessors (weekday as a lowercase symbol), five ordering predicates each for dates and durations
- Calendar arithmetic as its own category — months and years have no fixed length, so they are not durations
- Duration components that wrap at their unit (`(duration-hours (hours 26))` is 2) alongside totals that do not (26.0)
- Unix time by exact `Ticks` arithmetic: floored, negative before the epoch, 64-bit past 2038
- Invariant-culture ISO 8601 round-trip formatting; parsers return `#f` on malformed input, following `IronKernel.Strings`' discipline

No runtime dependencies; the test DSL arrives test-scoped. CI's lib loop picks the package up with no seeding change.

## Verification

- Clean build zero warnings; full suite **416/416** (415 + the new closed-set arithmetic test)
- All **seven** lib packages pass `ik test` (Time: 55 checks)
- Every example runs; CLR fault sweep `faulted: 0`
- Benchmarks A/B on the same machine: allocation byte-identical, timings within noise

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790011499&installation_model_id=427656&pr_number=88&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F88&signature=046ac215a70486409a58748743a65713e66a4c384fdd372e2e6bbe13a7e529f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->