### PR TITLE
ik lsp: an in-process language server (ADR 0009 phase 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,8 @@ row as a conformance claim.
 package format · 0004 compiling procedure bodies · 0005 mutable pairs · 0006 errors
 as abnormal passes · 0007 identity for derived combiners · 0008 caching compiled
 bodies (proposed, deliberately not built) · 0009 editor tooling from the runtime
-outward (`ik check --json` is its phase 1).
+outward (`ik check --json`, environment enumeration, and the `ik lsp` language
+server are its phases 1–3).
 
 They record measurements and rejected options, not just decisions. When a prediction
 in one turns out wrong, correct it in place rather than leaving it — several carry

--- a/IronKernel.Tests/IronKernel.Tests.fsproj
+++ b/IronKernel.Tests/IronKernel.Tests.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="ConformanceTests.fs" />
     <Compile Include="CliTests.fs" />
     <Compile Include="CheckTests.fs" />
+    <Compile Include="LspTests.fs" />
     <Compile Include="ProjectTests.fs" />
     <Compile Include="ContinuationTests.fs" />
     <Compile Include="EffectTests.fs" />

--- a/IronKernel.Tests/LspTests.fs
+++ b/IronKernel.Tests/LspTests.fs
@@ -1,0 +1,211 @@
+module IronKernel.Tests.LspTests
+
+open System
+open System.IO
+open System.Text
+open System.Text.Json
+open Xunit
+
+open IronKernel.Ast
+open IronKernel.LanguageServer
+
+let private frame (stream: Stream) (json: string) =
+    let bytes = Encoding.UTF8.GetBytes json
+    let header = Encoding.ASCII.GetBytes(sprintf "Content-Length: %d\r\n\r\n" bytes.Length)
+    stream.Write(header, 0, header.Length)
+    stream.Write(bytes, 0, bytes.Length)
+
+let private readFrames (data: byte[]) =
+    let text = Encoding.UTF8.GetString data
+    let mutable index = 0
+    let frames = ResizeArray()
+    while index < text.Length do
+        let headerEnd = text.IndexOf("\r\n\r\n", index, StringComparison.Ordinal)
+        let headers = text.Substring(index, headerEnd - index)
+        let length =
+            headers.Split("\r\n")
+            |> Array.pick (fun line ->
+                if line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase) then
+                    Some(int (line.Substring("Content-Length:".Length).Trim()))
+                else None)
+        // Content-Length counts bytes; the payload is ASCII-safe JSON in these
+        // tests except for escaped sequences, so slice the byte array instead.
+        let bodyStart = Encoding.UTF8.GetByteCount(text.Substring(0, headerEnd)) + 4
+        let body = Encoding.UTF8.GetString(data, bodyStart, length)
+        frames.Add(JsonDocument.Parse body)
+        let consumed = Encoding.UTF8.GetString(data, 0, bodyStart + length)
+        index <- consumed.Length
+    List.ofSeq frames
+
+/// Run one scripted session against the in-process server.
+let private session (messages: string list) =
+    use input = new MemoryStream()
+    messages |> List.iter (frame input)
+    input.Position <- 0L
+    use output = new MemoryStream()
+    let exitCode = runOn input output Unrestricted
+    Assert.Equal(0, exitCode)
+    readFrames (output.ToArray())
+
+let private request id method' parameters =
+    sprintf """{"jsonrpc":"2.0","id":%d,"method":"%s","params":%s}""" (id: int) (method': string) (parameters: string)
+
+let private notification method' parameters =
+    sprintf """{"jsonrpc":"2.0","method":"%s","params":%s}""" (method': string) (parameters: string)
+
+let private didOpen (text: string) =
+    let escaped = JsonSerializer.Serialize text
+    notification
+        "textDocument/didOpen"
+        (sprintf """{"textDocument":{"uri":"file:///probe.ikr","languageId":"ironkernel","version":1,"text":%s}}""" escaped)
+
+let private resultOf id (frames: JsonDocument list) =
+    frames
+    |> List.pick (fun frameDocument ->
+        let root = frameDocument.RootElement
+        match root.TryGetProperty "id" with
+        | true, value when value.ValueKind = JsonValueKind.Number && value.GetInt32() = id ->
+            Some(root.GetProperty "result")
+        | _ -> None)
+
+let private diagnosticsOf (frames: JsonDocument list) =
+    frames
+    |> List.choose (fun frameDocument ->
+        let root = frameDocument.RootElement
+        match root.TryGetProperty "method" with
+        | true, value when value.GetString() = "textDocument/publishDiagnostics" ->
+            Some(root.GetProperty("params").GetProperty "diagnostics")
+        | _ -> None)
+
+[<Fact>]
+let ``initialize reports the semantic token legend and features`` () =
+    let frames = session [ request 1 "initialize" "{}" ]
+    let capabilities = (resultOf 1 frames).GetProperty "capabilities"
+    Assert.True(capabilities.GetProperty("hoverProvider").GetBoolean())
+    Assert.Equal(1, capabilities.GetProperty("textDocumentSync").GetInt32())
+    let legend =
+        capabilities.GetProperty("semanticTokensProvider").GetProperty("legend").GetProperty "tokenTypes"
+    let tokenTypes = legend.EnumerateArray() |> Seq.map (fun t -> t.GetString()) |> List.ofSeq
+    Assert.Equal<string list>([ "operative"; "applicative" ], tokenTypes)
+
+[<Fact>]
+let ``diagnostics follow the buffer through open and change`` () =
+    let frames =
+        session
+            [ request 1 "initialize" "{}"
+              didOpen "(define whole 1)\n"
+              notification
+                  "textDocument/didChange"
+                  """{"textDocument":{"uri":"file:///probe.ikr"},"contentChanges":[{"text":"(broken\n"}]}""" ]
+    match diagnosticsOf frames with
+    | [ clean; broken ] ->
+        Assert.Equal(0, clean.GetArrayLength())
+        Assert.Equal(1, broken.GetArrayLength())
+        let diagnostic = broken.[0]
+        Assert.Contains("Parse error", diagnostic.GetProperty("message").GetString())
+        Assert.Equal(1, diagnostic.GetProperty("severity").GetInt32())
+        let start = diagnostic.GetProperty("range").GetProperty "start"
+        Assert.Equal(1, start.GetProperty("line").GetInt32())
+        Assert.Equal(0, start.GetProperty("character").GetInt32())
+    | published -> failwithf "expected two diagnostic publications, got %d" published.Length
+
+[<Fact>]
+let ``completion merges buffer defines with environment symbols`` () =
+    let frames =
+        session
+            [ request 1 "initialize" "{}"
+              didOpen "(define completion-probe 1)\n"
+              // Mid-edit the buffer no longer parses; defines from the last
+              // good parse must still complete.
+              notification
+                  "textDocument/didChange"
+                  """{"textDocument":{"uri":"file:///probe.ikr"},"contentChanges":[{"text":"(define completion-probe 1)\n(completion-pr"}]}"""
+              request 2 "textDocument/completion"
+                  """{"textDocument":{"uri":"file:///probe.ikr"},"position":{"line":1,"character":14}}"""
+              notification
+                  "textDocument/didChange"
+                  """{"textDocument":{"uri":"file:///probe.ikr"},"contentChanges":[{"text":"(vector-r"}]}"""
+              request 3 "textDocument/completion"
+                  """{"textDocument":{"uri":"file:///probe.ikr"},"position":{"line":0,"character":9}}""" ]
+    let labels id =
+        (resultOf id frames).EnumerateArray()
+        |> Seq.map (fun item -> item.GetProperty("label").GetString())
+        |> List.ofSeq
+    Assert.Contains("completion-probe", labels 2)
+    Assert.Contains("vector-ref", labels 3)
+    let vectorRef =
+        (resultOf 3 frames).EnumerateArray()
+        |> Seq.find (fun item -> item.GetProperty("label").GetString() = "vector-ref")
+    // 3 = Function: applicatives complete as functions, by resolution.
+    Assert.Equal(3, vectorRef.GetProperty("kind").GetInt32())
+
+[<Fact>]
+let ``hover renders contracts and buffer definitions`` () =
+    let frames =
+        session
+            [ request 1 "initialize" "{}"
+              didOpen "(define twice (vau (x) e x))\n(+ 1 2)\n"
+              request 2 "textDocument/hover"
+                  """{"textDocument":{"uri":"file:///probe.ikr"},"position":{"line":1,"character":1}}"""
+              request 3 "textDocument/hover"
+                  """{"textDocument":{"uri":"file:///probe.ikr"},"position":{"line":0,"character":9}}""" ]
+    let hoverText id =
+        (resultOf id frames).GetProperty("contents").GetProperty("value").GetString()
+    let plus = hoverText 2
+    Assert.Contains("`+`", plus)
+    Assert.Contains("number", plus)
+    Assert.Contains("certified", plus)
+    let twice = hoverText 3
+    Assert.Contains("`twice`", twice)
+    Assert.Contains("operative", twice)
+    Assert.Contains("defined in this file", twice)
+
+[<Fact>]
+let ``semantic tokens classify by resolution including buffer operatives`` () =
+    let frames =
+        session
+            [ request 1 "initialize" "{}"
+              didOpen "(define twice (vau (x) e x))\n(twice 1)\n(vector-ref (vector 1) 0)\n"
+              request 2 "textDocument/semanticTokens/full"
+                  """{"textDocument":{"uri":"file:///probe.ikr"}}""" ]
+    let data =
+        (resultOf 2 frames).GetProperty("data").EnumerateArray()
+        |> Seq.map (fun value -> value.GetInt32())
+        |> List.ofSeq
+    // (deltaLine, deltaStart, length, type, modifiers) per token; type 0 is
+    // operative, 1 applicative. `twice` classifying as 0 on both lines is the
+    // capability no lexical grammar has: it is a *user-defined* operative.
+    Assert.Equal<int list>(
+        [ 0; 1; 6; 0; 0      // define
+          0; 7; 5; 0; 0      // twice (definition)
+          0; 7; 3; 0; 0      // vau
+          1; 1; 5; 0; 0      // twice (use)
+          1; 1; 10; 1; 0     // vector-ref
+          0; 12; 6; 1; 0 ],  // vector
+        data)
+
+[<Fact>]
+let ``quoted atoms are data and get no semantic token`` () =
+    let data =
+        semanticTokenData
+            (fun _ -> OperativeSymbol)
+            "quoted.ikr"
+            "(aa b)\n'cc\n"
+    // Only the two atoms in the combination; the quoted one is data.
+    Assert.Equal<int64 list>([ 0L; 1L; 2L; 0L; 0L; 0L; 3L; 1L; 0L; 0L ], data)
+
+[<Fact>]
+let ``unknown requests get a method-not-found error`` () =
+    let frames =
+        session
+            [ request 1 "initialize" "{}"
+              request 2 "textDocument/definition"
+                  """{"textDocument":{"uri":"file:///probe.ikr"},"position":{"line":0,"character":0}}""" ]
+    let error =
+        frames
+        |> List.pick (fun frameDocument ->
+            let root = frameDocument.RootElement
+            match root.TryGetProperty "error" with
+            | true, value -> Some value
+            | _ -> None)
+    Assert.Equal(-32601, error.GetProperty("code").GetInt32())

--- a/IronKernel/Emit.fs
+++ b/IronKernel/Emit.fs
@@ -165,15 +165,18 @@ module Emit =
                 | Choice1Of2 e -> throwError e
                 | Choice2Of2 expressions -> writeIkcPackage outputPath expressions
 
+    /// Everything `compile` checks -- parse, analyze -- on in-memory source.
+    let checkSourceInEnv env sourceName source : ThrowsError<unit> =
+        match analyzePackage env sourceName source with
+        | Choice1Of2 e -> throwError e
+        | Choice2Of2 _ -> returnM ()
+
     /// Everything `compile` checks -- read, parse, analyze -- with nothing written.
     let checkSourceFileForProfile profile (inputPath: string) : ThrowsError<unit> =
         match readSource inputPath with
         | Choice1Of2 e -> throwError e
         | Choice2Of2 source ->
-            let env = makePrimitiveBindingsForProfile profile
-            match analyzePackage env inputPath source with
-            | Choice1Of2 e -> throwError e
-            | Choice2Of2 _ -> returnM ()
+            checkSourceInEnv (makePrimitiveBindingsForProfile profile) inputPath source
 
     [<Obsolete("Use compileFileToPackage; IKC files are packages, not CLR assemblies.")>]
     let compileFileToAssembly inputPath outputPath =

--- a/IronKernel/IronKernel.fsproj
+++ b/IronKernel/IronKernel.fsproj
@@ -44,6 +44,7 @@
     <Compile Include="Repl.fs" />
     <Compile Include="Project.fs" />
     <Compile Include="Check.fs" />
+    <Compile Include="LanguageServer.fs" />
     <Compile Include="Program.fs" />
     <!-- Pack=false: keep stdlib in the tool output (tools/net*/any) only, not as package contentFiles. -->
     <Content Include="kernel.ikr" CopyToOutputDirectory="PreserveNewest" Pack="false" />

--- a/IronKernel/LanguageServer.fs
+++ b/IronKernel/LanguageServer.fs
@@ -1,0 +1,573 @@
+namespace IronKernel
+
+/// `ik lsp`: a Language Server Protocol server over stdio, in-process with the
+/// runtime (ADR 0009 phase 3). Diagnostics reuse the `check` pipeline on the
+/// live buffer; completion and hover come from a bootstrapped environment,
+/// contracts, and the phase-2 enumeration; semantic tokens classify operatives
+/// and applicatives by resolving the binding, which no lexical grammar can do.
+///
+/// The protocol layer is deliberately a hand-rolled subset -- framing, JSON-RPC
+/// dispatch, and the handful of requests the features need -- so the server
+/// stays dependency-free and testable against in-memory streams.
+module LanguageServer =
+
+    open System
+    open System.Collections.Generic
+    open System.IO
+    open System.Text
+    open System.Text.Json
+    open Ast
+    open Errors
+
+    // ---- Framing ----------------------------------------------------------
+
+    let private readFramed (input: Stream) : JsonDocument option =
+        let readLine () =
+            let builder = StringBuilder()
+            let mutable eof = false
+            let mutable finished = false
+            while not finished do
+                match input.ReadByte() with
+                | -1 ->
+                    eof <- true
+                    finished <- true
+                | 10 -> finished <- true
+                | 13 -> ()
+                | b -> builder.Append(char b) |> ignore
+            if eof && builder.Length = 0 then None else Some(builder.ToString())
+        let mutable contentLength = -1
+        let rec readHeaders () =
+            match readLine () with
+            | None -> false
+            | Some "" -> true
+            | Some line ->
+                if line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase) then
+                    match Int32.TryParse(line.Substring("Content-Length:".Length).Trim()) with
+                    | true, length -> contentLength <- length
+                    | _ -> ()
+                readHeaders ()
+        if not (readHeaders ()) || contentLength < 0 then None
+        else
+            let buffer = Array.zeroCreate contentLength
+            let mutable filled = 0
+            let mutable ok = true
+            while ok && filled < contentLength do
+                let count = input.Read(buffer, filled, contentLength - filled)
+                if count <= 0 then ok <- false else filled <- filled + count
+            if ok then Some(JsonDocument.Parse(ReadOnlyMemory buffer)) else None
+
+    let private writeFramed (output: Stream) (json: string) =
+        let bytes = Encoding.UTF8.GetBytes json
+        let header = Encoding.ASCII.GetBytes(sprintf "Content-Length: %d\r\n\r\n" bytes.Length)
+        output.Write(header, 0, header.Length)
+        output.Write(bytes, 0, bytes.Length)
+        output.Flush()
+
+    let private toJson (write: Utf8JsonWriter -> unit) =
+        use stream = new MemoryStream()
+        use writer = new Utf8JsonWriter(stream)
+        write writer
+        writer.Flush()
+        Encoding.UTF8.GetString(stream.ToArray())
+
+    let private respond output (id: JsonElement) (writeResult: Utf8JsonWriter -> unit) =
+        toJson (fun writer ->
+            writer.WriteStartObject()
+            writer.WriteString("jsonrpc", "2.0")
+            writer.WritePropertyName "id"
+            id.WriteTo writer
+            writer.WritePropertyName "result"
+            writeResult writer
+            writer.WriteEndObject())
+        |> writeFramed output
+
+    let private respondError output (id: JsonElement) code (message: string) =
+        toJson (fun writer ->
+            writer.WriteStartObject()
+            writer.WriteString("jsonrpc", "2.0")
+            writer.WritePropertyName "id"
+            id.WriteTo writer
+            writer.WritePropertyName "error"
+            writer.WriteStartObject()
+            writer.WriteNumber("code", (code: int))
+            writer.WriteString("message", message)
+            writer.WriteEndObject()
+            writer.WriteEndObject())
+        |> writeFramed output
+
+    let private notify output (method: string) (writeParams: Utf8JsonWriter -> unit) =
+        toJson (fun writer ->
+            writer.WriteStartObject()
+            writer.WriteString("jsonrpc", "2.0")
+            writer.WriteString("method", method)
+            writer.WritePropertyName "params"
+            writeParams writer
+            writer.WriteEndObject())
+        |> writeFramed output
+
+    // ---- Positions --------------------------------------------------------
+
+    /// LSP positions are 0-based line/character; runtime spans are 1-based.
+    let private writePosition (writer: Utf8JsonWriter) (position: SourcePosition) =
+        writer.WriteStartObject()
+        writer.WriteNumber("line", max 0L (position.line - 1L))
+        writer.WriteNumber("character", max 0L (position.column - 1L))
+        writer.WriteEndObject()
+
+    let private writeRange (writer: Utf8JsonWriter) (span: SourceSpan) =
+        writer.WriteStartObject()
+        writer.WritePropertyName "start"
+        writePosition writer span.startPosition
+        writer.WritePropertyName "end"
+        if span.endPosition.offset > span.startPosition.offset then
+            writePosition writer span.endPosition
+        else
+            // A point span still needs a visible extent.
+            writePosition writer
+                { span.startPosition with column = span.startPosition.column + 1L }
+        writer.WriteEndObject()
+
+    /// Character offset of a 0-based LSP line/character in `text`.
+    let offsetAt (text: string) (line: int) (character: int) =
+        let mutable offset = 0
+        let mutable currentLine = 0
+        while currentLine < line && offset < text.Length do
+            if text.[offset] = '\n' then currentLine <- currentLine + 1
+            offset <- offset + 1
+        min text.Length (offset + max 0 character)
+
+    // ---- Classification ---------------------------------------------------
+
+    type SymbolClass =
+        | OperativeSymbol
+        | ApplicativeSymbol
+        | ValueSymbol
+
+    let classifyValue value =
+        match value with
+        | Applicative _ | IOFunc _ -> ApplicativeSymbol
+        | PrimitiveOperative _ | Operative _ | CompiledCombiner _ -> OperativeSymbol
+        | ContractedCombiner record ->
+            match record.contract.mode with
+            | RawOperands -> OperativeSymbol
+            | EvaluatedArguments -> ApplicativeSymbol
+        | _ -> ValueSymbol
+
+    let private classifyForm (form: Source.LocatedValue) =
+        match form.kind with
+        | Source.LList (head :: _) ->
+            match head.kind with
+            | Source.LAtom "vau" | Source.LAtom "$vau" -> OperativeSymbol
+            | Source.LAtom "lambda" | Source.LAtom "wrap" -> ApplicativeSymbol
+            | _ -> ValueSymbol
+        | _ -> ValueSymbol
+
+    /// `(define name form)` at any nesting depth, classified by the form's
+    /// syntactic head. Quoted structure defines nothing.
+    let rec private collectDefines acc (form: Source.LocatedValue) =
+        match form.kind with
+        | Source.LList (head :: rest as items) ->
+            let acc =
+                match head.kind, rest with
+                | Source.LAtom "define", nameForm :: valueForm :: _ ->
+                    match nameForm.kind with
+                    | Source.LAtom name -> Map.add name (classifyForm valueForm) acc
+                    | _ -> acc
+                | _ -> acc
+            List.fold collectDefines acc items
+        | Source.LDottedList (items, tail) ->
+            collectDefines (List.fold collectDefines acc items) tail
+        | Source.LVector items -> Array.fold collectDefines acc items
+        | _ -> acc
+
+    let private parsedForms sourceName text =
+        match Parser.readLocatedExprList sourceName text with
+        | Choice2Of2 forms -> forms
+        | Choice1Of2 _ -> []
+
+
+    // ---- Contracts and hover text -----------------------------------------
+
+    let private renderClass = function
+        | OperativeSymbol -> "operative"
+        | ApplicativeSymbol -> "applicative"
+        | ValueSymbol -> "value"
+
+    let renderContract (contract: OperativeContract) =
+        let operands = contract.operands |> List.map Contracts.shapeName
+        let operandText =
+            let text = String.concat " " operands
+            match contract.minimumOperands with
+            | Some _ -> text + " ..."
+            | None -> text
+        let effect =
+            match contract.effect with
+            | Pure -> "pure"
+            | Effectful -> "effectful"
+        let trust =
+            match contract.trust with
+            | Certified -> "certified"
+            | Asserted -> "asserted"
+        sprintf
+            "(%s%s) → %s — %s, %s"
+            contract.name
+            (if operandText = "" then "" else " " + operandText)
+            (Contracts.shapeName contract.result)
+            effect
+            trust
+
+    let private isSymbolChar (c: char) =
+        Char.IsLetterOrDigit c || "!#$%|*+-/:<=>?@^_~.&".Contains c
+
+    /// The symbol spanning `offset` in `text`, if any.
+    let symbolAt (text: string) (offset: int) =
+        let offset = max 0 (min offset text.Length)
+        let mutable start = offset
+        while start > 0 && isSymbolChar text.[start - 1] do
+            start <- start - 1
+        let mutable finish = offset
+        while finish < text.Length && isSymbolChar text.[finish] do
+            finish <- finish + 1
+        if finish > start then Some(text.Substring(start, finish - start)) else None
+
+    // ---- Session ----------------------------------------------------------
+
+    type private Session = {
+        documents : Dictionary<string, string>
+        /// Buffer defines from each document's last *successful* parse. A
+        /// half-typed buffer does not parse (the reader has no error
+        /// recovery, ADR 0009 phase 4), and completion mid-edit is exactly
+        /// when the buffer is broken -- so the last good parse serves until
+        /// the next one.
+        defines : Dictionary<string, Map<string, SymbolClass>>
+        /// Bootstrapped kernel environment: symbol source for completion,
+        /// hover, and semantic classification. Never evaluated into by the
+        /// server -- buffers are parsed and analyzed, not run.
+        env : LispVal
+        /// Fresh primitive environment for analysis, matching what `check`
+        /// and `compile` validate against.
+        checkEnv : LispVal
+    }
+
+    let private uriToPath (uri: string) =
+        try
+            let parsed = Uri uri
+            if parsed.IsFile then parsed.LocalPath else uri
+        with _ -> uri
+
+    let private refreshDefines session (uri: string) text =
+        match Parser.readLocatedExprList (uriToPath uri) text with
+        | Choice2Of2 forms ->
+            session.defines.[uri] <- List.fold collectDefines Map.empty forms
+        | Choice1Of2 _ -> ()
+
+    let private definesFor session (uri: string) =
+        match session.defines.TryGetValue uri with
+        | true, value -> value
+        | _ -> Map.empty
+
+    let private classifySymbol session defines name =
+        match Map.tryFind name defines with
+        | Some OperativeSymbol -> OperativeSymbol
+        | Some ApplicativeSymbol -> ApplicativeSymbol
+        | Some ValueSymbol ->
+            // A buffer define of unknown shape may still shadow a combiner;
+            // fall back to the environment only when the buffer says nothing.
+            ValueSymbol
+        | None ->
+            match SymbolTable.getVar' session.env name with
+            | Some value -> classifyValue value
+            | None -> ValueSymbol
+
+    // ---- Features ---------------------------------------------------------
+
+    let private publishDiagnostics output session (uri: string) =
+        let text =
+            match session.documents.TryGetValue uri with
+            | true, value -> value
+            | _ -> ""
+        let sourceName = uriToPath uri
+        notify output "textDocument/publishDiagnostics" (fun writer ->
+            writer.WriteStartObject()
+            writer.WriteString("uri", uri)
+            writer.WritePropertyName "diagnostics"
+            writer.WriteStartArray()
+            match Emit.checkSourceInEnv session.checkEnv sourceName text with
+            | Choice2Of2 () -> ()
+            | Choice1Of2 error ->
+                let locations, core = errorLocations error
+                writer.WriteStartObject()
+                writer.WritePropertyName "range"
+                let wholeDocument =
+                    { sourceName = sourceName
+                      startPosition = { offset = 0L; line = 1L; column = 1L }
+                      endPosition = { offset = 1L; line = 1L; column = 2L } }
+                let innermost, enclosing =
+                    match List.rev locations with
+                    | (span, _) :: rest -> span, List.map fst rest
+                    | [] -> wholeDocument, []
+                writeRange writer innermost
+                writer.WriteNumber("severity", 1)
+                writer.WriteString("source", "IronKernel")
+                writer.WriteString("message", errorMessage core)
+                if not (List.isEmpty enclosing) then
+                    writer.WritePropertyName "relatedInformation"
+                    writer.WriteStartArray()
+                    for span in enclosing do
+                        writer.WriteStartObject()
+                        writer.WritePropertyName "location"
+                        writer.WriteStartObject()
+                        writer.WriteString("uri", uri)
+                        writer.WritePropertyName "range"
+                        writeRange writer span
+                        writer.WriteEndObject()
+                        writer.WriteString("message", "in this enclosing form")
+                        writer.WriteEndObject()
+                    writer.WriteEndArray()
+                writer.WriteEndObject()
+            writer.WriteEndArray()
+            writer.WriteEndObject())
+
+    let private completionKind = function
+        | OperativeSymbol -> 14   // Keyword
+        | ApplicativeSymbol -> 3  // Function
+        | ValueSymbol -> 6        // Variable
+
+    let private handleCompletion output session (id: JsonElement) uri line character =
+        let text =
+            match session.documents.TryGetValue (uri: string) with
+            | true, value -> value
+            | _ -> ""
+        let offset = offsetAt text line character
+        let prefix, envMatches = Repl.completionCandidates session.env text offset
+        let defines = definesFor session uri
+        let fromBuffer =
+            if prefix = "" then []
+            else
+                defines
+                |> Map.toList
+                |> List.map fst
+                |> List.filter (fun name -> name.StartsWith(prefix, StringComparison.Ordinal))
+        let names = List.distinct (fromBuffer @ envMatches) |> List.sort
+        respond output id (fun writer ->
+            writer.WriteStartArray()
+            for name in names do
+                writer.WriteStartObject()
+                writer.WriteString("label", (name: string))
+                let symbolClass = classifySymbol session defines name
+                writer.WriteNumber("kind", completionKind symbolClass)
+                match SymbolTable.getVar' session.env name with
+                | Some value ->
+                    match Contracts.tryGetContract value with
+                    | Some contract -> writer.WriteString("detail", renderContract contract)
+                    | None -> writer.WriteString("detail", renderClass symbolClass)
+                | None -> writer.WriteString("detail", renderClass symbolClass)
+                writer.WriteEndObject()
+            writer.WriteEndArray())
+
+    let private handleHover output session (id: JsonElement) uri line character =
+        let text =
+            match session.documents.TryGetValue (uri: string) with
+            | true, value -> value
+            | _ -> ""
+        let offset = offsetAt text line character
+        match symbolAt text offset with
+        | None -> respond output id (fun writer -> writer.WriteNullValue())
+        | Some name ->
+            let defines = definesFor session uri
+            let lines =
+                match SymbolTable.getVar' session.env name with
+                | Some value ->
+                    let heading = sprintf "`%s` — %s" name (renderClass (classifyValue value))
+                    match Contracts.tryGetContract value with
+                    | Some contract -> [ heading; ""; "```"; renderContract contract; "```" ]
+                    | None -> [ heading ]
+                | None ->
+                    match Map.tryFind name defines with
+                    | Some symbolClass ->
+                        [ sprintf "`%s` — %s, defined in this file" name (renderClass symbolClass) ]
+                    | None -> []
+            match lines with
+            | [] -> respond output id (fun writer -> writer.WriteNullValue())
+            | lines ->
+                respond output id (fun writer ->
+                    writer.WriteStartObject()
+                    writer.WritePropertyName "contents"
+                    writer.WriteStartObject()
+                    writer.WriteString("kind", "markdown")
+                    writer.WriteString("value", String.concat "\n" lines)
+                    writer.WriteEndObject()
+                    writer.WriteEndObject())
+
+    let rec private collectAtoms acc (form: Source.LocatedValue) =
+        match form.kind with
+        | Source.LAtom name -> (form.span, name) :: acc
+        | Source.LList items -> List.fold collectAtoms acc items
+        | Source.LDottedList (items, tail) ->
+            collectAtoms (List.fold collectAtoms acc items) tail
+        | Source.LVector items -> Array.fold collectAtoms acc items
+        // Quoted atoms are data, not references; classifying them would lie.
+        | Source.LQuote _ | Source.LLiteral _ -> acc
+
+    /// LSP semantic token encoding: (deltaLine, deltaStartChar, length, type, 0)
+    /// per token, sorted by position. Types index the legend: 0 operative,
+    /// 1 applicative.
+    let semanticTokenData classify sourceName text =
+        let atoms =
+            parsedForms sourceName text
+            |> List.fold collectAtoms []
+            |> List.choose (fun (span, name) ->
+                match classify name with
+                | OperativeSymbol -> Some(span, 0)
+                | ApplicativeSymbol -> Some(span, 1)
+                | ValueSymbol -> None)
+            |> List.sortBy (fun (span, _) -> span.startPosition.line, span.startPosition.column)
+        let mutable previousLine = 1L
+        let mutable previousColumn = 1L
+        [ for span, tokenType in atoms do
+            let line = span.startPosition.line
+            let column = span.startPosition.column
+            let deltaLine = line - previousLine
+            let deltaColumn = if deltaLine = 0L then column - previousColumn else column - 1L
+            let length = span.endPosition.offset - span.startPosition.offset
+            previousLine <- line
+            previousColumn <- column
+            yield! [ deltaLine; deltaColumn; length; int64 tokenType; 0L ] ]
+
+    let private handleSemanticTokens output session (id: JsonElement) uri =
+        let text =
+            match session.documents.TryGetValue (uri: string) with
+            | true, value -> value
+            | _ -> ""
+        let sourceName = uriToPath uri
+        let data = semanticTokenData (classifySymbol session (definesFor session uri)) sourceName text
+        respond output id (fun writer ->
+            writer.WriteStartObject()
+            writer.WritePropertyName "data"
+            writer.WriteStartArray()
+            for value in data do
+                writer.WriteNumberValue value
+            writer.WriteEndArray()
+            writer.WriteEndObject())
+
+    // ---- Dispatch ---------------------------------------------------------
+
+    let private textDocumentUri (parameters: JsonElement) =
+        parameters.GetProperty("textDocument").GetProperty("uri").GetString()
+
+    let private positionOf (parameters: JsonElement) =
+        let position = parameters.GetProperty "position"
+        position.GetProperty("line").GetInt32(), position.GetProperty("character").GetInt32()
+
+    /// Run the server over the given streams until `exit` or end of input.
+    let runOn (input: Stream) (output: Stream) profile : int =
+        match Emit.bootstrapEnvForProfile profile with
+        | Choice1Of2 error ->
+            eprintfn "Startup error: %s" (showError error)
+            1
+        | Choice2Of2 env ->
+            let session = {
+                documents = Dictionary()
+                defines = Dictionary()
+                env = env
+                checkEnv = Runtime.makePrimitiveBindingsForProfile profile
+            }
+            let mutable running = true
+            let mutable exitCode = 0
+            while running do
+                match readFramed input with
+                | None -> running <- false
+                | Some document ->
+                    use document = document
+                    let root = document.RootElement
+                    let methodName =
+                        match root.TryGetProperty "method" with
+                        | true, value -> value.GetString()
+                        | _ -> ""
+                    let hasId, id = root.TryGetProperty "id"
+                    let parameters =
+                        match root.TryGetProperty "params" with
+                        | true, value -> value
+                        | _ -> JsonDocument.Parse("null").RootElement
+                    match methodName with
+                    | "initialize" ->
+                        respond output id (fun writer ->
+                            writer.WriteStartObject()
+                            writer.WritePropertyName "capabilities"
+                            writer.WriteStartObject()
+                            writer.WriteNumber("textDocumentSync", 1)
+                            writer.WritePropertyName "completionProvider"
+                            writer.WriteStartObject()
+                            writer.WriteEndObject()
+                            writer.WriteBoolean("hoverProvider", true)
+                            writer.WritePropertyName "semanticTokensProvider"
+                            writer.WriteStartObject()
+                            writer.WritePropertyName "legend"
+                            writer.WriteStartObject()
+                            writer.WritePropertyName "tokenTypes"
+                            writer.WriteStartArray()
+                            writer.WriteStringValue "operative"
+                            writer.WriteStringValue "applicative"
+                            writer.WriteEndArray()
+                            writer.WritePropertyName "tokenModifiers"
+                            writer.WriteStartArray()
+                            writer.WriteEndArray()
+                            writer.WriteEndObject()
+                            writer.WriteBoolean("full", true)
+                            writer.WriteEndObject()
+                            writer.WriteEndObject()
+                            writer.WritePropertyName "serverInfo"
+                            writer.WriteStartObject()
+                            writer.WriteString("name", "IronKernel")
+                            writer.WriteString("version", Repl.version)
+                            writer.WriteEndObject()
+                            writer.WriteEndObject())
+                    | "initialized" -> ()
+                    | "shutdown" ->
+                        respond output id (fun writer -> writer.WriteNullValue())
+                    | "exit" -> running <- false
+                    | "textDocument/didOpen" ->
+                        let textDocument = parameters.GetProperty "textDocument"
+                        let uri = textDocument.GetProperty("uri").GetString()
+                        session.documents.[uri] <- textDocument.GetProperty("text").GetString()
+                        refreshDefines session uri session.documents.[uri]
+                        publishDiagnostics output session uri
+                    | "textDocument/didChange" ->
+                        let uri = textDocumentUri parameters
+                        let changes = parameters.GetProperty "contentChanges"
+                        // Full sync: the last change carries the whole document.
+                        let mutable text = None
+                        for change in changes.EnumerateArray() do
+                            text <- Some(change.GetProperty("text").GetString())
+                        match text with
+                        | Some value ->
+                            session.documents.[uri] <- value
+                            refreshDefines session uri value
+                            publishDiagnostics output session uri
+                        | None -> ()
+                    | "textDocument/didClose" ->
+                        let uri = textDocumentUri parameters
+                        session.documents.Remove uri |> ignore
+                        session.defines.Remove uri |> ignore
+                        notify output "textDocument/publishDiagnostics" (fun writer ->
+                            writer.WriteStartObject()
+                            writer.WriteString("uri", uri)
+                            writer.WritePropertyName "diagnostics"
+                            writer.WriteStartArray()
+                            writer.WriteEndArray()
+                            writer.WriteEndObject())
+                    | "textDocument/completion" ->
+                        let line, character = positionOf parameters
+                        handleCompletion output session id (textDocumentUri parameters) line character
+                    | "textDocument/hover" ->
+                        let line, character = positionOf parameters
+                        handleHover output session id (textDocumentUri parameters) line character
+                    | "textDocument/semanticTokens/full" ->
+                        handleSemanticTokens output session id (textDocumentUri parameters)
+                    | other when hasId ->
+                        respondError output id -32601 (sprintf "method not found: %s" other)
+                    | _ -> ()
+            exitCode
+
+    let run profile : int =
+        runOn (Console.OpenStandardInput()) (Console.OpenStandardOutput()) profile

--- a/IronKernel/Program.fs
+++ b/IronKernel/Program.fs
@@ -15,6 +15,7 @@ let private usage =
   ironkernel [--profile <profile>] <file.ikr> [args...]    Run a source script
   ironkernel [--profile <profile>] run <file> [args...]    Run a .ikr script or .ikc package
   ironkernel [--profile <profile>] check [--json] [<file.ikr> | project.ikproj]
+  ironkernel [--profile <profile>] lsp                     Start the language server (stdio)
     ironkernel [--profile <profile>] compile <file.ikr> [-o <file.ikc>]
     ironkernel [--profile <profile>] compile <file.ikr> --managed [-o <directory>]
     ironkernel --profile <minimal|safe> compile <file.ikr> --native <rid> [-o <directory>]
@@ -160,6 +161,7 @@ let private dispatch (profileOverride: CapabilityProfile option) args =
     | "run" :: scriptArgs ->
         // Non-source tokens (including flags) are project program args, not scripts.
         withProject profileOverride None (fun project -> ProjectTool.run project scriptArgs)
+    | ["lsp"] -> IronKernel.LanguageServer.run profile
     | "check" :: rest ->
         let json = List.contains "--json" rest
         let arguments = rest |> List.filter (fun argument -> argument <> "--json")

--- a/README.md
+++ b/README.md
@@ -370,9 +370,11 @@ See [`Examples/contracts.ikr`](Examples/contracts.ikr).
 ## VS Code extension and playground
 
 The extension in [`editors/vscode/`](editors/vscode/) provides IronKernel syntax
-highlighting, snippets, run/compile commands, check-on-save diagnostics fed by
-`ik check --json`, and a playground backed by the real CLI. Build a local VSIX
-with:
+highlighting, snippets, run/compile commands, and a playground backed by the
+real CLI. A language server (`ik lsp`, in-process with the runtime) adds live
+diagnostics, completion, contract hover, and semantic operative/applicative
+highlighting; `ik check --json` diagnostics on save are the fallback. Build a
+local VSIX with:
 
 ```bash
 cd editors/vscode

--- a/docs/adr/0009-editor-tooling-from-the-runtime-outward.md
+++ b/docs/adr/0009-editor-tooling-from-the-runtime-outward.md
@@ -1,6 +1,6 @@
 # ADR 0009: Editor tooling grows from the runtime outward
 
-Status: Accepted — phases 1 and 2 implemented
+Status: Accepted — phases 1 through 3 implemented
 
 ## Decision
 
@@ -122,13 +122,35 @@ The predicted payoff landed: REPL tab-completion now works through
 computation (`Repl.completionCandidates`) split from the editor callback so
 it is testable without a TTY.
 
-**Phase 3 — the language server.** F#, referencing IronKernel in-process.
-Semantic tokens from actual binding resolution and `contract-of` — retiring
-both hand-maintained name lists — hover and signature help from contracts,
-completion from phase 2, diagnostics from phase 1's pipeline. Ships with
-marketplace publishing, which CI has already reduced to a decision
-(`vsce package` runs on every push; the `.vsix` is an artifact nobody
-publishes).
+**Phase 3 — the language server.** *Done, with three corrections to what was
+planned.* It shipped as `ik lsp` — a subcommand of the existing binary, not a
+separate server — so it distributes with the tool and the extension's runtime
+discovery needed no new path. The protocol layer is a hand-rolled subset
+(framing, JSON-RPC dispatch, and exactly the requests the features use) kept
+dependency-free and exercised against in-memory streams; the client side uses
+`vscode-languageclient`, the extension's first runtime dependency.
+
+Features as planned: diagnostics on every change through the same
+parse-and-analyze pipeline as `check`; completion merging the bootstrapped
+environment (phase 2's machinery) with buffer-level `define`s; hover from
+`contract-of`; and semantic tokens that classify every symbol by *resolving*
+it — a `(define twice (vau …))` colors `twice` as an operative at every use
+site, which is the capability no lexical grammar has.
+
+The corrections. First, "retiring both hand-maintained name lists" was
+overstated: semantic tokens override the TextMate list inside VS Code, but
+that list stays as the fallback (untrusted workspaces, no runtime on PATH)
+and the website's copy has no language server to lean on — so both lists
+survive, demoted rather than retired. Second, signature help did not ship;
+the contract already renders in hover and in completion detail, and a third
+surface for the same six fields was not worth its handler until someone
+misses it. Third, phase 4's absence was felt immediately and concretely: a
+buffer being typed into does not parse, which is precisely when completion is
+wanted, so the server keeps each document's defines from its last successful
+parse — a cache that parser recovery will later make unnecessary.
+
+Marketplace publishing remains a human decision: it needs a publisher
+account, and CI already builds the `.vsix` on every push.
 
 **Phase 4 — parser error recovery.** A first failure with no partial tree is
 acceptable for check-on-save and fatal for as-you-type diagnostics and

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -9,10 +9,17 @@ The extension never implements a second evaluator in JavaScript.
 - Distinct colors for **operatives** (unevaluated operands) vs **applicatives** (args evaluated first), matching the website token sets
 - `.ikproj` files open as XML (MSBuild project syntax highlighting)
 - Bracket matching, comments, indentation, and IronKernel snippets
+- **Language server** (`ik lsp`, in-process with the real runtime): live
+  diagnostics as you type, completion over everything in scope plus your
+  buffer's defines, hover with contracts, and semantic highlighting that
+  classifies operatives/applicatives by *resolution* — your own `vau`
+  definitions get the operative color (disable with
+  `ironkernel.languageServer.enabled`)
 - **Run Current File** and **Compile Current File to IKC** commands
 - **Run Project** and **Build Project** for `.ikproj` (nearest project, picker, or explorer context menu)
 - Check on save: `ik check --json` runs on saved `.ikr` files and publishes
-  span-accurate diagnostics (disable with `ironkernel.checkOnSave`)
+  span-accurate diagnostics — the fallback when the language server is
+  disabled or unavailable (disable with `ironkernel.checkOnSave`)
 - Source-range diagnostics in VS Code's Problems view
 - A playground with runnable examples, validation, cancellation, output limits, and timeouts
 

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -8,6 +8,9 @@
       "name": "ironkernel",
       "version": "0.1.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "vscode-languageclient": "^10.1.0"
+      },
       "devDependencies": {
         "@types/node": "^26.1.1",
         "@types/vscode": "^1.125.0",
@@ -2172,7 +2175,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2247,7 +2249,6 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
       "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4114,7 +4115,6 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -4891,7 +4891,6 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5826,6 +5825,52 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.1.0.tgz",
+      "integrity": "sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.1",
+        "vscode-languageserver-protocol": "3.18.2",
+        "vscode-languageserver-textdocument": "1.0.13"
+      },
+      "engines": {
+        "vscode": "^1.91.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.13.tgz",
+      "integrity": "sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "license": "MIT"
     },
     "node_modules/vscode-oniguruma": {
       "version": "2.0.1",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -219,7 +219,12 @@
         "ironkernel.checkOnSave": {
           "type": "boolean",
           "default": true,
-          "description": "Run 'ik check' on saved IronKernel files and show its diagnostics inline. Requires a trusted workspace."
+          "description": "Run 'ik check' on saved IronKernel files and show its diagnostics inline. Used as a fallback when the language server is disabled or unavailable. Requires a trusted workspace."
+        },
+        "ironkernel.languageServer.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Start the IronKernel language server ('ik lsp') for live diagnostics, completion, hover, and semantic operative/applicative highlighting. Requires a trusted workspace."
         },
         "ironkernel.playground.timeoutMs": {
           "type": "number",
@@ -237,6 +242,28 @@
         }
       }
     },
+    "semanticTokenTypes": [
+      {
+        "id": "operative",
+        "description": "A combiner that receives its operands unevaluated"
+      },
+      {
+        "id": "applicative",
+        "description": "A combiner whose arguments are evaluated first"
+      }
+    ],
+    "semanticTokenScopes": [
+      {
+        "scopes": {
+          "operative": [
+            "keyword.control.operative.ironkernel"
+          ],
+          "applicative": [
+            "support.function.applicative.ironkernel"
+          ]
+        }
+      }
+    ],
     "problemPatterns": [
       {
         "name": "ironkernel",
@@ -275,5 +302,8 @@
     "vitest": "^4.1.10",
     "vscode-oniguruma": "^2.0.1",
     "vscode-textmate": "^9.3.2"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^10.1.0"
   }
 }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -2,6 +2,11 @@ import * as path from "node:path";
 import * as vscode from "vscode";
 import { resolveRuntime, runProcess, type RuntimeCommand } from "./cli.js";
 import {
+  LanguageClient,
+  type LanguageClientOptions,
+  type ServerOptions
+} from "vscode-languageclient/node";
+import {
   parseCheckReport,
   parseDiagnostics,
   type CheckDiagnostic,
@@ -16,6 +21,11 @@ export function activate(context: vscode.ExtensionContext): void {
   const output = vscode.window.createOutputChannel("IronKernel");
   const diagnostics = vscode.languages.createDiagnosticCollection("ironkernel");
   context.subscriptions.push(output, diagnostics);
+
+  void startLanguageServer(output);
+  context.subscriptions.push(
+    vscode.workspace.onDidGrantWorkspaceTrust(() => void startLanguageServer(output))
+  );
 
   context.subscriptions.push(
     vscode.commands.registerCommand("ironkernel.showOutput", () => output.show()),
@@ -32,6 +42,9 @@ export function activate(context: vscode.ExtensionContext): void {
       if (
         document.languageId === "ironkernel" &&
         vscode.workspace.isTrusted &&
+        // The language server already diagnoses every change; check-on-save
+        // is the fallback when it is disabled or failed to start.
+        languageClient === undefined &&
         vscode.workspace
           .getConfiguration("ironkernel", document.uri)
           .get<boolean>("checkOnSave", true)
@@ -213,9 +226,52 @@ async function saveIronKernelDocumentsNear(projectPath: string): Promise<void> {
   }
 }
 
+let languageClient: LanguageClient | undefined;
+
+async function startLanguageServer(output: vscode.OutputChannel): Promise<void> {
+  if (languageClient !== undefined || !vscode.workspace.isTrusted) {
+    return;
+  }
+  const scopeUri =
+    vscode.window.activeTextEditor?.document.uri ??
+    vscode.workspace.workspaceFolders?.[0]?.uri ??
+    vscode.Uri.file(process.cwd());
+  const configuration = vscode.workspace.getConfiguration("ironkernel", scopeUri);
+  if (!configuration.get<boolean>("languageServer.enabled", true)) {
+    return;
+  }
+  const resolved = await resolveConfiguredRuntime(scopeUri, output, { quiet: true });
+  if (!resolved) {
+    return;
+  }
+  const serverOptions: ServerOptions = {
+    command: resolved.runtime.command,
+    args: [...resolved.runtime.prefixArgs, "lsp"],
+    options: { cwd: resolved.runtime.cwd }
+  };
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [{ language: "ironkernel" }]
+  };
+  const client = new LanguageClient(
+    "ironkernel",
+    "IronKernel Language Server",
+    serverOptions,
+    clientOptions
+  );
+  try {
+    await client.start();
+    languageClient = client;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    output.appendLine(`[language server unavailable] ${message}`);
+    output.appendLine("Falling back to check-on-save diagnostics.");
+  }
+}
+
 async function resolveConfiguredRuntime(
   scopeUri: vscode.Uri,
-  output: vscode.OutputChannel
+  output: vscode.OutputChannel,
+  options?: { quiet?: boolean }
 ): Promise<{ runtime: RuntimeCommand; maxOutputBytes: number } | undefined> {
   const folder = vscode.workspace.getWorkspaceFolder(scopeUri);
   const configuration = vscode.workspace.getConfiguration("ironkernel", scopeUri);
@@ -229,7 +285,9 @@ async function resolveConfiguredRuntime(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     output.appendLine(`[launch failed] ${message}`);
-    void vscode.window.showErrorMessage(`Unable to resolve IronKernel: ${message}`);
+    if (!options?.quiet) {
+      void vscode.window.showErrorMessage(`Unable to resolve IronKernel: ${message}`);
+    }
     return undefined;
   }
   const profile = configuration.get<string>("profile", "unrestricted");
@@ -426,6 +484,9 @@ function publishDiagnostics(
   }
 }
 
-export function deactivate(): void {
-  // Resources registered in ExtensionContext are disposed by VS Code.
+export function deactivate(): Thenable<void> | undefined {
+  // Other resources registered in ExtensionContext are disposed by VS Code.
+  const client = languageClient;
+  languageClient = undefined;
+  return client?.stop();
 }


### PR DESCRIPTION
## What

Phase 3 of [ADR 0009](docs/adr/0009-editor-tooling-from-the-runtime-outward.md). **Stacked on #87** (base: `environment-enumeration`), which stacks on #85; it will retarget as those merge.

`ik lsp` starts a Language Server Protocol server on stdio — a subcommand of the existing binary, so it distributes with the tool and the VS Code extension's runtime discovery needs no new path. The protocol layer is a deliberately hand-rolled LSP subset (framing, JSON-RPC dispatch, exactly the requests the features use): dependency-free on the .NET side, and tested end-to-end against in-memory streams.

### Features

- **Diagnostics on every keystroke** through the same parse-and-analyze pipeline as `ik check` (phase 1), with spans and related-location chains.
- **Completion** merging the bootstrapped environment (phase 2's `reachableFrames`/`completionCandidates`) with buffer-level `define`s. Since a buffer being typed into does not parse (no reader recovery until phase 4 — felt immediately), the server keeps each document's defines from its last successful parse.
- **Hover** rendering `contract-of` data: `(+ number number ...) → number — pure, certified`.
- **Semantic tokens** that classify every symbol by *resolving* it: `(define twice (vau …))` colors `twice` as an operative at every use site — the capability no lexical grammar has, and the original motivation for specialized tooling. Quoted atoms are data and deliberately get no token.

### Extension

Starts the server on activation in trusted workspaces (`ironkernel.languageServer.enabled`, default on) via `vscode-languageclient` — the extension's first runtime dependency, bundled by esbuild. Check-on-save demotes to the fallback when the server is disabled or unavailable. The custom `operative`/`applicative` semantic token types map onto the existing TextMate scopes through `semanticTokenScopes`, so the configured colors apply unchanged.

### ADR corrections, in place per house convention

- "Retiring both hand-maintained name lists" was overstated: semantic tokens override the TextMate list in VS Code, but it survives as fallback and the website's copy has no server to lean on — demoted, not retired.
- Signature help deliberately did not ship: the contract already renders in hover and completion detail.
- Marketplace publishing remains a human decision (needs a publisher account); CI builds the `.vsix` on every push.

## Verification

- Clean `--no-incremental` rebuild: zero warnings. Full suite: **435/435** (7 new LSP tests: capabilities/legend, diagnostics across open→change, mid-edit completion from the last good parse, contract + buffer-define hover, an exact-match semantic-token encoding test, quoted-atoms-get-no-token, and method-not-found).
- Scripted end-to-end session against the real binary (`ik lsp` over pipes): initialize → didOpen → semanticTokens → hover → completion → didChange → shutdown/exit, all correct, exit 0.
- All examples run (yingyang skipped); CLR fault sweep: `faulted (process aborted): 0`.
- Extension: `tsc --noEmit` clean, vitest 21/21, `vsce package` produces the VSIX.
- Benchmarks deliberately skipped: the server is entirely cold code behind a new subcommand; nothing touches the ordinary evaluation path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ironkernel-lang/codesmith/IronKernel/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790012073&installation_model_id=427656&pr_number=89&repository=ironkernel-lang%2FIronKernel&return_to=https%3A%2F%2Fgithub.com%2Fironkernel-lang%2FIronKernel%2Fpull%2F89&signature=e8356eec1bdcac0fb29a81e0e3f3d1d3bc70785fc44eb442a4261c63e4294ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->